### PR TITLE
Modify all import paths to gopkg.in/kit.v0

### DIFF
--- a/addsvc/add.go
+++ b/addsvc/add.go
@@ -3,9 +3,9 @@ package main
 import (
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/addsvc/reqrep"
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/addsvc/reqrep"
+	"gopkg.in/kit.v0/endpoint"
+	"gopkg.in/kit.v0/log"
 )
 
 // Add is the abstract definition of what this service does. It could easily

--- a/addsvc/client/addcli/main.go
+++ b/addsvc/client/addcli/main.go
@@ -12,13 +12,13 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	thriftadd "github.com/go-kit/kit/addsvc/_thrift/gen-go/add"
-	grpcclient "github.com/go-kit/kit/addsvc/client/grpc"
-	httpclient "github.com/go-kit/kit/addsvc/client/http"
-	netrpcclient "github.com/go-kit/kit/addsvc/client/netrpc"
-	thriftclient "github.com/go-kit/kit/addsvc/client/thrift"
-	"github.com/go-kit/kit/addsvc/reqrep"
-	"github.com/go-kit/kit/endpoint"
+	thriftadd "gopkg.in/kit.v0/addsvc/_thrift/gen-go/add"
+	grpcclient "gopkg.in/kit.v0/addsvc/client/grpc"
+	httpclient "gopkg.in/kit.v0/addsvc/client/http"
+	netrpcclient "gopkg.in/kit.v0/addsvc/client/netrpc"
+	thriftclient "gopkg.in/kit.v0/addsvc/client/thrift"
+	"gopkg.in/kit.v0/addsvc/reqrep"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 func main() {

--- a/addsvc/client/grpc/client.go
+++ b/addsvc/client/grpc/client.go
@@ -4,9 +4,9 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
-	"github.com/go-kit/kit/addsvc/pb"
-	"github.com/go-kit/kit/addsvc/reqrep"
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/addsvc/pb"
+	"gopkg.in/kit.v0/addsvc/reqrep"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // NewClient takes a gRPC ClientConn that should point to an instance of an

--- a/addsvc/client/http/client.go
+++ b/addsvc/client/http/client.go
@@ -7,9 +7,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/addsvc/reqrep"
-	"github.com/go-kit/kit/endpoint"
-	httptransport "github.com/go-kit/kit/transport/http"
+	"gopkg.in/kit.v0/addsvc/reqrep"
+	"gopkg.in/kit.v0/endpoint"
+	httptransport "gopkg.in/kit.v0/transport/http"
 )
 
 // NewClient takes a URL that should point to an instance of an addsvc. It

--- a/addsvc/client/netrpc/client.go
+++ b/addsvc/client/netrpc/client.go
@@ -5,8 +5,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/addsvc/reqrep"
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/addsvc/reqrep"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // NewClient takes a net/rpc Client that should point to an instance of an

