### PR TITLE
transport/http: {Encode,Decode}{Request,Response}Func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-cover.out
 examples/addsvc/addsvc
 examples/addsvc/client/addcli/addcli
 examples/stringsvc1/stringsvc1
 examples/stringsvc2/stringsvc2
 examples/stringsvc3/stringsvc3
+gover.coverprofile
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o

--- a/coverage.bash
+++ b/coverage.bash
@@ -4,6 +4,8 @@
 # WEB environment variable, it will additionally open the web-based coverage
 # visualizer for each package.
 
+set -e
+
 function go_files { find . -name '*_test.go' ; }
 function filter { grep -v '/_' ; }
 function remove_relative_prefix { sed -e 's/^\.\///g' ; }
@@ -19,24 +21,27 @@ function unique_directories { directories | sort | uniq ; }
 
 PATHS=${1:-$(unique_directories)}
 
-function package_names {
-	for d in $PATHS
+function report {
+	for path in $PATHS
 	do
-		echo github.com/go-kit/kit/$d
+		go test -coverprofile=$path/cover.coverprofile ./$path
 	done
 }
 
-function report {
-	package_names | while read pkg
-	do
-		go test -coverprofile=cover.out $pkg
-		if [ -n "${WEB+x}" ]
-		then
-			go tool cover -html=cover.out
-		fi
-	done
-	rm cover.out
+function combine {
+	gover
+}
+
+function clean {
+	find . -name cover.coverprofile | xargs rm
 }
 
 report
+combine
+clean
+
+if [ -n "${WEB+x}" ]
+then
+	go tool cover -html=gover.coverprofile
+fi
 

--- a/examples/stringsvc1/main.go
+++ b/examples/stringsvc1/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -38,17 +37,17 @@ func main() {
 	svc := stringService{}
 
 	uppercaseHandler := httptransport.Server{
-		Context:    ctx,
-		Endpoint:   makeUppercaseEndpoint(svc),
-		DecodeFunc: decodeUppercaseRequest,
-		EncodeFunc: encodeResponse,
+		Context:            ctx,
+		Endpoint:           makeUppercaseEndpoint(svc),
+		DecodeRequestFunc:  decodeUppercaseRequest,
+		EncodeResponseFunc: encodeResponse,
 	}
 
 	countHandler := httptransport.Server{
-		Context:    ctx,
-		Endpoint:   makeCountEndpoint(svc),
-		DecodeFunc: decodeCountRequest,
-		EncodeFunc: encodeResponse,
+		Context:            ctx,
+		Endpoint:           makeCountEndpoint(svc),
+		DecodeRequestFunc:  decodeCountRequest,
+		EncodeResponseFunc: encodeResponse,
 	}
 
 	http.Handle("/uppercase", uppercaseHandler)
@@ -72,23 +71,23 @@ func makeCountEndpoint(svc StringService) endpoint.Endpoint {
 	}
 }
 
-func decodeUppercaseRequest(r io.Reader) (interface{}, error) {
+func decodeUppercaseRequest(r *http.Request) (interface{}, error) {
 	var request uppercaseRequest
-	if err := json.NewDecoder(r).Decode(&request); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
 	}
 	return request, nil
 }
 
-func decodeCountRequest(r io.Reader) (interface{}, error) {
+func decodeCountRequest(r *http.Request) (interface{}, error) {
 	var request countRequest
-	if err := json.NewDecoder(r).Decode(&request); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
 	}
 	return request, nil
 }
 
-func encodeResponse(w io.Writer, response interface{}) error {
+func encodeResponse(w http.ResponseWriter, response interface{}) error {
 	return json.NewEncoder(w).Encode(response)
 }
 

--- a/examples/stringsvc2/main.go
+++ b/examples/stringsvc2/main.go
@@ -44,17 +44,17 @@ func main() {
 	svc = instrumentingMiddleware{requestCount, requestLatency, countResult, svc}
 
 	uppercaseHandler := httptransport.Server{
-		Context:    ctx,
-		Endpoint:   makeUppercaseEndpoint(svc),
-		DecodeFunc: decodeUppercaseRequest,
-		EncodeFunc: encodeResponse,
+		Context:            ctx,
+		Endpoint:           makeUppercaseEndpoint(svc),
+		DecodeRequestFunc:  decodeUppercaseRequest,
+		EncodeResponseFunc: encodeResponse,
 	}
 
 	countHandler := httptransport.Server{
-		Context:    ctx,
-		Endpoint:   makeCountEndpoint(svc),
-		DecodeFunc: decodeCountRequest,
-		EncodeFunc: encodeResponse,
+		Context:            ctx,
+		Endpoint:           makeCountEndpoint(svc),
+		DecodeRequestFunc:  decodeCountRequest,
+		EncodeResponseFunc: encodeResponse,
 	}
 
 	http.Handle("/uppercase", uppercaseHandler)

--- a/examples/stringsvc2/transport.go
+++ b/examples/stringsvc2/transport.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"encoding/json"
-	"io"
+	"net/http"
 
 	"golang.org/x/net/context"
 
@@ -25,23 +25,23 @@ func makeCountEndpoint(svc StringService) endpoint.Endpoint {
 	}
 }
 
-func decodeUppercaseRequest(r io.Reader) (interface{}, error) {
+func decodeUppercaseRequest(r *http.Request) (interface{}, error) {
 	var request uppercaseRequest
-	if err := json.NewDecoder(r).Decode(&request); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
 	}
 	return request, nil
 }
 
-func decodeCountRequest(r io.Reader) (interface{}, error) {
+func decodeCountRequest(r *http.Request) (interface{}, error) {
 	var request countRequest
-	if err := json.NewDecoder(r).Decode(&request); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
 	}
 	return request, nil
 }
 
-func encodeResponse(w io.Writer, response interface{}) error {
+func encodeResponse(w http.ResponseWriter, response interface{}) error {
 	return json.NewEncoder(w).Encode(response)
 }
 

--- a/examples/stringsvc3/main.go
+++ b/examples/stringsvc3/main.go
@@ -55,16 +55,16 @@ func main() {
 	svc = instrumentingMiddleware(requestCount, requestLatency, countResult)(svc)
 
 	uppercaseHandler := httptransport.Server{
-		Context:    ctx,
-		Endpoint:   makeUppercaseEndpoint(svc),
-		DecodeFunc: decodeUppercaseRequest,
-		EncodeFunc: encode,
+		Context:            ctx,
+		Endpoint:           makeUppercaseEndpoint(svc),
+		DecodeRequestFunc:  decodeUppercaseRequest,
+		EncodeResponseFunc: encodeResponse,
 	}
 	countHandler := httptransport.Server{
-		Context:    ctx,
-		Endpoint:   makeCountEndpoint(svc),
-		DecodeFunc: decodeCountRequest,
-		EncodeFunc: encode,
+		Context:            ctx,
+		Endpoint:           makeCountEndpoint(svc),
+		DecodeRequestFunc:  decodeCountRequest,
+		EncodeResponseFunc: encodeResponse,
 	}
 
 	http.Handle("/uppercase", uppercaseHandler)

--- a/examples/stringsvc3/proxying.go
+++ b/examples/stringsvc3/proxying.go
@@ -82,12 +82,12 @@ func makeUppercaseProxy(ctx context.Context, instance string) endpoint.Endpoint 
 		u.Path = "/uppercase"
 	}
 	return (httptransport.Client{
-		Client:     http.DefaultClient,
-		Method:     "GET",
-		URL:        u,
-		Context:    ctx,
-		EncodeFunc: encode,
-		DecodeFunc: decodeUppercaseResponse,
+		Client:             http.DefaultClient,
+		Method:             "GET",
+		URL:                u,
+		Context:            ctx,
+		DecodeResponseFunc: decodeUppercaseResponse,
+		EncodeRequestFunc:  encodeRequest,
 	}).Endpoint()
 }
 

--- a/examples/stringsvc3/transport.go
+++ b/examples/stringsvc3/transport.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
-	"io"
+	"io/ioutil"
+	"net/http"
 
 	"golang.org/x/net/context"
 
@@ -25,32 +27,41 @@ func makeCountEndpoint(svc StringService) endpoint.Endpoint {
 	}
 }
 
-func decodeUppercaseRequest(r io.Reader) (interface{}, error) {
+func decodeUppercaseRequest(r *http.Request) (interface{}, error) {
 	var request uppercaseRequest
-	if err := json.NewDecoder(r).Decode(&request); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
 	}
 	return request, nil
 }
 
-func decodeCountRequest(r io.Reader) (interface{}, error) {
+func decodeCountRequest(r *http.Request) (interface{}, error) {
 	var request countRequest
-	if err := json.NewDecoder(r).Decode(&request); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
 	}
 	return request, nil
 }
 
-func decodeUppercaseResponse(r io.Reader) (interface{}, error) {
+func decodeUppercaseResponse(r *http.Response) (interface{}, error) {
 	var response uppercaseResponse
-	if err := json.NewDecoder(r).Decode(&response); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&response); err != nil {
 		return nil, err
 	}
 	return response, nil
 }
 
-func encode(w io.Writer, response interface{}) error {
+func encodeResponse(w http.ResponseWriter, response interface{}) error {
 	return json.NewEncoder(w).Encode(response)
+}
+
+func encodeRequest(r *http.Request, request interface{}) error {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(request); err != nil {
+		return err
+	}
+	r.Body = ioutil.NopCloser(&buf)
+	return nil
 }
 
 type uppercaseRequest struct {

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -1,7 +1,6 @@
 package http_test
 
 import (
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,8 +14,8 @@ import (
 
 func TestHTTPClient(t *testing.T) {
 	var (
-		decode    = func(r io.Reader) (interface{}, error) { return struct{}{}, nil }
-		encode    = func(w io.Writer, response interface{}) error { return nil }
+		encode    = func(*http.Request, interface{}) error { return nil }
+		decode    = func(*http.Response) (interface{}, error) { return struct{}{}, nil }
 		headers   = make(chan string, 1)
 		headerKey = "X-Foo"
 		headerVal = "abcde"
@@ -28,12 +27,12 @@ func TestHTTPClient(t *testing.T) {
 	}))
 
 	client := httptransport.Client{
-		Method:     "GET",
-		URL:        mustParse(server.URL),
-		Context:    context.Background(),
-		DecodeFunc: decode,
-		EncodeFunc: encode,
-		Before:     []httptransport.RequestFunc{httptransport.SetRequestHeader(headerKey, headerVal)},
+		Method:             "GET",
+		URL:                mustParse(server.URL),
+		Context:            context.Background(),
+		EncodeRequestFunc:  encode,
+		DecodeResponseFunc: decode,
+		Before:             []httptransport.RequestFunc{httptransport.SetRequestHeader(headerKey, headerVal)},
 	}
 
 	_, err := client.Endpoint()(context.Background(), struct{}{})

--- a/transport/http/encode_decode.go
+++ b/transport/http/encode_decode.go
@@ -1,12 +1,27 @@
 package http
 
-import "io"
+import "net/http"
 
-// DecodeFunc converts a serialized request (server) or response (client) to a
-// user version of the same. One straightforward DecodeFunc could be something
-// that JSON-decodes the reader to a concrete type.
-type DecodeFunc func(io.Reader) (interface{}, error)
+// DecodeRequestFunc extracts a user-domain request object from an HTTP
+// request object. It's designed to be used in HTTP servers, for server-side
+// endpoints. One straightforward DecodeRequestFunc could be something that
+// JSON decodes from the request body to the concrete response type.
+type DecodeRequestFunc func(*http.Request) (request interface{}, err error)
 
-// EncodeFunc converts a user response (server) or request (client) to a
-// serialized version of the same, by encoding the interface to the writer.
-type EncodeFunc func(io.Writer, interface{}) error
+// EncodeRequestFunc encodes the passed request object into the HTTP request
+// object. It's designed to be used in HTTP clients, for client-side
+// endpoints. One straightforward EncodeRequestFunc could something that JSON
+// encodes the object directly to the request body.
+type EncodeRequestFunc func(*http.Request, interface{}) error
+
+// EncodeResponseFunc encodes the passed response object to the HTTP response
+// writer. It's designed to be used in HTTP servers, for server-side
+// endpoints. One straightforward EncodeResponseFunc could be something that
+// JSON encodes the object directly to the response body.
+type EncodeResponseFunc func(http.ResponseWriter, interface{}) error
+
+// DecodeResponseFunc extracts a user-domain response object from an HTTP
+// response object. It's designed to be used in HTTP clients, for client-side
+// endpoints. One straightforward DecodeResponseFunc could be something that
+// JSON decodes from the response body to the concrete response type.
+type DecodeResponseFunc func(*http.Response) (response interface{}, err error)

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -22,7 +22,7 @@ func TestServerBadDecode(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 	resp, _ := http.Get(server.URL)
-	if want, have := http.StatusInternalServerError, resp.StatusCode; want != have {
+	if want, have := http.StatusBadRequest, resp.StatusCode; want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
 }
@@ -67,8 +67,8 @@ func TestServerErrorEncoder(t *testing.T) {
 	}
 	handler := httptransport.Server{
 		Context:            context.Background(),
-		Endpoint:           func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
-		DecodeRequestFunc:  func(*http.Request) (interface{}, error) { return struct{}{}, errTeapot },
+		Endpoint:           func(context.Context, interface{}) (interface{}, error) { return struct{}{}, errTeapot },
+		DecodeRequestFunc:  func(*http.Request) (interface{}, error) { return struct{}{}, nil },
 		EncodeResponseFunc: func(http.ResponseWriter, interface{}) error { return nil },
 		ErrorEncoder:       func(w http.ResponseWriter, err error) { w.WriteHeader(code(err)) },
 	}

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -2,7 +2,6 @@ package http_test
 
 import (
 	"errors"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -15,10 +14,10 @@ import (
 
 func TestServerBadDecode(t *testing.T) {
 	handler := httptransport.Server{
-		Context:    context.Background(),
-		Endpoint:   func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
-		DecodeFunc: func(io.Reader) (interface{}, error) { return struct{}{}, errors.New("dang") },
-		EncodeFunc: func(io.Writer, interface{}) error { return nil },
+		Context:            context.Background(),
+		Endpoint:           func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
+		DecodeRequestFunc:  func(*http.Request) (interface{}, error) { return struct{}{}, errors.New("dang") },
+		EncodeResponseFunc: func(http.ResponseWriter, interface{}) error { return nil },
 	}
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -30,10 +29,10 @@ func TestServerBadDecode(t *testing.T) {
 
 func TestServerBadEndpoint(t *testing.T) {
 	handler := httptransport.Server{
-		Context:    context.Background(),
-		Endpoint:   func(context.Context, interface{}) (interface{}, error) { return struct{}{}, errors.New("dang") },
-		DecodeFunc: func(io.Reader) (interface{}, error) { return struct{}{}, nil },
-		EncodeFunc: func(io.Writer, interface{}) error { return nil },
+		Context:            context.Background(),
+		Endpoint:           func(context.Context, interface{}) (interface{}, error) { return struct{}{}, errors.New("dang") },
+		DecodeRequestFunc:  func(*http.Request) (interface{}, error) { return struct{}{}, nil },
+		EncodeResponseFunc: func(http.ResponseWriter, interface{}) error { return nil },
 	}
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -45,10 +44,10 @@ func TestServerBadEndpoint(t *testing.T) {
 
 func TestServerBadEncode(t *testing.T) {
 	handler := httptransport.Server{
-		Context:    context.Background(),
-		Endpoint:   func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
-		DecodeFunc: func(io.Reader) (interface{}, error) { return struct{}{}, nil },
-		EncodeFunc: func(io.Writer, interface{}) error { return errors.New("dang") },
+		Context:            context.Background(),
+		Endpoint:           func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
+		DecodeRequestFunc:  func(*http.Request) (interface{}, error) { return struct{}{}, nil },
+		EncodeResponseFunc: func(http.ResponseWriter, interface{}) error { return errors.New("dang") },
 	}
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -76,12 +75,12 @@ func testServer(t *testing.T) (cancel, step func(), resp <-chan *http.Response) 
 		endpoint      = func(context.Context, interface{}) (interface{}, error) { <-stepch; return struct{}{}, nil }
 		response      = make(chan *http.Response)
 		handler       = httptransport.Server{
-			Context:    ctx,
-			Endpoint:   endpoint,
-			DecodeFunc: func(io.Reader) (interface{}, error) { return struct{}{}, nil },
-			EncodeFunc: func(io.Writer, interface{}) error { return nil },
-			Before:     []httptransport.RequestFunc{func(ctx context.Context, r *http.Request) context.Context { return ctx }},
-			After:      []httptransport.ResponseFunc{func(ctx context.Context, w http.ResponseWriter) { return }},
+			Context:            ctx,
+			Endpoint:           endpoint,
+			DecodeRequestFunc:  func(*http.Request) (interface{}, error) { return struct{}{}, nil },
+			EncodeResponseFunc: func(http.ResponseWriter, interface{}) error { return nil },
+			Before:             []httptransport.RequestFunc{func(ctx context.Context, r *http.Request) context.Context { return ctx }},
+			After:              []httptransport.ResponseFunc{func(ctx context.Context, w http.ResponseWriter) { return }},
 		}
 	)
 	go func() {


### PR DESCRIPTION
This reverts a misoptimization I made in the README PR, and allows users of transport/http.{Client,Server} to take requests and responses from http.{Request,Response} objects rather than plain io.Readers.