### PR TITLE
Adding Prometheus handler

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -422,6 +422,8 @@ func main() {
 		Endpoint: makeCountEndpoint(svc),
 		// ...
 	}
+
+	http.Handle("/metrics", stdprometheus.Handler())
 }
 ```
 

--- a/examples/stringsvc2/main.go
+++ b/examples/stringsvc2/main.go
@@ -59,6 +59,7 @@ func main() {
 
 	http.Handle("/uppercase", uppercaseHandler)
 	http.Handle("/count", countHandler)
+	http.Handle("/metrics", stdprometheus.Handler())
 	_ = logger.Log("msg", "HTTP", "addr", ":8080")
 	_ = logger.Log("err", http.ListenAndServe(":8080", nil))
 }

--- a/examples/stringsvc3/main.go
+++ b/examples/stringsvc3/main.go
@@ -69,6 +69,7 @@ func main() {
 
 	http.Handle("/uppercase", uppercaseHandler)
 	http.Handle("/count", countHandler)
+	http.Handle("/metrics", stdprometheus.Handler())
 	_ = logger.Log("msg", "HTTP", "addr", *listen)
 	_ = logger.Log("err", http.ListenAndServe(*listen, nil))
 }


### PR DESCRIPTION
Adding Prometheus handler to allow metrics to be visible on `/metric` in examples stringsvc2 and stringsvc3.

Just provides a bit more of a full view of an example service with the metrics available via an endpoint.