### PR TITLE
ratelimit: simplify

### DIFF
--- a/ratelimit/export_test.go
+++ b/ratelimit/export_test.go
@@ -1,0 +1,3 @@
+package ratelimit
+
+var TimeSleep = &timeSleep

--- a/ratelimit/token_bucket.go
+++ b/ratelimit/token_bucket.go
@@ -1,126 +1,54 @@
+// Package ratelimit implements middleware for limiting
+// the rate at which requests are executed.
 package ratelimit
 
 import (
 	"errors"
 	"time"
 
-	juju "github.com/juju/ratelimit"
 	"golang.org/x/net/context"
 
 	"github.com/go-kit/kit/endpoint"
 )
 
+// Bucket represents a token bucket.  See github.com/juju/ratelimit
+// for one implementation.
+type Bucket interface {
+	// TakeMaxDuration takes count tokens from the bucket, but it
+	// will only take tokens from the bucket if the wait time is no
+	// greater than maxWait.
+	//
+	// If it would take longer than maxWait for the tokens to become
+	// available, it does nothing and reports false, otherwise it
+	// returns the time that the caller should wait until the tokens
+	// are actually available, and reports true.
+	TakeMaxDuration(count int64, maxWait time.Duration) (time.Duration, bool)
+}
+
+// timeSleep allows the tests to mock the implementation of time.Sleep.
+var timeSleep = time.Sleep
+
 // ErrLimited is returned in the request path when the rate limiter is
 // triggered and the request is rejected.
 var ErrLimited = errors.New("rate limit exceeded")
 
-// NewTokenBucketLimiter returns an endpoint.Middleware that acts as a rate
-// limiter based on a token-bucket algorithm. Requests that would exceed the
-// maximum request rate are simply rejected with an error.
-func NewTokenBucketLimiter(options ...TokenBucketLimiterOption) endpoint.Middleware {
-	limiter := tokenBucketLimiter{
-		rate:     100,
-		capacity: 100,
-		take:     1,
-	}
-	for _, option := range options {
-		option(&limiter)
-	}
-	tb := juju.NewBucketWithRate(limiter.rate, limiter.capacity)
+// NewTokenBucketLimiter returns an endpoint.Middleware that acts as a
+// rate limiter using the given token bucket implementation. Each
+// request takes one token from the bucket and waits for a maximum of
+// maxSleep for a token to become available. If a token will not be
+// available within that time, it will return an ErrLimited error.
+//
+// To make the request always return an error if the rate has been
+// exceeded, pass 0 for maxSleep.
+func NewTokenBucketLimiter(bucket Bucket, maxSleep time.Duration) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (interface{}, error) {
-			if tb.TakeAvailable(limiter.take) == 0 {
+			d, ok := bucket.TakeMaxDuration(1, maxSleep)
+			if !ok {
 				return nil, ErrLimited
 			}
+			timeSleep(d)
 			return next(ctx, request)
 		}
 	}
-}
-
-type tokenBucketLimiter struct {
-	rate     float64
-	capacity int64
-	take     int64
-}
-
-// TokenBucketLimiterOption sets a parameter on the TokenBucketLimiter.
-type TokenBucketLimiterOption func(*tokenBucketLimiter)
-
-// TokenBucketLimiterRate sets the rate (per second) at which tokens are
-// replenished into the bucket. For most use cases, this should be the same as
-// the capacity. By default, the rate is 100.
-func TokenBucketLimiterRate(rate float64) TokenBucketLimiterOption {
-	return func(tb *tokenBucketLimiter) { tb.rate = rate }
-}
-
-// TokenBucketLimiterCapacity sets the maximum number of tokens that the
-// bucket will hold. For most use cases, this should be the same as the rate.
-// By default, the capacity is 100.
-func TokenBucketLimiterCapacity(capacity int64) TokenBucketLimiterOption {
-	return func(tb *tokenBucketLimiter) { tb.capacity = capacity }
-}
-
-// TokenBucketLimiterTake sets the number of tokens that will be taken from
-// the bucket with each request. By default, this is 1.
-func TokenBucketLimiterTake(take int64) TokenBucketLimiterOption {
-	return func(tb *tokenBucketLimiter) { tb.take = take }
-}
-
-// NewTokenBucketThrottler returns an endpoint.Middleware that acts as a
-// request throttler based on a token-bucket algorithm. Requests that would
-// exceed the maximum request rate are delayed via a parameterized sleep
-// function.
-func NewTokenBucketThrottler(options ...TokenBucketThrottlerOption) endpoint.Middleware {
-	throttler := tokenBucketThrottler{
-		tokenBucketLimiter: tokenBucketLimiter{
-			rate:     100,
-			capacity: 100,
-			take:     1,
-		},
-		sleep: time.Sleep,
-	}
-	for _, option := range options {
-		option(&throttler)
-	}
-	tb := juju.NewBucketWithRate(throttler.rate, throttler.capacity)
-	return func(next endpoint.Endpoint) endpoint.Endpoint {
-		return func(ctx context.Context, request interface{}) (interface{}, error) {
-			throttler.sleep(tb.Take(throttler.take))
-			return next(ctx, request)
-		}
-	}
-}
-
-type tokenBucketThrottler struct {
-	tokenBucketLimiter
-	sleep func(time.Duration)
-}
-
-// TokenBucketThrottlerOption sets a parameter on the TokenBucketThrottler.
-type TokenBucketThrottlerOption func(*tokenBucketThrottler)
-
-// TokenBucketThrottlerRate sets the rate (per second) at which tokens are
-// replenished into the bucket. For most use cases, this should be the same as
-// the capacity. By default, the rate is 100.
-func TokenBucketThrottlerRate(rate float64) TokenBucketThrottlerOption {
-	return func(tb *tokenBucketThrottler) { tb.rate = rate }
-}
-
-// TokenBucketThrottlerCapacity sets the maximum number of tokens that the
-// bucket will hold. For most use cases, this should be the same as the rate.
-// By default, the capacity is 100.
-func TokenBucketThrottlerCapacity(capacity int64) TokenBucketThrottlerOption {
-	return func(tb *tokenBucketThrottler) { tb.capacity = capacity }
-}
-
-// TokenBucketThrottlerTake sets the number of tokens that will be taken from
-// the bucket with each request. By default, this is 1.
-func TokenBucketThrottlerTake(take int64) TokenBucketThrottlerOption {
-	return func(tb *tokenBucketThrottler) { tb.take = take }
-}
-
-// TokenBucketThrottlerSleep sets the sleep function that's invoked to
-// throttle requests. By default, it's time.Sleep.
-func TokenBucketThrottlerSleep(sleep func(time.Duration)) TokenBucketThrottlerOption {
-	return func(tb *tokenBucketThrottler) { tb.sleep = sleep }
 }

