### PR TITLE
Implement term.ColorLogger

### DIFF
--- a/log/json_logger.go
+++ b/log/json_logger.go
@@ -74,3 +74,7 @@ func safeError(err error) (s interface{}) {
 	s = err.Error()
 	return
 }
+
+func (l *jsonLogger) Hijack(f func(io.Writer) io.Writer) {
+	l.Writer = f(l.Writer)
+}

--- a/log/log.go
+++ b/log/log.go
@@ -6,6 +6,7 @@ package log
 
 import (
 	"errors"
+	"io"
 	"sync/atomic"
 )
 
@@ -16,6 +17,12 @@ import (
 // modifies any of its elements must make a copy first.
 type Logger interface {
 	Log(keyvals ...interface{}) error
+}
+
+// Hijacker allows accessing the Logger's underlying io.Writer with Hijack.
+type Hijacker interface {
+	// Hijack gets the Logger's underlying Writer, and replaces it with the returned one.
+	Hijack(func(io.Writer) io.Writer)
 }
 
 // ErrMissingValue is appended to keyvals slices with odd length to substitute

--- a/log/log.go
+++ b/log/log.go
@@ -22,6 +22,7 @@ type Logger interface {
 // Hijacker allows accessing the Logger's underlying io.Writer with Hijack.
 type Hijacker interface {
 	// Hijack gets the Logger's underlying Writer, and replaces it with the returned one.
+	// The implementor must ensure safe concurrent calls!
 	Hijack(func(io.Writer) io.Writer)
 }
 

--- a/log/logfmt_logger.go
+++ b/log/logfmt_logger.go
@@ -32,3 +32,7 @@ func (l logfmtLogger) Log(keyvals ...interface{}) error {
 	}
 	return nil
 }
+
+func (l *logfmtLogger) Hijack(f func(io.Writer) io.Writer) {
+	l.w = f(l.w)
+}

--- a/log/term/LICENSE
+++ b/log/term/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Simon Eskildsen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/log/term/colorlogger.go
+++ b/log/term/colorlogger.go
@@ -31,14 +31,9 @@ func (c FgBgColor) IsZero() bool {
 	return c.Fg == NoColor && c.Bg == NoColor
 }
 
-type ColorOption struct {
-	Key   FgBgColor
-	Value func(interface{}) FgBgColor
-}
-
 var _ = log.Logger((*colorLogger)(nil))
 
-// NewColorLogger returns a log.Logger which prouces nice colored logs.
+// NewColorLogger returns a log.Logger which produces nice colored logs.
 // It colors whole records based on the FgBgColor returned by the color function.
 //
 // For example for such a function, see LevelColor.
@@ -61,16 +56,21 @@ var _ = log.Logger((*colorLogger)(nil))
 //	logger.Log("c", "c is uncolored value", "err", nil)
 //	logger.Log("c", "c is colored 'cause err colors it", "err", errors.New("coloring error"))
 func NewColorLogger(logger log.Logger, color func(keyvals ...interface{}) FgBgColor) log.Logger {
+	// FIXME(tgulacsi): I don't understand why can't I use log.Hijacker here...
+	hj, ok := logger.(interface {
+		Hijack(func(io.Writer) io.Writer)
+	})
+	if !ok {
+		return logger
+	}
 	cl := &colorLogger{
 		logger: logger,
 	}
-	if hj, ok := logger.(log.Hijacker); ok {
-		cl.color = color // otherwise, no coloring is possible!
-		hj.Hijack(func(w io.Writer) io.Writer {
-			cl.w = w
-			return cl
-		})
-	}
+	cl.color = color // otherwise, no coloring is possible!
+	hj.Hijack(func(w io.Writer) io.Writer {
+		cl.w = w
+		return cl
+	})
 	return cl
 }
 
@@ -78,6 +78,7 @@ type colorLogger struct {
 	logger log.Logger
 	color  func(keyvals ...interface{}) FgBgColor
 	w      io.Writer
+	mu     sync.RWMutex // protects w
 
 	actColor   FgBgColor
 	actColorMu sync.RWMutex // protects actColor
@@ -119,34 +120,20 @@ func (l *colorLogger) Write(p []byte) (int, error) {
 		return n + m, err
 	}
 	n += m
-	m, err = l.w.Write([]byte("\x1b[0m"))
+	l.mu.RLock()
+	w := l.w
+	l.mu.RUnlock()
+	m, err = w.Write([]byte("\x1b[0m"))
 	return n + m, err
 }
 
 func (l *colorLogger) Hijack(f func(io.Writer) io.Writer) {
+	l.mu.Lock()
 	l.w = f(l.w)
+	l.mu.Unlock()
 }
 
-type ColoredValue struct {
-	FgBgColor
-	Value interface{}
-}
-
-func (cv ColoredValue) String() string {
-	// http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
-	if cv.Fg == 0 && cv.Bg == 0 {
-		return fmt.Sprintf("%v", cv.Value)
-	}
-	if cv.Bg == 0 {
-		return fmt.Sprintf("\x1b[%dm%v\x1b[0m", 30+cv.Fg, cv.Value)
-	}
-	if cv.Fg == 0 {
-		return fmt.Sprintf("\x1b[%dm%v\x1b[0m", 40+cv.Bg, cv.Value)
-	}
-	return fmt.Sprintf("\x1b[%dm\x1b[%dm%v\x1b[0m", 30+cv.Fg, 40+cv.Bg, cv.Value)
-}
-
-func AsString(v interface{}) string {
+func asString(v interface{}) string {
 	switch x := v.(type) {
 	case string:
 		return x
@@ -157,4 +144,28 @@ func AsString(v interface{}) string {
 	default:
 		return fmt.Sprintf("%v", x)
 	}
+}
+
+// LevelColor returns the color for the record based on the value of the "level" key, if exists.
+func LevelColor(keyvals ...interface{}) FgBgColor {
+	for i := 0; i < len(keyvals); i += 2 {
+		if asString(keyvals[i]) != "level" {
+			continue
+		}
+		switch asString(keyvals[i+1]) {
+		case "debug":
+			return FgBgColor{Fg: Green}
+		case "info":
+			return FgBgColor{Fg: White}
+		case "warn":
+			return FgBgColor{Fg: Yellow}
+		case "error":
+			return FgBgColor{Fg: Red}
+		case "crit":
+			return FgBgColor{Fg: Default, Bg: Red}
+		default:
+			return FgBgColor{}
+		}
+	}
+	return FgBgColor{}
 }

--- a/log/term/colorlogger.go
+++ b/log/term/colorlogger.go
@@ -1,0 +1,160 @@
+package term
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/go-kit/kit/log"
+)
+
+// Color is the abstract color, the zero value is the Default.
+type Color uint8
+
+const (
+	NoColor = Color(iota)
+	Red
+	Green
+	Yellow
+	Blue
+	Magenta
+	Cyan
+	White
+	Default
+)
+
+type FgBgColor struct {
+	Fg, Bg Color
+}
+
+func (c FgBgColor) IsZero() bool {
+	return c.Fg == NoColor && c.Bg == NoColor
+}
+
+type ColorOption struct {
+	Key   FgBgColor
+	Value func(interface{}) FgBgColor
+}
+
+var _ = log.Logger((*colorLogger)(nil))
+
+// NewColorLogger returns a log.Logger which prouces nice colored logs.
+// It colors whole records based on the FgBgColor returned by the color function.
+//
+// For example for such a function, see LevelColor.
+//
+// Example for coloring errors with red:
+//
+//	logger := term.NewColorLogger(log.NewLogfmtLogger(os.Stdout),
+//		func(keyvals ...interface) term.FgBgColor {
+//			for i := 1; i < len(keyvals); i += 2 {
+//				if keyvals[i] != nil {
+//					continue
+//				}
+//				if _, ok := keyvals[i].(error) {
+//					return term.FgBgColor{Fg: term.White, Bg: term.Red}
+//				}
+//			}
+//			return term.FgBgColor{}
+//		})
+//
+//	logger.Log("c", "c is uncolored value", "err", nil)
+//	logger.Log("c", "c is colored 'cause err colors it", "err", errors.New("coloring error"))
+func NewColorLogger(logger log.Logger, color func(keyvals ...interface{}) FgBgColor) log.Logger {
+	cl := &colorLogger{
+		logger: logger,
+	}
+	if hj, ok := logger.(log.Hijacker); ok {
+		cl.color = color // otherwise, no coloring is possible!
+		hj.Hijack(func(w io.Writer) io.Writer {
+			cl.w = w
+			return cl
+		})
+	}
+	return cl
+}
+
+type colorLogger struct {
+	logger log.Logger
+	color  func(keyvals ...interface{}) FgBgColor
+	w      io.Writer
+
+	actColor   FgBgColor
+	actColorMu sync.RWMutex // protects actColor
+}
+
+func (l *colorLogger) Log(keyvals ...interface{}) error {
+	l.actColorMu.Lock() // Unlock is in Write!
+	if l.color != nil {
+		l.actColor = l.color(keyvals...)
+	}
+	l.actColorMu.Unlock()
+	return l.logger.Log(keyvals...)
+}
+
+func (l *colorLogger) Write(p []byte) (int, error) {
+	l.actColorMu.RLock()
+	color := l.actColor
+	l.actColorMu.RUnlock()
+	if color.IsZero() {
+		return l.w.Write(p)
+	}
+	var n int
+	if color.Fg != NoColor {
+		m, err := fmt.Fprintf(l.w, "\x1b[%dm", 30+color.Fg)
+		if err != nil {
+			return m, err
+		}
+		n += m
+	}
+	if color.Bg != NoColor {
+		m, err := fmt.Fprintf(l.w, "\x1b[%dm", 40+color.Bg)
+		if err != nil {
+			return n + m, err
+		}
+		n += m
+	}
+	m, err := l.w.Write(p)
+	if err != nil {
+		return n + m, err
+	}
+	n += m
+	m, err = l.w.Write([]byte("\x1b[0m"))
+	return n + m, err
+}
+
+func (l *colorLogger) Hijack(f func(io.Writer) io.Writer) {
+	l.w = f(l.w)
+}
+
+type ColoredValue struct {
+	FgBgColor
+	Value interface{}
+}
+
+func (cv ColoredValue) String() string {
+	// http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+	if cv.Fg == 0 && cv.Bg == 0 {
+		return fmt.Sprintf("%v", cv.Value)
+	}
+	if cv.Bg == 0 {
+		return fmt.Sprintf("\x1b[%dm%v\x1b[0m", 30+cv.Fg, cv.Value)
+	}
+	if cv.Fg == 0 {
+		return fmt.Sprintf("\x1b[%dm%v\x1b[0m", 40+cv.Bg, cv.Value)
+	}
+	return fmt.Sprintf("\x1b[%dm\x1b[%dm%v\x1b[0m", 30+cv.Fg, 40+cv.Bg, cv.Value)
+}
+
+func AsString(v interface{}) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case fmt.Stringer:
+		return x.String()
+	case fmt.Formatter:
+		return fmt.Sprint(x)
+	default:
+		return fmt.Sprintf("%v", x)
+	}
+}