--- a/addsvc/client/thrift/client.go
+++ b/addsvc/client/thrift/client.go
@@ -3,9 +3,9 @@ package thrift
 import (
 	"golang.org/x/net/context"
 
-	thriftadd "github.com/go-kit/kit/addsvc/_thrift/gen-go/add"
-	"github.com/go-kit/kit/addsvc/reqrep"
-	"github.com/go-kit/kit/endpoint"
+	thriftadd "gopkg.in/kit.v0/addsvc/_thrift/gen-go/add"
+	"gopkg.in/kit.v0/addsvc/reqrep"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // NewClient takes a Thrift AddServiceClient, which should point to an

--- a/addsvc/endpoint.go
+++ b/addsvc/endpoint.go
@@ -3,8 +3,8 @@ package main
 import (
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/addsvc/reqrep"
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/addsvc/reqrep"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // makeEndpoint returns an endpoint wrapping the passed Add. If Add were an

--- a/addsvc/enhancements.go
+++ b/addsvc/enhancements.go
@@ -5,8 +5,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
+	"gopkg.in/kit.v0/log"
+	"gopkg.in/kit.v0/metrics"
 )
 
 func logging(logger log.Logger) func(Add) Add {

--- a/addsvc/grpc_binding.go
+++ b/addsvc/grpc_binding.go
@@ -3,9 +3,9 @@ package main
 import (
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/addsvc/pb"
-	"github.com/go-kit/kit/addsvc/reqrep"
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/addsvc/pb"
+	"gopkg.in/kit.v0/addsvc/reqrep"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // A binding wraps an Endpoint so that it's usable by a transport. grpcBinding

--- a/addsvc/http_binding.go
+++ b/addsvc/http_binding.go
@@ -6,9 +6,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/addsvc/reqrep"
-	"github.com/go-kit/kit/endpoint"
-	httptransport "github.com/go-kit/kit/transport/http"
+	"gopkg.in/kit.v0/addsvc/reqrep"
+	"gopkg.in/kit.v0/endpoint"
+	httptransport "gopkg.in/kit.v0/transport/http"
 )
 
 func makeHTTPBinding(ctx context.Context, e endpoint.Endpoint, before []httptransport.BeforeFunc, after []httptransport.AfterFunc) http.Handler {

--- a/addsvc/main.go
+++ b/addsvc/main.go
@@ -21,17 +21,17 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
-	thriftadd "github.com/go-kit/kit/addsvc/_thrift/gen-go/add"
-	httpclient "github.com/go-kit/kit/addsvc/client/http"
-	"github.com/go-kit/kit/addsvc/pb"
-	"github.com/go-kit/kit/endpoint"
-	kitlog "github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/expvar"
-	"github.com/go-kit/kit/metrics/prometheus"
-	"github.com/go-kit/kit/metrics/statsd"
-	"github.com/go-kit/kit/tracing/zipkin"
-	httptransport "github.com/go-kit/kit/transport/http"
+	thriftadd "gopkg.in/kit.v0/addsvc/_thrift/gen-go/add"
+	httpclient "gopkg.in/kit.v0/addsvc/client/http"
+	"gopkg.in/kit.v0/addsvc/pb"
+	"gopkg.in/kit.v0/endpoint"
+	kitlog "gopkg.in/kit.v0/log"
+	"gopkg.in/kit.v0/metrics"
+	"gopkg.in/kit.v0/metrics/expvar"
+	"gopkg.in/kit.v0/metrics/prometheus"
+	"gopkg.in/kit.v0/metrics/statsd"
+	"gopkg.in/kit.v0/tracing/zipkin"
+	httptransport "gopkg.in/kit.v0/transport/http"
 )
 
 func main() {

--- a/addsvc/netrpc_binding.go
+++ b/addsvc/netrpc_binding.go
@@ -3,8 +3,8 @@ package main
 import (
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/addsvc/reqrep"
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/addsvc/reqrep"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // NetrpcBinding makes an endpoint usable over net/rpc. It needs to be

--- a/addsvc/thrift_binding.go
+++ b/addsvc/thrift_binding.go
@@ -3,9 +3,9 @@ package main
 import (
 	"golang.org/x/net/context"
 
-	thriftadd "github.com/go-kit/kit/addsvc/_thrift/gen-go/add"
-	"github.com/go-kit/kit/addsvc/reqrep"
-	"github.com/go-kit/kit/endpoint"
+	thriftadd "gopkg.in/kit.v0/addsvc/_thrift/gen-go/add"
+	"gopkg.in/kit.v0/addsvc/reqrep"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // A binding wraps an Endpoint so that it's usable by a transport.

--- a/circuitbreaker/gobreaker.go
+++ b/circuitbreaker/gobreaker.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sony/gobreaker"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // Gobreaker returns an endpoint.Middleware that implements the circuit

--- a/circuitbreaker/gobreaker_test.go
+++ b/circuitbreaker/gobreaker_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/sony/gobreaker"
 
-	"github.com/go-kit/kit/circuitbreaker"
+	"gopkg.in/kit.v0/circuitbreaker"
 )
 
 func TestGobreaker(t *testing.T) {

--- a/circuitbreaker/handy_breaker.go
+++ b/circuitbreaker/handy_breaker.go
@@ -6,7 +6,7 @@ import (
 	"github.com/streadway/handy/breaker"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // HandyBreaker returns an endpoint.Middleware that implements the circuit

--- a/circuitbreaker/handy_breaker_test.go
+++ b/circuitbreaker/handy_breaker_test.go
@@ -5,7 +5,7 @@ import (
 
 	handybreaker "github.com/streadway/handy/breaker"
 
-	"github.com/go-kit/kit/circuitbreaker"
+	"gopkg.in/kit.v0/circuitbreaker"
 )
 
 func TestHandyBreaker(t *testing.T) {

--- a/circuitbreaker/hystrix.go
+++ b/circuitbreaker/hystrix.go
@@ -4,7 +4,7 @@ import (
 	"github.com/afex/hystrix-go/hystrix"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // Hystrix returns an endpoint.Middleware that implements the circuit

--- a/circuitbreaker/hystrix_test.go
+++ b/circuitbreaker/hystrix_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/afex/hystrix-go/hystrix"
 
-	"github.com/go-kit/kit/circuitbreaker"
-	kitlog "github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/circuitbreaker"
+	kitlog "gopkg.in/kit.v0/log"
 )
 
 func TestHystrix(t *testing.T) {

--- a/circuitbreaker/util_test.go
+++ b/circuitbreaker/util_test.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 func testFailingEndpoint(t *testing.T, breaker endpoint.Middleware, primeWith int, shouldPass func(int) bool, openCircuitError string) {

--- a/endpoint/endpoint_example_test.go
+++ b/endpoint/endpoint_example_test.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 func ExampleChain() {

--- a/loadbalancer/dnssrv/publisher.go
+++ b/loadbalancer/dnssrv/publisher.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/loadbalancer"
-	"github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/endpoint"
+	"gopkg.in/kit.v0/loadbalancer"
+	"gopkg.in/kit.v0/log"
 )
 
 // Publisher yields endpoints taken from the named DNS SRV record. The name is

--- a/loadbalancer/dnssrv/publisher_internal_test.go
+++ b/loadbalancer/dnssrv/publisher_internal_test.go
@@ -9,9 +9,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/loadbalancer"
-	"github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/endpoint"
+	"gopkg.in/kit.v0/loadbalancer"
+	"gopkg.in/kit.v0/log"
 )
 
 func TestPublisher(t *testing.T) {

--- a/loadbalancer/factory.go
+++ b/loadbalancer/factory.go
@@ -1,6 +1,6 @@
 package loadbalancer
 
-import "github.com/go-kit/kit/endpoint"
+import "gopkg.in/kit.v0/endpoint"
 
 // Factory is a function that converts an instance string, e.g. a host:port,
 // to a usable endpoint. Factories are used by load balancers to lift

--- a/loadbalancer/loadbalancer.go
+++ b/loadbalancer/loadbalancer.go
@@ -3,7 +3,7 @@ package loadbalancer
 import (
 	"errors"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // LoadBalancer describes something that can yield endpoints for a remote

--- a/loadbalancer/publisher.go
+++ b/loadbalancer/publisher.go
@@ -3,7 +3,7 @@ package loadbalancer
 import (
 	"errors"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // Publisher describes something that provides a set of identical endpoints.

--- a/loadbalancer/random.go
+++ b/loadbalancer/random.go
@@ -3,7 +3,7 @@ package loadbalancer
 import (
 	"math/rand"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // Random is a completely stateless load balancer that chooses a random

--- a/loadbalancer/random_test.go
+++ b/loadbalancer/random_test.go
@@ -6,9 +6,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/loadbalancer"
-	"github.com/go-kit/kit/loadbalancer/static"
+	"gopkg.in/kit.v0/endpoint"
+	"gopkg.in/kit.v0/loadbalancer"
+	"gopkg.in/kit.v0/loadbalancer/static"
 )
 
 func TestRandomDistribution(t *testing.T) {

--- a/loadbalancer/retry.go
+++ b/loadbalancer/retry.go
@@ -7,7 +7,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // Retry wraps the load balancer to make it behave like a simple endpoint.

--- a/loadbalancer/retry_test.go
+++ b/loadbalancer/retry_test.go
@@ -7,9 +7,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/loadbalancer"
-	"github.com/go-kit/kit/loadbalancer/static"
+	"gopkg.in/kit.v0/endpoint"
+	"gopkg.in/kit.v0/loadbalancer"
+	"gopkg.in/kit.v0/loadbalancer/static"
 )
 
 func TestRetryMaxTotalFail(t *testing.T) {

--- a/loadbalancer/round_robin.go
+++ b/loadbalancer/round_robin.go
@@ -3,7 +3,7 @@ package loadbalancer
 import (
 	"sync/atomic"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // RoundRobin is a simple load balancer that returns each of the published

--- a/loadbalancer/round_robin_test.go
+++ b/loadbalancer/round_robin_test.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/loadbalancer"
-	"github.com/go-kit/kit/loadbalancer/static"
+	"gopkg.in/kit.v0/endpoint"
+	"gopkg.in/kit.v0/loadbalancer"
+	"gopkg.in/kit.v0/loadbalancer/static"
 	"golang.org/x/net/context"
 )
 

--- a/loadbalancer/static/publisher.go
+++ b/loadbalancer/static/publisher.go
@@ -3,7 +3,7 @@ package static
 import (
 	"sync"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // Publisher yields the same set of static endpoints.

--- a/loadbalancer/static/publisher_test.go
+++ b/loadbalancer/static/publisher_test.go
@@ -6,8 +6,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/loadbalancer/static"
+	"gopkg.in/kit.v0/endpoint"
+	"gopkg.in/kit.v0/loadbalancer/static"
 )
 
 func TestStatic(t *testing.T) {

--- a/log/benchmark_test.go
+++ b/log/benchmark_test.go
@@ -3,7 +3,7 @@ package log_test
 import (
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/log"
 )
 
 func benchmarkRunner(b *testing.B, logger log.Logger, f func(log.Logger)) {

--- a/log/concurrency_test.go
+++ b/log/concurrency_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/log"
 )
 
 // These test are designed to be run with the race detector.

--- a/log/example_test.go
+++ b/log/example_test.go
@@ -3,7 +3,7 @@ package log_test
 import (
 	"os"
 
-	"github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/log"
 )
 
 func ExampleContext() {

--- a/log/json_logger_test.go
+++ b/log/json_logger_test.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/log"
 )
 
 func TestJSONLogger(t *testing.T) {

--- a/log/levels/levels.go
+++ b/log/levels/levels.go
@@ -1,6 +1,6 @@
 package levels
 
-import "github.com/go-kit/kit/log"
+import "gopkg.in/kit.v0/log"
 
 // Levels provides a leveled logging wrapper around a logger. It has five
 // levels: debug, info, warning (warn), error, and critical (crit). If you

--- a/log/levels/levels_test.go
+++ b/log/levels/levels_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/levels"
+	"gopkg.in/kit.v0/log"
+	"gopkg.in/kit.v0/log/levels"
 )
 
 func TestDefaultLevels(t *testing.T) {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/log"
 )
 
 var discard = log.Logger(log.LoggerFunc(func(...interface{}) error { return nil }))

--- a/log/logfmt_logger_test.go
+++ b/log/logfmt_logger_test.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/log"
 	"gopkg.in/logfmt.v0"
 )
 

--- a/log/nop_logger_test.go
+++ b/log/nop_logger_test.go
@@ -3,7 +3,7 @@ package log_test
 import (
 	"testing"
 
-	"github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/log"
 )
 
 func TestNopLogger(t *testing.T) {

--- a/log/value_test.go
+++ b/log/value_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/log"
 )
 
 func TestValueBinding(t *testing.T) {

--- a/metrics/expvar/expvar.go
+++ b/metrics/expvar/expvar.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/codahale/hdrhistogram"
 
-	"github.com/go-kit/kit/metrics"
+	"gopkg.in/kit.v0/metrics"
 )
 
 type counter struct {

--- a/metrics/expvar/expvar_test.go
+++ b/metrics/expvar/expvar_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/expvar"
-	"github.com/go-kit/kit/metrics/teststat"
+	"gopkg.in/kit.v0/metrics"
+	"gopkg.in/kit.v0/metrics/expvar"
+	"gopkg.in/kit.v0/metrics/teststat"
 )
 
 func TestHistogramQuantiles(t *testing.T) {

--- a/metrics/multi_test.go
+++ b/metrics/multi_test.go
@@ -15,9 +15,9 @@ import (
 
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/expvar"
-	"github.com/go-kit/kit/metrics/prometheus"
+	"gopkg.in/kit.v0/metrics"
+	"gopkg.in/kit.v0/metrics/expvar"
+	"gopkg.in/kit.v0/metrics/prometheus"
 )
 
 func TestMultiWith(t *testing.T) {

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -4,7 +4,7 @@ package prometheus
 import (
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/go-kit/kit/metrics"
+	"gopkg.in/kit.v0/metrics"
 )
 
 // Prometheus has strong opinions about the dimensionality of fields. Users

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -6,9 +6,9 @@ import (
 
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/prometheus"
-	"github.com/go-kit/kit/metrics/teststat"
+	"gopkg.in/kit.v0/metrics"
+	"gopkg.in/kit.v0/metrics/prometheus"
+	"gopkg.in/kit.v0/metrics/teststat"
 )
 
 func TestPrometheusLabelBehavior(t *testing.T) {

--- a/metrics/scaled_histogram_test.go
+++ b/metrics/scaled_histogram_test.go
@@ -3,8 +3,8 @@ package metrics_test
 import (
 	"testing"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/expvar"
+	"gopkg.in/kit.v0/metrics"
+	"gopkg.in/kit.v0/metrics/expvar"
 )
 
 func TestScaledHistogram(t *testing.T) {

--- a/metrics/statsd/statsd.go
+++ b/metrics/statsd/statsd.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/go-kit/kit/metrics"
+	"gopkg.in/kit.v0/metrics"
 )
 
 // statsd metrics take considerable influence from

--- a/metrics/teststat/common.go
+++ b/metrics/teststat/common.go
@@ -7,7 +7,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/go-kit/kit/metrics"
+	"gopkg.in/kit.v0/metrics"
 )
 
 const population = 1234

--- a/metrics/time_histogram_test.go
+++ b/metrics/time_histogram_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/kit/metrics"
-	"github.com/go-kit/kit/metrics/expvar"
+	"gopkg.in/kit.v0/metrics"
+	"gopkg.in/kit.v0/metrics/expvar"
 )
 
 func TestTimeHistogram(t *testing.T) {

--- a/ratelimit/token_bucket.go
+++ b/ratelimit/token_bucket.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/ratelimit"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // ErrLimited is returned in the request path when the rate limiter is

--- a/ratelimit/token_bucket_test.go
+++ b/ratelimit/token_bucket_test.go
@@ -8,8 +8,8 @@ import (
 	jujuratelimit "github.com/juju/ratelimit"
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/ratelimit"
+	"gopkg.in/kit.v0/endpoint"
+	"gopkg.in/kit.v0/ratelimit"
 )
 
 func TestTokenBucketLimiter(t *testing.T) {

--- a/tracing/zipkin/collector.go
+++ b/tracing/zipkin/collector.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/tracing/zipkin/_thrift/gen-go/scribe"
+	"gopkg.in/kit.v0/log"
+	"gopkg.in/kit.v0/tracing/zipkin/_thrift/gen-go/scribe"
 )
 
 // Collector represents a Zipkin trace collector, which is probably a set of

--- a/tracing/zipkin/collector_test.go
+++ b/tracing/zipkin/collector_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 
-	"github.com/go-kit/kit/tracing/zipkin"
-	"github.com/go-kit/kit/tracing/zipkin/_thrift/gen-go/scribe"
-	"github.com/go-kit/kit/tracing/zipkin/_thrift/gen-go/zipkincore"
+	"gopkg.in/kit.v0/tracing/zipkin"
+	"gopkg.in/kit.v0/tracing/zipkin/_thrift/gen-go/scribe"
+	"gopkg.in/kit.v0/tracing/zipkin/_thrift/gen-go/zipkincore"
 )
 
 func TestScribeCollector(t *testing.T) {

--- a/tracing/zipkin/span.go
+++ b/tracing/zipkin/span.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-kit/kit/tracing/zipkin/_thrift/gen-go/zipkincore"
+	"gopkg.in/kit.v0/tracing/zipkin/_thrift/gen-go/zipkincore"
 )
 
 var (

--- a/tracing/zipkin/zipkin.go
+++ b/tracing/zipkin/zipkin.go
@@ -7,8 +7,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
+	"gopkg.in/kit.v0/endpoint"
+	"gopkg.in/kit.v0/log"
 )
 
 // In Zipkin, "spans are considered to start and stop with the client." The

--- a/tracing/zipkin/zipkin_test.go
+++ b/tracing/zipkin/zipkin_test.go
@@ -12,9 +12,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/tracing/zipkin"
+	"gopkg.in/kit.v0/endpoint"
+	"gopkg.in/kit.v0/log"
+	"gopkg.in/kit.v0/tracing/zipkin"
 )
 
 func TestToContext(t *testing.T) {

--- a/transport/http/before_after_test.go
+++ b/transport/http/before_after_test.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	httptransport "github.com/go-kit/kit/transport/http"
+	httptransport "gopkg.in/kit.v0/transport/http"
 )
 
 func TestSetHeader(t *testing.T) {

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/go-kit/kit/endpoint"
+	"gopkg.in/kit.v0/endpoint"
 )
 
 // Server wraps an endpoint and implements http.Handler.

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -9,7 +9,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	httptransport "github.com/go-kit/kit/transport/http"
+	httptransport "gopkg.in/kit.v0/transport/http"
 )
 
 func TestServerBadDecode(t *testing.T) {


### PR DESCRIPTION
If I import gopkg.in/kit.v0/metrics and
gopkg.in/kit.v0/metrics/prometheus, I get compile errors, as prometheus
uses metrics.Field from github.com/go-kit/kit, but I have metrics.Fields
from gopkg.in/kit.v0/metrics.