### PR TITLE
Add Consul publisher

### DIFF
--- a/loadbalancer/consul/client.go
+++ b/loadbalancer/consul/client.go
@@ -1,0 +1,30 @@
+package consul
+
+import consul "github.com/hashicorp/consul/api"
+
+// Client is a wrapper around the Consul API.
+type Client interface {
+	Service(service string, tag string, queryOpts *consul.QueryOptions) ([]*consul.ServiceEntry, *consul.QueryMeta, error)
+}
+
+type client struct {
+	consul *consul.Client
+}
+
+// NewClient returns an implementation of the Client interface expecting a fully
+// setup Consul Client.
+func NewClient(c *consul.Client) Client {
+	return &client{
+		consul: c,
+	}
+}
+
+// GetInstances returns the list of healthy entries for a given service filtered
+// by tag.
+func (c *client) Service(
+	service string,
+	tag string,
+	opts *consul.QueryOptions,
+) ([]*consul.ServiceEntry, *consul.QueryMeta, error) {
+	return c.consul.Health().Service(service, tag, true, opts)
+}

--- a/loadbalancer/consul/publisher.go
+++ b/loadbalancer/consul/publisher.go
@@ -1,0 +1,175 @@
+package consul
+
+import (
+	"fmt"
+
+	consul "github.com/hashicorp/consul/api"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/loadbalancer"
+	"github.com/go-kit/kit/log"
+)
+
+const defaultIndex = 0
+
+// Publisher yields endpoints for a service in Consul. Updates to the service
+// are watched and will update the Publisher endpoints.
+type Publisher struct {
+	cache      *loadbalancer.EndpointCache
+	client     Client
+	logger     log.Logger
+	service    string
+	tags       []string
+	endpointsc chan []endpoint.Endpoint
+	quitc      chan struct{}
+}
+
+// NewPublisher returns a Consul publisher which returns Endpoints for the
+// requested service. It only returns instances for which all of the passed
+// tags are present.
+func NewPublisher(
+	client Client,
+	factory loadbalancer.Factory,
+	logger log.Logger,
+	service string,
+	tags ...string,
+) (*Publisher, error) {
+	logger = log.NewContext(logger).With("component", "Consul Publisher")
+
+	p := &Publisher{
+		cache:   loadbalancer.NewEndpointCache(factory, logger),
+		client:  client,
+		logger:  logger,
+		service: service,
+		tags:    tags,
+		quitc:   make(chan struct{}),
+	}
+
+	is, index, err := p.getInstances(defaultIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	p.cache.Replace(is)
+
+	go p.loop(index)
+
+	return p, nil
+}
+
+// Endpoints implements the Publisher interface.
+func (p *Publisher) Endpoints() ([]endpoint.Endpoint, error) {
+	return p.cache.Endpoints()
+}
+
+// Stop terminates the publisher.
+func (p *Publisher) Stop() {
+	close(p.quitc)
+}
+
+func (p *Publisher) loop(lastIndex uint64) {
+	var (
+		errc = make(chan error, 1)
+		resc = make(chan response, 1)
+	)
+
+	for {
+		go func() {
+			is, index, err := p.getInstances(lastIndex)
+			if err != nil {
+				errc <- err
+				return
+			}
+
+			resc <- response{
+				index:     index,
+				instances: is,
+			}
+		}()
+
+		select {
+		case err := <-errc:
+			p.logger.Log("service", p.service, "err", err)
+		case res := <-resc:
+			p.cache.Replace(res.instances)
+			lastIndex = res.index
+		case <-p.quitc:
+			return
+		}
+	}
+}
+
+func (p *Publisher) getInstances(lastIndex uint64) ([]string, uint64, error) {
+	tag := ""
+
+	if len(p.tags) > 0 {
+		tag = p.tags[0]
+	}
+
+	entries, meta, err := p.client.Service(
+		p.service,
+		tag,
+		&consul.QueryOptions{
+			WaitIndex: lastIndex,
+		},
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// If more than one tag is passed we need to filter it in the publisher until
+	// Consul supports multiple tags[0].
+	//
+	// [0] https://github.com/hashicorp/consul/issues/294
+	if len(p.tags) > 1 {
+		entries = filterEntries(entries, p.tags[1:]...)
+	}
+
+	return makeInstances(entries), meta.LastIndex, nil
+}
+
+// response is used as container to transport instances as well as the updated
+// index.
+type response struct {
+	index     uint64
+	instances []string
+}
+
+func filterEntries(entries []*consul.ServiceEntry, tags ...string) []*consul.ServiceEntry {
+	var es []*consul.ServiceEntry
+
+ENTRIES:
+	for _, entry := range entries {
+		ts := make(map[string]struct{}, len(entry.Service.Tags))
+
+		for _, tag := range entry.Service.Tags {
+			ts[tag] = struct{}{}
+		}
+
+		for _, tag := range tags {
+			if _, ok := ts[tag]; !ok {
+				continue ENTRIES
+			}
+		}
+
+		es = append(es, entry)
+	}
+
+	return es
+}
+
+func makeInstances(entries []*consul.ServiceEntry) []string {
+	is := make([]string, len(entries))
+
+	for i, entry := range entries {
+		addr := entry.Node.Address
+
+		if entry.Service.Address != "" {
+			addr = entry.Service.Address
+		}
+
+		is[i] = fmt.Sprintf("%s:%d", addr, entry.Service.Port)
+	}
+
+	return is
+}

--- a/loadbalancer/consul/publisher_test.go
+++ b/loadbalancer/consul/publisher_test.go
@@ -1,0 +1,207 @@
+package consul
+
+import (
+	"io"
+	"testing"
+
+	consul "github.com/hashicorp/consul/api"
+	"golang.org/x/net/context"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/log"
+)
+
+var consulState = []*consul.ServiceEntry{
+	&consul.ServiceEntry{
+		Node: &consul.Node{
+			Address: "10.0.0.0",
+			Node:    "app00.local",
+		},
+		Service: &consul.AgentService{
+			ID:      "search-api-0",
+			Port:    8000,
+			Service: "search",
+			Tags: []string{
+				"api",
+				"v1",
+			},
+		},
+	},
+	&consul.ServiceEntry{
+		Node: &consul.Node{
+			Address: "10.0.0.1",
+			Node:    "app01.local",
+		},
+		Service: &consul.AgentService{
+			ID:      "search-api-1",
+			Port:    8001,
+			Service: "search",
+			Tags: []string{
+				"api",
+				"v2",
+			},
+		},
+	},
+	&consul.ServiceEntry{
+		Node: &consul.Node{
+			Address: "10.0.0.1",
+			Node:    "app01.local",
+		},
+		Service: &consul.AgentService{
+			Address: "10.0.0.10",
+			ID:      "search-db-0",
+			Port:    9000,
+			Service: "search",
+			Tags: []string{
+				"db",
+			},
+		},
+	},
+}
+
+func TestPublisher(t *testing.T) {
+	var (
+		logger = log.NewNopLogger()
+		client = newTestClient(consulState)
+	)
+
+	p, err := NewPublisher(client, testFactory, logger, "search", "api")
+	if err != nil {
+		t.Fatalf("publisher setup failed: %s", err)
+	}
+	defer p.Stop()
+
+	eps, err := p.Endpoints()
+	if err != nil {
+		t.Fatalf("endpoints failed: %s", err)
+	}
+
+	if have, want := len(eps), 2; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func TestPublisherNoService(t *testing.T) {
+	var (
+		logger = log.NewNopLogger()
+		client = newTestClient(consulState)
+	)
+
+	p, err := NewPublisher(client, testFactory, logger, "feed")
+	if err != nil {
+		t.Fatalf("publisher setup failed: %s", err)
+	}
+	defer p.Stop()
+
+	eps, err := p.Endpoints()
+	if err != nil {
+		t.Fatalf("endpoints failed: %s", err)
+	}
+
+	if have, want := len(eps), 0; have != want {
+		t.Fatalf("have %v, want %v", have, want)
+	}
+}
+
+func TestPublisherWithTags(t *testing.T) {
+	var (
+		logger = log.NewNopLogger()
+		client = newTestClient(consulState)
+	)
+
+	p, err := NewPublisher(client, testFactory, logger, "search", "api", "v2")
+	if err != nil {
+		t.Fatalf("publisher setup failed: %s", err)
+	}
+	defer p.Stop()
+
+	eps, err := p.Endpoints()
+	if err != nil {
+		t.Fatalf("endpoints failed: %s", err)
+	}
+
+	if have, want := len(eps), 1; have != want {
+		t.Fatalf("have %v, want %v", have, want)
+	}
+}
+
+func TestPublisherAddressOverride(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		logger = log.NewNopLogger()
+		client = newTestClient(consulState)
+	)
+
+	p, err := NewPublisher(client, testFactory, logger, "search", "db")
+	if err != nil {
+		t.Fatalf("publisher setup failed: %s", err)
+	}
+	defer p.Stop()
+
+	eps, err := p.Endpoints()
+	if err != nil {
+		t.Fatalf("endpoints failed: %s", err)
+	}
+
+	if have, want := len(eps), 1; have != want {
+		t.Fatalf("have %v, want %v", have, want)
+	}
+
+	ins, err := eps[0](ctx, struct{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := ins.(string), "10.0.0.10:9000"; have != want {
+		t.Errorf("have %#v, want %#v", have, want)
+	}
+}
+
+type testClient struct {
+	entries []*consul.ServiceEntry
+}
+
+func newTestClient(entries []*consul.ServiceEntry) Client {
+	if entries == nil {
+		entries = []*consul.ServiceEntry{}
+	}
+
+	return &testClient{
+		entries: entries,
+	}
+}
+
+func (c *testClient) Service(
+	service string,
+	tag string,
+	opts *consul.QueryOptions,
+) ([]*consul.ServiceEntry, *consul.QueryMeta, error) {
+	es := []*consul.ServiceEntry{}
+
+	for _, e := range c.entries {
+		if e.Service.Service != service {
+			continue
+		}
+		if tag != "" {
+			tagMap := map[string]struct{}{}
+
+			for _, t := range e.Service.Tags {
+				tagMap[t] = struct{}{}
+			}
+
+			if _, ok := tagMap[tag]; !ok {
+				continue
+			}
+		}
+
+		es = append(es, e)
+	}
+
+	return es, &consul.QueryMeta{}, nil
+}
+
+func testFactory(ins string) (endpoint.Endpoint, io.Closer, error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		return ins, nil
+	}, nil, nil
+}


### PR DESCRIPTION
**open questions**

- [x] Is it allowed to return stale endpoints?
- [x] Are publishers expected to return `ip:port` or are `hostnames` equally valid?
- [x] Does it suffice to only be able to filter by one tag?

**todos**

- [x] only emit endpoints when different
- [ ] documentation
- [ ] example
- [x] tests

***
*The commits in this branch will be cleaned up in time and likely stashed into a single coherent change-set.*