--- a/log/term/colorlogger_test.go
+++ b/log/term/colorlogger_test.go
@@ -1,0 +1,108 @@
+package term_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/term"
+	"gopkg.in/logfmt.v0"
+)
+
+type mymap map[int]int
+
+func (m mymap) String() string { return "special_behavior" }
+
+func TestColorLogger(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newColorLogger(t, &buf)
+
+	if err := logger.Log("hello", "world"); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := "hello=world\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	buf.Reset()
+	if err := logger.Log("a", 1, "err", errors.New("error")); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := "\u001b[32m\u001b[48ma=1 err=error\n\u001b[0m", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	buf.Reset()
+	if err := logger.Log("std_map", map[int]int{1: 2}, "my_map", mymap{0: 0}); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := "std_map=\""+logfmt.ErrUnsupportedValueType.Error()+"\" my_map=special_behavior\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+}
+
+func newColorLogger(t testing.TB, w io.Writer) log.Logger {
+	return term.NewColorLogger(log.NewLogfmtLogger(w),
+		func(keyvals ...interface{}) term.FgBgColor {
+			for i := 0; i < len(keyvals); i += 2 {
+				key := term.AsString(keyvals[i])
+				if key == "a" {
+					return term.FgBgColor{Fg: term.Green, Bg: term.Default}
+				}
+				if key == "err" && keyvals[i+1] != nil {
+					return term.FgBgColor{Fg: term.White, Bg: term.Red}
+				}
+			}
+			return term.FgBgColor{}
+		})
+}
+
+func BenchmarkColorLoggerSimple(b *testing.B) {
+	benchmarkRunner(b, newColorLogger(b, ioutil.Discard), baseMessage)
+}
+
+func BenchmarkColorLoggerContextual(b *testing.B) {
+	benchmarkRunner(b, newColorLogger(b, ioutil.Discard), withMessage)
+}
+
+func TestColorLoggerConcurrency(t *testing.T) {
+	testConcurrency(t, newColorLogger(t, ioutil.Discard))
+}
+
+// copied from log/benchmark_test.go
+func benchmarkRunner(b *testing.B, logger log.Logger, f func(log.Logger)) {
+	lc := log.NewContext(logger).With("common_key", "common_value")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f(lc)
+	}
+}
+
+var (
+	baseMessage = func(logger log.Logger) { logger.Log("foo_key", "foo_value") }
+	withMessage = func(logger log.Logger) { log.NewContext(logger).With("a", "b").Log("c", "d") }
+)
+
+// copied from log/concurrency_test.go
+func testConcurrency(t *testing.T, logger log.Logger) {
+	for _, n := range []int{10, 100, 500} {
+		wg := sync.WaitGroup{}
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() { spam(logger); wg.Done() }()
+		}
+		wg.Wait()
+	}
+}
+
+func spam(logger log.Logger) {
+	for i := 0; i < 100; i++ {
+		logger.Log("key", strconv.FormatInt(int64(i), 10))
+	}
+}

