### PR TITLE
Fixed example code for metrics

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -37,7 +37,6 @@ import (
 
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/prometheus"
-	"github.com/go-kit/kit/metrics/statsd"
 )
 
 var requestDuration = prometheus.NewSummary(stdprometheus.SummaryOpts{


### PR DESCRIPTION
There are no usage of `statsd` in the example code for prometheus.