### PR TITLE
Fix bugs in StdlibWriter and tests.

### DIFF
--- a/log/stdlib.go
+++ b/log/stdlib.go
@@ -7,14 +7,14 @@ import (
 	"strings"
 )
 
-// StdlibWriter implements io.Writer by invoking the stdlib log.Printf. It's
+// StdlibWriter implements io.Writer by invoking the stdlib log.Print. It's
 // designed to be passed to a gokit logger as the writer, for cases where it's
 // desirable to pipe all log output to the same, canonical destination.
 type StdlibWriter struct{}
 
 // Write implements io.Writer.
 func (w StdlibWriter) Write(p []byte) (int, error) {
-	log.Printf(strings.TrimSpace(string(p)))
+	log.Print(strings.TrimSpace(string(p)))
 	return len(p), nil
 }
 

--- a/log/stdlib_test.go
+++ b/log/stdlib_test.go
@@ -11,6 +11,7 @@ import (
 func TestStdlibWriter(t *testing.T) {
 	buf := &bytes.Buffer{}
 	log.SetOutput(buf)
+	log.SetFlags(log.LstdFlags)
 	logger := NewPrefixLogger(StdlibWriter{})
 	logger.Log("key", "val")
 	timestamp := time.Now().Format("2006/01/02 15:04:05")
@@ -34,9 +35,9 @@ func TestStdlibAdapterUsage(t *testing.T) {
 		log.Ldate:                              "ts=" + date + " msg=hello\n",
 		log.Ltime:                              "ts=" + time + " msg=hello\n",
 		log.Ldate | log.Ltime:                  "ts=" + date + " " + time + " msg=hello\n",
-		log.Lshortfile:                         "file=stdlib_test.go:43 msg=hello\n",
-		log.Lshortfile | log.Ldate:             "ts=" + date + " file=stdlib_test.go:43 msg=hello\n",
-		log.Lshortfile | log.Ldate | log.Ltime: "ts=" + date + " " + time + " file=stdlib_test.go:43 msg=hello\n",
+		log.Lshortfile:                         "file=stdlib_test.go:44 msg=hello\n",
+		log.Lshortfile | log.Ldate:             "ts=" + date + " file=stdlib_test.go:44 msg=hello\n",
+		log.Lshortfile | log.Ldate | log.Ltime: "ts=" + date + " " + time + " file=stdlib_test.go:44 msg=hello\n",
 	} {
 		buf.Reset()
 		stdlog.SetFlags(flag)

--- a/log/stdlib_test.go
+++ b/log/stdlib_test.go
@@ -23,7 +23,7 @@ func TestStdlibAdapterUsage(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := NewPrefixLogger(buf)
 	writer := NewStdlibAdapter(logger)
-	log.SetOutput(writer)
+	stdlog := log.New(writer, "", 0)
 
 	now := time.Now()
 	date := now.Format("2006/01/02")
@@ -39,8 +39,8 @@ func TestStdlibAdapterUsage(t *testing.T) {
 		log.Lshortfile | log.Ldate | log.Ltime: "ts=" + date + " " + time + " file=stdlib_test.go:43 msg=hello\n",
 	} {
 		buf.Reset()
-		log.SetFlags(flag)
-		log.Print("hello")
+		stdlog.SetFlags(flag)
+		stdlog.Print("hello")
 		if have := buf.String(); want != have {
 			t.Errorf("flag=%d: want %#v, have %#v", flag, want, have)
 		}

--- a/log/stdlib_test.go
+++ b/log/stdlib_test.go
@@ -64,7 +64,7 @@ func TestStdLibAdapterExtraction(t *testing.T) {
 		"/a/b/c/d.go:23: hello":                            "file=/a/b/c/d.go:23 msg=hello\n",
 	} {
 		buf.Reset()
-		fmt.Fprintf(writer, input)
+		fmt.Fprint(writer, input)
 		if have := buf.String(); want != have {
 			t.Errorf("%q: want %#v, have %#v", input, want, have)
 		}


### PR DESCRIPTION
Two fixes in this PR.

1. We were passing data strings to the format argument of Printf and Fprintf. Not good if the data contains any %'s.
2. go test -cpu 2,4 was failing because `TestStdlibAdapterUsage` was calling `log.SetFlags`. On the second pass `TestStdlibWriter` would fail because the logger flags were not set to the defaults.