--- a/ratelimit/token_bucket_test.go
+++ b/ratelimit/token_bucket_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	jujuratelimit "github.com/juju/ratelimit"
 	"golang.org/x/net/context"
 
 	"github.com/go-kit/kit/endpoint"
@@ -12,36 +13,10 @@ import (
 )
 
 func TestTokenBucketLimiter(t *testing.T) {
-	e := func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil }
 	for _, n := range []int{1, 2, 100} {
-		testLimiter(t, ratelimit.NewTokenBucketLimiter(
-			ratelimit.TokenBucketLimiterRate(float64(n)),
-			ratelimit.TokenBucketLimiterCapacity(int64(n)),
-		)(e), int(n))
-	}
-}
-
-func TestTokenBucketThrottler(t *testing.T) {
-	d := time.Duration(0)
-	s := func(d0 time.Duration) { d = d0 }
-
-	e := func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil }
-	e = ratelimit.NewTokenBucketThrottler(
-		ratelimit.TokenBucketThrottlerRate(1),
-		ratelimit.TokenBucketThrottlerCapacity(1),
-		ratelimit.TokenBucketThrottlerSleep(s),
-	)(e)
-
-	// First request should go through with no delay.
-	e(context.Background(), struct{}{})
-	if want, have := time.Duration(0), d; want != have {
-		t.Errorf("want %s, have %s", want, have)
-	}
-
-	// Next request should request a ~1s sleep.
-	e(context.Background(), struct{}{})
-	if want, have, tol := time.Second, d, time.Millisecond; math.Abs(float64(want-have)) > float64(tol) {
-		t.Errorf("want %s, have %s", want, have)
+		b := jujuratelimit.NewBucketWithRate(float64(n), int64(n))
+		limiter := ratelimit.NewTokenBucketLimiter(b, 0)
+		testLimiter(t, limiter(noNext), n)
 	}
 }
 
@@ -57,4 +32,62 @@ func testLimiter(t *testing.T, e endpoint.Endpoint, rate int) {
 	if _, err := e(context.Background(), struct{}{}); err != ratelimit.ErrLimited {
 		t.Errorf("rate=%d: want %v, have %v", rate, ratelimit.ErrLimited, err)
 	}
+}
+
+func TestTokenBucketThrottling(t *testing.T) {
+	var d time.Duration
+	*ratelimit.TimeSleep = func(d0 time.Duration) { d = d0 }
+	defer func() {
+		*ratelimit.TimeSleep = time.Sleep
+	}()
+	b := jujuratelimit.NewBucketWithRate(1, 1)
+	e := ratelimit.NewTokenBucketLimiter(b, 10*time.Second)(noNext)
+
+	// First request should go through with no delay.
+	_, err := e(context.Background(), struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error from request: %v", err)
+	}
+	if want, have := time.Duration(0), d; want != have {
+		t.Errorf("want %s, have %s", want, have)
+	}
+
+	// Next request should request a ~1s sleep.
+	_, err = e(context.Background(), struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error from request: %v", err)
+	}
+	if want, have, tol := time.Second, d, time.Millisecond; math.Abs(float64(want-have)) > float64(tol) {
+		t.Errorf("want %s, have %s", want, have)
+	}
+}
+
+func TestTokenBucketThrottlerTimeout(t *testing.T) {
+	var d time.Duration
+	*ratelimit.TimeSleep = func(d0 time.Duration) { d = d0 }
+	defer func() {
+		*ratelimit.TimeSleep = time.Sleep
+	}()
+	b := jujuratelimit.NewBucketWithRate(1, 1)
+	e := ratelimit.NewTokenBucketLimiter(b, 500*time.Millisecond)(noNext)
+
+	// First request should go through with no delay.
+	_, err := e(context.Background(), struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error from request: %v", err)
+	}
+	if want, have := time.Duration(0), d; want != have {
+		t.Errorf("want %s, have %s", want, have)
+	}
+
+	// Next request should fail because it would need to
+	// wait for >500ms.
+	_, err = e(context.Background(), struct{}{})
+	if _, err := e(context.Background(), struct{}{}); err != ratelimit.ErrLimited {
+		t.Errorf("want %v, have %v", ratelimit.ErrLimited, err)
+	}
+}
+
+func noNext(context.Context, interface{}) (interface{}, error) {
+	return struct{}{}, nil
 }


### PR DESCRIPTION
Following on from my comments on #57, here's an implementation
of those ideas. This removes token bucket creation entirely
from the package, giving clients the freedom to create the
bucket in any way they choose.

For example, it's common to want to start with the token bucket
empty, but the current implementation does not provide this possibility
without adding extra options.

It also fixes the implementation - the current implementation will
allow a request even if there are less tokens available than requested.
