### PR TITLE
Testing if LoadBalancer is nil before Retry

### DIFF
--- a/loadbalancer/retry.go
+++ b/loadbalancer/retry.go
@@ -15,6 +15,10 @@ import (
 // balancer. Requests that return errors will be retried until they succeed,
 // up to max times, or until the timeout is elapsed, whichever comes first.
 func Retry(max int, timeout time.Duration, lb LoadBalancer) endpoint.Endpoint {
+	if lb == nil {
+		panic("nil LoadBalancer")
+	}
+
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		var (
 			newctx, cancel = context.WithTimeout(ctx, timeout)


### PR DESCRIPTION
In cases that a LoadBalancer isn't created correctly a nil value can be passed in to the Retry function. `panic: runtime error: invalid memory address or nil pointer dereference` This checks if the LoadBalancer value is nil and returns with an error passed to the errs channel. 