### PR TITLE
Logging nil error pointer must not panic

### DIFF
--- a/log/json_logger.go
+++ b/log/json_logger.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 )
 
 type jsonLogger struct {
@@ -37,7 +38,7 @@ func merge(dst map[string]interface{}, k, v interface{}) map[string]interface{} 
 	default:
 		key = fmt.Sprintf("%v", x)
 	}
-	if x, ok := v.(error); ok {
+	if x, ok := v.(error); ok && !reflect.ValueOf(v).IsNil() {
 		v = x.Error()
 	}
 	dst[key] = v

--- a/log/json_logger_test.go
+++ b/log/json_logger_test.go
@@ -20,6 +20,19 @@ func TestJSONLogger(t *testing.T) {
 	}
 }
 
+func TestJSONLoggerNilError(t *testing.T) {
+	var err error
+
+	buf := &bytes.Buffer{}
+	logger := log.NewJSONLogger(buf)
+	if err := logger.Log("err", err); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := `{"err":null}`+"\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+}
+
 func BenchmarkJSONLoggerSimple(b *testing.B) {
 	benchmarkRunner(b, log.NewJSONLogger(ioutil.Discard), baseMessage)
 }


### PR DESCRIPTION
When logging, every value is checked if it implements `error` interface. When
positive, `Error` method is called. This may cause panic when passed value is
`nil` pointer to structure that use it's internal state to produce `Error`
method optput.
Before calling `Error` on any error implementing structure, make sure it's not
nil pointer first.

Closing #86 