### PR TITLE
Fix resource link for commit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,5 +18,5 @@ Before submitting major changes, here are a few guidelines to follow:
 [issues]: https://github.com/go-kit/kit/issues
 [prs]: https://github.com/go-kit/kit/pulls
 [squash]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
-[message]: https://github.com/go-kit/kit/issues
+[message]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 


### PR DESCRIPTION
As [mentioned](https://github.com/go-kit/kit/commit/9adcbcf8ebcebeac3f2da53e62242b50ebbdc876#commitcomment-11439341) in the original commit this resource is the intended one for expected commit messages.