--- a/log/term/terminal_appengine.go
+++ b/log/term/terminal_appengine.go
@@ -1,0 +1,13 @@
+// Based on ssh/terminal:
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+package term
+
+// IsTty always returns false on AppEngine.
+func IsTty(fd uintptr) bool {
+	return false
+}

--- a/log/term/terminal_darwin.go
+++ b/log/term/terminal_darwin.go
@@ -1,0 +1,12 @@
+// Based on ssh/terminal:
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package term
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA
+
+type Termios syscall.Termios

--- a/log/term/terminal_freebsd.go
+++ b/log/term/terminal_freebsd.go
@@ -1,0 +1,18 @@
+package term
+
+import (
+	"syscall"
+)
+
+const ioctlReadTermios = syscall.TIOCGETA
+
+// Go 1.2 doesn't include Termios for FreeBSD. This should be added in 1.3 and this could be merged with terminal_darwin.
+type Termios struct {
+	Iflag  uint32
+	Oflag  uint32
+	Cflag  uint32
+	Lflag  uint32
+	Cc     [20]uint8
+	Ispeed uint32
+	Ospeed uint32
+}

--- a/log/term/terminal_linux.go
+++ b/log/term/terminal_linux.go
@@ -1,0 +1,14 @@
+// Based on ssh/terminal:
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !appengine
+
+package term
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TCGETS
+
+type Termios syscall.Termios

--- a/log/term/terminal_notwindows.go
+++ b/log/term/terminal_notwindows.go
@@ -1,0 +1,20 @@
+// Based on ssh/terminal:
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux,!appengine darwin freebsd openbsd
+
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// IsTty returns true if the given file descriptor is a terminal.
+func IsTty(fd uintptr) bool {
+	var termios Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/log/term/terminal_openbsd.go
+++ b/log/term/terminal_openbsd.go
@@ -1,0 +1,7 @@
+package term
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA
+
+type Termios syscall.Termios

--- a/log/term/terminal_windows.go
+++ b/log/term/terminal_windows.go
@@ -1,0 +1,26 @@
+// Based on ssh/terminal:
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+var (
+	procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+)
+
+// IsTty returns true if the given file descriptor is a terminal.
+func IsTty(fd uintptr) bool {
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, fd, uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}


### PR DESCRIPTION
This needs a Hijack method for Logger - this is implemented on Logfmt.
This logger colorizes whole records, for the first matching key/value.

This way you can colorize the record if it contains a given key, or if it contains a non-nil error, for example.
Or colorize levels differently.