### PR TITLE
Keep log.Context.Log stack depth consistent.

### DIFF
--- a/log/levels/levels.go
+++ b/log/levels/levels.go
@@ -7,7 +7,7 @@ import "github.com/go-kit/kit/log"
 // want a different set of levels, you can create your own levels type very
 // easily, and you can elide the configuration.
 type Levels struct {
-	ctx      log.Context
+	ctx      *log.Context
 	levelKey string
 
 	// We have a choice between storing level values in string fields or

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
-var discard = log.Logger(log.LoggerFunc(func(...interface{}) error { return nil }))
-
 func TestContext(t *testing.T) {
 	t.Parallel()
 	buf := &bytes.Buffer{}
@@ -111,7 +109,7 @@ func TestWithConcurrent(t *testing.T) {
 }
 
 func BenchmarkDiscard(b *testing.B) {
-	logger := discard
+	logger := log.NewNopLogger()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -120,7 +118,7 @@ func BenchmarkDiscard(b *testing.B) {
 }
 
 func BenchmarkOneWith(b *testing.B) {
-	logger := discard
+	logger := log.NewNopLogger()
 	lc := log.NewContext(logger).With("k", "v")
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -130,7 +128,7 @@ func BenchmarkOneWith(b *testing.B) {
 }
 
 func BenchmarkTwoWith(b *testing.B) {
-	logger := discard
+	logger := log.NewNopLogger()
 	lc := log.NewContext(logger).With("k", "v")
 	for i := 1; i < 2; i++ {
 		lc = lc.With("k", "v")
@@ -143,7 +141,7 @@ func BenchmarkTwoWith(b *testing.B) {
 }
 
 func BenchmarkTenWith(b *testing.B) {
-	logger := discard
+	logger := log.NewNopLogger()
 	lc := log.NewContext(logger).With("k", "v")
 	for i := 1; i < 10; i++ {
 		lc = lc.With("k", "v")

--- a/log/value_test.go
+++ b/log/value_test.go
@@ -89,7 +89,7 @@ func TestValueBinding_loggingZeroKeyvals(t *testing.T) {
 }
 
 func BenchmarkValueBindingTimestamp(b *testing.B) {
-	logger := discard
+	logger := log.NewNopLogger()
 	lc := log.NewContext(logger).With("ts", log.DefaultTimestamp)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -99,7 +99,7 @@ func BenchmarkValueBindingTimestamp(b *testing.B) {
 }
 
 func BenchmarkValueBindingCaller(b *testing.B) {
-	logger := discard
+	logger := log.NewNopLogger()
 	lc := log.NewContext(logger).With("caller", log.DefaultCaller)
 	b.ReportAllocs()
 	b.ResetTimer()


### PR DESCRIPTION
Change `log.Context` methods to take pointer receivers to prevent the compiler from introducing generated functions to dereference pointers when calling methods via a `log.Logger` interface.

See comments in `log/log.go` and the new `TestContextStackDepth` for more details.