### PR TITLE
loadbalancer: closable endpoints

### DIFF
--- a/examples/stringsvc3/proxying.go
+++ b/examples/stringsvc3/proxying.go
@@ -64,12 +64,12 @@ func (mw proxymw) Uppercase(s string) (string, error) {
 }
 
 func factory(ctx context.Context, qps int) loadbalancer.Factory {
-	return func(instance string) (endpoint.Endpoint, error) {
+	return func(instance string) (endpoint.Endpoint, loadbalancer.Closer, error) {
 		var e endpoint.Endpoint
 		e = makeUppercaseProxy(ctx, instance)
 		e = circuitbreaker.Gobreaker(gobreaker.NewCircuitBreaker(gobreaker.Settings{}))(e)
 		e = kitratelimit.NewTokenBucketLimiter(jujuratelimit.NewBucketWithRate(float64(qps), int64(qps)))(e)
-		return e, nil
+		return e, make(loadbalancer.Closer), nil
 	}
 }
 

--- a/examples/stringsvc3/proxying.go
+++ b/examples/stringsvc3/proxying.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"strings"
 	"time"
@@ -64,12 +65,12 @@ func (mw proxymw) Uppercase(s string) (string, error) {
 }
 
 func factory(ctx context.Context, qps int) loadbalancer.Factory {
-	return func(instance string) (endpoint.Endpoint, loadbalancer.Closer, error) {
+	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
 		var e endpoint.Endpoint
 		e = makeUppercaseProxy(ctx, instance)
 		e = circuitbreaker.Gobreaker(gobreaker.NewCircuitBreaker(gobreaker.Settings{}))(e)
 		e = kitratelimit.NewTokenBucketLimiter(jujuratelimit.NewBucketWithRate(float64(qps), int64(qps)))(e)
-		return e, make(loadbalancer.Closer), nil
+		return e, nil, nil
 	}
 }
 

--- a/loadbalancer/dnssrv/publisher.go
+++ b/loadbalancer/dnssrv/publisher.go
@@ -1,10 +1,8 @@
 package dnssrv
 
 import (
-	"crypto/md5"
 	"fmt"
 	"net"
-	"sort"
 	"time"
 
 	"github.com/go-kit/kit/endpoint"
@@ -17,7 +15,7 @@ import (
 type Publisher struct {
 	name      string
 	ttl       time.Duration
-	factory   loadbalancer.Factory
+	cache     *loadbalancer.EndpointCache
 	logger    log.Logger
 	endpoints chan []endpoint.Endpoint
 	quit      chan struct{}
@@ -28,22 +26,26 @@ type Publisher struct {
 // constructor will return an error. The factory is used to convert a
 // host:port to a usable endpoint. The logger is used to report DNS and
 // factory errors.
-func NewPublisher(name string, ttl time.Duration, f loadbalancer.Factory, logger log.Logger) (*Publisher, error) {
-	logger = log.NewContext(logger).With("component", "DNS SRV Publisher")
-	addrs, md5, err := resolve(name)
-	if err != nil {
-		return nil, err
-	}
+func NewPublisher(name string, ttl time.Duration, factory loadbalancer.Factory, logger log.Logger) *Publisher {
 	p := &Publisher{
 		name:      name,
 		ttl:       ttl,
-		factory:   f,
+		cache:     loadbalancer.NewEndpointCache(factory, logger),
 		logger:    logger,
 		endpoints: make(chan []endpoint.Endpoint),
 		quit:      make(chan struct{}),
 	}
-	go p.loop(makeEndpoints(addrs, f, logger), md5)
-	return p, nil
+
+	instances, err := p.resolve()
+	if err != nil {
+		logger.Log(name, len(instances))
+	} else {
+		logger.Log(name, err)
+	}
+	p.cache.Replace(instances)
+
+	go p.loop()
+	return p
 }
 
 // Stop terminates the publisher.
@@ -51,25 +53,20 @@ func (p *Publisher) Stop() {
 	close(p.quit)
 }
 
-func (p *Publisher) loop(m map[string]endpointCloser, md5 string) {
+func (p *Publisher) loop() {
 	t := newTicker(p.ttl)
 	defer t.Stop()
 	for {
 		select {
-		case p.endpoints <- flatten(m):
+		case p.endpoints <- p.cache.Endpoints():
 
 		case <-t.C:
-			// TODO should we do this out-of-band?
-			addrs, newmd5, err := resolve(p.name)
+			instances, err := p.resolve()
 			if err != nil {
-				p.logger.Log("name", p.name, "err", err)
-				continue // don't replace probably-good endpoints with bad ones
+				p.logger.Log(p.name, err)
+				continue // don't replace potentially-good with bad
 			}
-			if newmd5 == md5 {
-				continue // optimization: no change
-			}
-			m = migrate(m, makeEndpoints(addrs, p.factory, p.logger))
-			md5 = newmd5
+			p.cache.Replace(instances)
 
 		case <-p.quit:
 			return
@@ -92,59 +89,14 @@ var (
 	newTicker = time.NewTicker
 )
 
-func resolve(name string) (addrs []*net.SRV, md5sum string, err error) {
-	_, addrs, err = lookupSRV("", "", name)
+func (p *Publisher) resolve() ([]string, error) {
+	_, addrs, err := lookupSRV("", "", p.name)
 	if err != nil {
-		return addrs, "", err
+		return []string{}, err
 	}
 	instances := make([]string, len(addrs))
 	for i, addr := range addrs {
-		instances[i] = addr2instance(addr)
+		instances[i] = net.JoinHostPort(addr.Target, fmt.Sprint(addr.Port))
 	}
-	sort.Sort(sort.StringSlice(instances))
-	h := md5.New()
-	for _, instance := range instances {
-		fmt.Fprintf(h, instance)
-	}
-	return addrs, fmt.Sprintf("%x", h.Sum(nil)), nil
-}
-
-func makeEndpoints(addrs []*net.SRV, f loadbalancer.Factory, logger log.Logger) map[string]endpointCloser {
-	m := make(map[string]endpointCloser, len(addrs))
-	for _, addr := range addrs {
-		instance := addr2instance(addr)
-		endpoint, closer, err := f(instance)
-		if err != nil {
-			logger.Log("instance", addr2instance(addr), "err", err)
-			continue
-		}
-		m[instance] = endpointCloser{endpoint, closer}
-	}
-	return m
-}
-
-func migrate(prev, curr map[string]endpointCloser) map[string]endpointCloser {
-	for instance, ec := range prev {
-		if _, ok := curr[instance]; !ok {
-			close(ec.Closer)
-		}
-	}
-	return curr
-}
-
-func addr2instance(addr *net.SRV) string {
-	return net.JoinHostPort(addr.Target, fmt.Sprint(addr.Port))
-}
-
-func flatten(m map[string]endpointCloser) []endpoint.Endpoint {
-	a := make([]endpoint.Endpoint, 0, len(m))
-	for _, ec := range m {
-		a = append(a, ec.Endpoint)
-	}
-	return a
-}
-
-type endpointCloser struct {
-	endpoint.Endpoint
-	loadbalancer.Closer
+	return instances, nil
 }

--- a/loadbalancer/dnssrv/publisher_internal_test.go
+++ b/loadbalancer/dnssrv/publisher_internal_test.go
@@ -2,6 +2,7 @@ package dnssrv
 
 import (
 	"errors"
+	"io"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/loadbalancer"
 	"github.com/go-kit/kit/log"
 )
 
@@ -19,8 +19,7 @@ func TestPublisher(t *testing.T) {
 		name    = "foo"
 		ttl     = time.Second
 		e       = func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil }
-		c       = make(chan struct{})
-		factory = func(string) (endpoint.Endpoint, loadbalancer.Closer, error) { return e, c, nil }
+		factory = func(string) (endpoint.Endpoint, io.Closer, error) { return e, nil, nil }
 		logger  = log.NewNopLogger()
 	)
 
@@ -41,8 +40,7 @@ func TestBadLookup(t *testing.T) {
 		name    = "some-name"
 		ttl     = time.Second
 		e       = func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil }
-		c       = make(chan struct{})
-		factory = func(string) (endpoint.Endpoint, loadbalancer.Closer, error) { return e, c, nil }
+		factory = func(string) (endpoint.Endpoint, io.Closer, error) { return e, nil, nil }
 		logger  = log.NewNopLogger()
 	)
 
@@ -64,7 +62,7 @@ func TestBadFactory(t *testing.T) {
 		addrs   = []*net.SRV{addr}
 		name    = "some-name"
 		ttl     = time.Second
-		factory = func(string) (endpoint.Endpoint, loadbalancer.Closer, error) { return nil, nil, errors.New("kaboom") }
+		factory = func(string) (endpoint.Endpoint, io.Closer, error) { return nil, nil, errors.New("kaboom") }
 		logger  = log.NewNopLogger()
 	)
 
@@ -97,7 +95,7 @@ func TestRefreshNoChange(t *testing.T) {
 		addrs   = []*net.SRV{addr}
 		name    = "my-name"
 		ttl     = time.Second
-		factory = func(string) (endpoint.Endpoint, loadbalancer.Closer, error) { return nil, nil, errors.New("kaboom") }
+		factory = func(string) (endpoint.Endpoint, io.Closer, error) { return nil, nil, errors.New("kaboom") }
 		logger  = log.NewNopLogger()
 	)
 

--- a/loadbalancer/dnssrv/publisher_internal_test.go
+++ b/loadbalancer/dnssrv/publisher_internal_test.go
@@ -30,11 +30,11 @@ func TestPublisher(t *testing.T) {
 	defer func() { lookupSRV = oldLookup }()
 	lookupSRV = mockLookupSRV(addrs, nil, nil)
 
-	factory := func(instance string) (endpoint.Endpoint, error) {
+	factory := func(instance string) (endpoint.Endpoint, loadbalancer.Closer, error) {
 		if want, have := addr2instance(addr), instance; want != have {
 			t.Errorf("want %q, have %q", want, have)
 		}
-		return e, nil
+		return e, make(loadbalancer.Closer), nil
 	}
 
 	p, err := NewPublisher(name, ttl, factory, logger)
@@ -56,7 +56,7 @@ func TestBadLookup(t *testing.T) {
 	var (
 		name    = "some-name"
 		ttl     = time.Second
-		factory = func(string) (endpoint.Endpoint, error) { return nil, errors.New("unreachable") }
+		factory = func(string) (endpoint.Endpoint, loadbalancer.Closer, error) { return nil, nil, errors.New("false") }
 		logger  = log.NewNopLogger()
 	)
 
@@ -71,7 +71,7 @@ func TestBadFactory(t *testing.T) {
 		addrs   = []*net.SRV{addr}
 		name    = "some-name"
 		ttl     = time.Second
-		factory = func(string) (endpoint.Endpoint, error) { return nil, errors.New("kaboom") }
+		factory = func(string) (endpoint.Endpoint, loadbalancer.Closer, error) { return nil, nil, errors.New("kaboom") }
 		logger  = log.NewNopLogger()
 	)
 
@@ -107,7 +107,7 @@ func TestRefreshNoChange(t *testing.T) {
 		addrs   = []*net.SRV{addr}
 		name    = "my-name"
 		ttl     = time.Second
-		factory = func(string) (endpoint.Endpoint, error) { return nil, errors.New("kaboom") }
+		factory = func(string) (endpoint.Endpoint, loadbalancer.Closer, error) { return nil, nil, errors.New("kaboom") }
 		logger  = log.NewNopLogger()
 	)
 
@@ -140,7 +140,7 @@ func TestErrPublisherStopped(t *testing.T) {
 	var (
 		name    = "my-name"
 		ttl     = time.Second
-		factory = func(string) (endpoint.Endpoint, error) { return nil, errors.New("kaboom") }
+		factory = func(string) (endpoint.Endpoint, loadbalancer.Closer, error) { return nil, nil, errors.New("kaboom") }
 		logger  = log.NewNopLogger()
 	)
 

--- a/loadbalancer/dnssrv/publisher_internal_test.go
+++ b/loadbalancer/dnssrv/publisher_internal_test.go
@@ -123,27 +123,6 @@ func TestRefreshResolveError(t *testing.T) {
 	t.Skip("TODO")
 }
 
-func TestErrPublisherStopped(t *testing.T) {
-	var (
-		name    = "my-name"
-		ttl     = time.Second
-		factory = func(string) (endpoint.Endpoint, loadbalancer.Closer, error) { return nil, nil, errors.New("kaboom") }
-		logger  = log.NewNopLogger()
-	)
-
-	oldLookup := lookupSRV
-	defer func() { lookupSRV = oldLookup }()
-	lookupSRV = mockLookupSRV([]*net.SRV{}, nil, nil)
-
-	p := NewPublisher(name, ttl, factory, logger)
-
-	p.Stop()
-	_, have := p.Endpoints()
-	if want := loadbalancer.ErrPublisherStopped; want != have {
-		t.Fatalf("want %v, have %v", want, have)
-	}
-}
-
 func mockLookupSRV(addrs []*net.SRV, err error, count *uint64) func(service, proto, name string) (string, []*net.SRV, error) {
 	return func(service, proto, name string) (string, []*net.SRV, error) {
 		if count != nil {

--- a/loadbalancer/endpoint_cache.go
+++ b/loadbalancer/endpoint_cache.go
@@ -7,7 +7,15 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
-// EndpointCache TODO
+// EndpointCache caches resource-managed endpoints. Clients update the cache
+// by providing a current set of instance strings. The cache converts each
+// instance string to an endpoint and a closer via the factory function.
+//
+// Instance strings are assumed to be unique and used as keys. Endpoints that
+// were in the previous set of instances and removed from the current set are
+// considered invalid and closed.
+//
+// EndpointCache is designed to be used in your publisher implementation.
 type EndpointCache struct {
 	mtx    sync.RWMutex
 	f      Factory
@@ -15,7 +23,9 @@ type EndpointCache struct {
 	logger log.Logger
 }
 
-// NewEndpointCache TODO
+// NewEndpointCache produces a new EndpointCache, ready for use. Instance
+// strings will be converted to endpoints via the provided factory function.
+// The logger is used to log errors.
 func NewEndpointCache(f Factory, logger log.Logger) *EndpointCache {
 	return &EndpointCache{
 		f:      f,
@@ -29,7 +39,9 @@ type endpointCloser struct {
 	Closer
 }
 
-// Replace TODO
+// Replace replaces the current set of endpoints with endpoints manufactured
+// by the passed instances. If the same instance exists in both the existing
+// and new sets, it's left untouched.
 func (t *EndpointCache) Replace(instances []string) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
@@ -62,7 +74,7 @@ func (t *EndpointCache) Replace(instances []string) {
 	t.m = m
 }
 
-// Endpoints TODO
+// Endpoints returns the current set of endpoints in undefined order.
 func (t *EndpointCache) Endpoints() []endpoint.Endpoint {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()

--- a/loadbalancer/endpoint_cache.go
+++ b/loadbalancer/endpoint_cache.go
@@ -1,6 +1,7 @@
 package loadbalancer
 
 import (
+	"io"
 	"sync"
 
 	"github.com/go-kit/kit/endpoint"
@@ -37,7 +38,7 @@ func NewEndpointCache(f Factory, logger log.Logger) *EndpointCache {
 
 type endpointCloser struct {
 	endpoint.Endpoint
-	Closer
+	io.Closer
 }
 
 // Replace replaces the current set of endpoints with endpoints manufactured
@@ -68,7 +69,9 @@ func (t *EndpointCache) Replace(instances []string) {
 
 	// Close any leftover endpoints.
 	for _, ec := range t.m {
-		close(ec.Closer)
+		if ec.Closer != nil {
+			ec.Closer.Close()
+		}
 	}
 
 	// Swap and GC.

--- a/loadbalancer/endpoint_cache.go
+++ b/loadbalancer/endpoint_cache.go
@@ -7,13 +7,14 @@ import (
 	"github.com/go-kit/kit/log"
 )
 
-// EndpointCache caches resource-managed endpoints. Clients update the cache
-// by providing a current set of instance strings. The cache converts each
-// instance string to an endpoint and a closer via the factory function.
+// EndpointCache caches endpoints that need to be deallocated when they're no
+// longer useful. Clients update the cache by providing a current set of
+// instance strings. The cache converts each instance string to an endpoint
+// and a closer via the factory function.
 //
-// Instance strings are assumed to be unique and used as keys. Endpoints that
-// were in the previous set of instances and removed from the current set are
-// considered invalid and closed.
+// Instance strings are assumed to be unique and are used as keys. Endpoints
+// that were in the previous set of instances and are not in the current set
+// are considered invalid and closed.
 //
 // EndpointCache is designed to be used in your publisher implementation.
 type EndpointCache struct {
@@ -30,7 +31,7 @@ func NewEndpointCache(f Factory, logger log.Logger) *EndpointCache {
 	return &EndpointCache{
 		f:      f,
 		m:      map[string]endpointCloser{},
-		logger: logger,
+		logger: log.NewContext(logger).With("component", "Endpoint Cache"),
 	}
 }
 

--- a/loadbalancer/endpoint_cache.go
+++ b/loadbalancer/endpoint_cache.go
@@ -1,0 +1,74 @@
+package loadbalancer
+
+import (
+	"sync"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/log"
+)
+
+// EndpointCache TODO
+type EndpointCache struct {
+	mtx    sync.RWMutex
+	f      Factory
+	m      map[string]endpointCloser
+	logger log.Logger
+}
+
+// NewEndpointCache TODO
+func NewEndpointCache(f Factory, logger log.Logger) *EndpointCache {
+	return &EndpointCache{
+		f:      f,
+		m:      map[string]endpointCloser{},
+		logger: logger,
+	}
+}
+
+type endpointCloser struct {
+	endpoint.Endpoint
+	Closer
+}
+
+// Replace TODO
+func (t *EndpointCache) Replace(instances []string) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+
+	// Produce the current set of endpoints.
+	m := make(map[string]endpointCloser, len(instances))
+	for _, instance := range instances {
+		// If it already exists, just copy it over.
+		if ec, ok := t.m[instance]; ok {
+			m[instance] = ec
+			delete(t.m, instance)
+			continue
+		}
+
+		// If it doesn't exist, create it.
+		endpoint, closer, err := t.f(instance)
+		if err != nil {
+			t.logger.Log("instance", instance, "err", err)
+			continue
+		}
+		m[instance] = endpointCloser{endpoint, closer}
+	}
+
+	// Close any leftover endpoints.
+	for _, ec := range t.m {
+		close(ec.Closer)
+	}
+
+	// Swap and GC.
+	t.m = m
+}
+
+// Endpoints TODO
+func (t *EndpointCache) Endpoints() []endpoint.Endpoint {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	a := make([]endpoint.Endpoint, 0, len(t.m))
+	for _, ec := range t.m {
+		a = append(a, ec.Endpoint)
+	}
+	return a
+}

--- a/loadbalancer/endpoint_cache_test.go
+++ b/loadbalancer/endpoint_cache_test.go
@@ -1,6 +1,7 @@
 package loadbalancer_test
 
 import (
+	"io"
 	"testing"
 	"time"
 
@@ -14,10 +15,10 @@ import (
 func TestEndpointCache(t *testing.T) {
 	var (
 		e  = func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil }
-		ca = make(loadbalancer.Closer)
-		cb = make(loadbalancer.Closer)
-		c  = map[string]loadbalancer.Closer{"a": ca, "b": cb}
-		f  = func(s string) (endpoint.Endpoint, loadbalancer.Closer, error) { return e, c[s], nil }
+		ca = make(closer)
+		cb = make(closer)
+		c  = map[string]io.Closer{"a": ca, "b": cb}
+		f  = func(s string) (endpoint.Endpoint, io.Closer, error) { return e, c[s], nil }
 		ec = loadbalancer.NewEndpointCache(f, log.NewNopLogger())
 	)
 
@@ -64,3 +65,7 @@ func TestEndpointCache(t *testing.T) {
 		t.Errorf("didn't close the deleted instance in time")
 	}
 }
+
+type closer chan struct{}
+
+func (c closer) Close() error { close(c); return nil }

--- a/loadbalancer/endpoint_cache_test.go
+++ b/loadbalancer/endpoint_cache_test.go
@@ -1,0 +1,66 @@
+package loadbalancer_test
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/loadbalancer"
+	"github.com/go-kit/kit/log"
+)
+
+func TestEndpointCache(t *testing.T) {
+	var (
+		e  = func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil }
+		ca = make(loadbalancer.Closer)
+		cb = make(loadbalancer.Closer)
+		c  = map[string]loadbalancer.Closer{"a": ca, "b": cb}
+		f  = func(s string) (endpoint.Endpoint, loadbalancer.Closer, error) { return e, c[s], nil }
+		ec = loadbalancer.NewEndpointCache(f, log.NewNopLogger())
+	)
+
+	// Populate
+	ec.Replace([]string{"a", "b"})
+	select {
+	case <-ca:
+		t.Errorf("endpoint a closed, not good")
+	case <-cb:
+		t.Errorf("endpoint b closed, not good")
+	case <-time.After(time.Millisecond):
+		t.Logf("no closures yet, good")
+	}
+
+	// Duplicate, should be no-op
+	ec.Replace([]string{"a", "b"})
+	select {
+	case <-ca:
+		t.Errorf("endpoint a closed, not good")
+	case <-cb:
+		t.Errorf("endpoint b closed, not good")
+	case <-time.After(time.Millisecond):
+		t.Logf("no closures yet, good")
+	}
+
+	// Delete b
+	go ec.Replace([]string{"a"})
+	select {
+	case <-ca:
+		t.Errorf("endpoint a closed, not good")
+	case <-cb:
+		t.Logf("endpoint b closed, good")
+	case <-time.After(time.Millisecond):
+		t.Errorf("didn't close the deleted instance in time")
+	}
+
+	// Delete a
+	go ec.Replace([]string{""})
+	select {
+	// case <-cb: will succeed, as it's closed
+	case <-ca:
+		t.Logf("endpoint a closed, good")
+	case <-time.After(time.Millisecond):
+		t.Errorf("didn't close the deleted instance in time")
+	}
+}

--- a/loadbalancer/etcd/client.go
+++ b/loadbalancer/etcd/client.go
@@ -7,7 +7,7 @@ import (
 	"github.com/coreos/go-etcd/etcd"
 )
 
-// Client is a wrapper arround the etcd client
+// Client is a wrapper arround the etcd client.
 type Client interface {
 	// GetEntries will query the given prefix in etcd and returns a set of entries.
 	GetEntries(prefix string) ([]string, error)
@@ -43,7 +43,7 @@ func NewClient(machines []string, cert, key, caCert string) (Client, error) {
 	return &client{c}, nil
 }
 
-// GetEntries implements the EtcdClient interface.
+// GetEntries implements the etcd Client interface.
 func (c *client) GetEntries(key string) ([]string, error) {
 	resp, err := c.Get(key, false, true)
 	if err != nil {
@@ -57,7 +57,7 @@ func (c *client) GetEntries(key string) ([]string, error) {
 	return entries, nil
 }
 
-// WatchPrefix implements the EtcdClient interface.
+// WatchPrefix implements the etcd Client interface.
 func (c *client) WatchPrefix(prefix string, responseChan chan *etcd.Response) {
 	c.Watch(prefix, 0, true, responseChan, nil)
 }

--- a/loadbalancer/etcd/publisher.go
+++ b/loadbalancer/etcd/publisher.go
@@ -22,8 +22,7 @@ type Publisher struct {
 // NewPublisher returs a etcd publisher. Etcd will start watching the given
 // prefix for changes and update the Publisher endpoints.
 func NewPublisher(c Client, prefix string, f loadbalancer.Factory, logger log.Logger) (*Publisher, error) {
-	logger = log.NewContext(logger).With("component", "Etcd Publisher")
-
+	logger = log.NewContext(logger).With("component", "etcd Publisher")
 	p := &Publisher{
 		client:    c,
 		prefix:    prefix,
@@ -32,7 +31,6 @@ func NewPublisher(c Client, prefix string, f loadbalancer.Factory, logger log.Lo
 		endpoints: make(chan []endpoint.Endpoint),
 		quit:      make(chan struct{}),
 	}
-
 	entries, err := p.client.GetEntries(prefix)
 	if err != nil {
 		return nil, err
@@ -41,13 +39,12 @@ func NewPublisher(c Client, prefix string, f loadbalancer.Factory, logger log.Lo
 	return p, nil
 }
 
-func (p *Publisher) loop(endpoints []endpoint.Endpoint) {
+func (p *Publisher) loop(endpoints map[string]endpointCloser) {
 	responseChan := make(chan *etcd.Response)
 	go p.client.WatchPrefix(p.prefix, responseChan)
-
 	for {
 		select {
-		case p.endpoints <- endpoints:
+		case p.endpoints <- flatten(endpoints):
 
 		case <-responseChan:
 			entries, err := p.client.GetEntries(p.prefix)
@@ -55,7 +52,7 @@ func (p *Publisher) loop(endpoints []endpoint.Endpoint) {
 				p.logger.Log("msg", "failed to retrieve entries", "err", err)
 				continue
 			}
-			endpoints = makeEndpoints(entries, p.factory, p.logger)
+			endpoints = migrate(endpoints, makeEndpoints(entries, p.factory, p.logger))
 
 		case <-p.quit:
 			return
@@ -78,16 +75,40 @@ func (p *Publisher) Stop() {
 	close(p.quit)
 }
 
-func makeEndpoints(addrs []string, f loadbalancer.Factory, logger log.Logger) []endpoint.Endpoint {
-	endpoints := make([]endpoint.Endpoint, 0, len(addrs))
-
+func makeEndpoints(addrs []string, f loadbalancer.Factory, logger log.Logger) map[string]endpointCloser {
+	m := make(map[string]endpointCloser, len(addrs))
 	for _, addr := range addrs {
-		endpoint, err := f(addr)
+		if _, ok := m[addr]; ok {
+			continue // duplicate
+		}
+		endpoint, closer, err := f(addr)
 		if err != nil {
 			logger.Log("instance", addr, "err", err)
 			continue
 		}
-		endpoints = append(endpoints, endpoint)
+		m[addr] = endpointCloser{endpoint, closer}
 	}
-	return endpoints
+	return m
+}
+
+type endpointCloser struct {
+	endpoint.Endpoint
+	loadbalancer.Closer
+}
+
+func migrate(prev, curr map[string]endpointCloser) map[string]endpointCloser {
+	for instance, ec := range prev {
+		if _, ok := curr[instance]; !ok {
+			close(ec.Closer)
+		}
+	}
+	return curr
+}
+
+func flatten(m map[string]endpointCloser) []endpoint.Endpoint {
+	a := make([]endpoint.Endpoint, 0, len(m))
+	for _, ec := range m {
+		a = append(a, ec.Endpoint)
+	}
+	return a
 }

--- a/loadbalancer/etcd/publisher_test.go
+++ b/loadbalancer/etcd/publisher_test.go
@@ -32,8 +32,8 @@ func TestPublisher(t *testing.T) {
 		e      = func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil }
 	)
 
-	factory := func(instance string) (endpoint.Endpoint, error) {
-		return e, nil
+	factory := func(string) (endpoint.Endpoint, loadbalancer.Closer, error) {
+		return e, make(loadbalancer.Closer), nil
 	}
 
 	client := &fakeClient{
@@ -52,13 +52,10 @@ func TestPublisher(t *testing.T) {
 }
 
 func TestBadFactory(t *testing.T) {
-	var (
-		logger = log.NewNopLogger()
-		e      = func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil }
-	)
+	logger := log.NewNopLogger()
 
-	factory := func(instance string) (endpoint.Endpoint, error) {
-		return e, errors.New("_")
+	factory := func(string) (endpoint.Endpoint, loadbalancer.Closer, error) {
+		return nil, nil, errors.New("kaboom")
 	}
 
 	client := &fakeClient{
@@ -82,13 +79,10 @@ func TestBadFactory(t *testing.T) {
 }
 
 func TestPublisherStoppped(t *testing.T) {
-	var (
-		logger = log.NewNopLogger()
-		e      = func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil }
-	)
+	logger := log.NewNopLogger()
 
-	factory := func(instance string) (endpoint.Endpoint, error) {
-		return e, errors.New("_")
+	factory := func(string) (endpoint.Endpoint, loadbalancer.Closer, error) {
+		return nil, nil, errors.New("kaboom")
 	}
 
 	client := &fakeClient{

--- a/loadbalancer/etcd/publisher_test.go
+++ b/loadbalancer/etcd/publisher_test.go
@@ -78,30 +78,6 @@ func TestBadFactory(t *testing.T) {
 	}
 }
 
-func TestPublisherStoppped(t *testing.T) {
-	logger := log.NewNopLogger()
-
-	factory := func(string) (endpoint.Endpoint, loadbalancer.Closer, error) {
-		return nil, nil, errors.New("kaboom")
-	}
-
-	client := &fakeClient{
-		responses: map[string]*stdetcd.Response{"/foo": fakeResponse},
-	}
-
-	p, err := kitetcd.NewPublisher(client, "/foo", factory, logger)
-	if err != nil {
-		t.Fatalf("failed to create new publisher: %v", err)
-	}
-
-	p.Stop()
-
-	_, have := p.Endpoints()
-	if want := loadbalancer.ErrPublisherStopped; want != have {
-		t.Fatalf("want %v, have %v", want, have)
-	}
-}
-
 type fakeClient struct {
 	responses map[string]*stdetcd.Response
 }

--- a/loadbalancer/etcd/publisher_test.go
+++ b/loadbalancer/etcd/publisher_test.go
@@ -2,13 +2,13 @@ package etcd_test
 
 import (
 	"errors"
+	"io"
 	"testing"
 
 	stdetcd "github.com/coreos/go-etcd/etcd"
 	"golang.org/x/net/context"
 
 	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/loadbalancer"
 	kitetcd "github.com/go-kit/kit/loadbalancer/etcd"
 	"github.com/go-kit/kit/log"
 )
@@ -32,8 +32,8 @@ func TestPublisher(t *testing.T) {
 		e      = func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil }
 	)
 
-	factory := func(string) (endpoint.Endpoint, loadbalancer.Closer, error) {
-		return e, make(loadbalancer.Closer), nil
+	factory := func(string) (endpoint.Endpoint, io.Closer, error) {
+		return e, nil, nil
 	}
 
 	client := &fakeClient{
@@ -54,7 +54,7 @@ func TestPublisher(t *testing.T) {
 func TestBadFactory(t *testing.T) {
 	logger := log.NewNopLogger()
 
-	factory := func(string) (endpoint.Endpoint, loadbalancer.Closer, error) {
+	factory := func(string) (endpoint.Endpoint, io.Closer, error) {
 		return nil, nil, errors.New("kaboom")
 	}
 

--- a/loadbalancer/factory.go
+++ b/loadbalancer/factory.go
@@ -8,4 +8,8 @@ import "github.com/go-kit/kit/endpoint"
 // endpoints. Users are expected to provide their own factory functions that
 // assume specific transports, or can deduce transports by parsing the
 // instance string.
-type Factory func(instance string) (endpoint.Endpoint, error)
+type Factory func(instance string) (endpoint.Endpoint, Closer, error)
+
+// Closer is returned by factory functions as a way to close a generated
+// endpoint.
+type Closer chan struct{}

--- a/loadbalancer/factory.go
+++ b/loadbalancer/factory.go
@@ -1,6 +1,10 @@
 package loadbalancer
 
-import "github.com/go-kit/kit/endpoint"
+import (
+	"io"
+
+	"github.com/go-kit/kit/endpoint"
+)
 
 // Factory is a function that converts an instance string, e.g. a host:port,
 // to a usable endpoint. Factories are used by load balancers to convert
@@ -8,8 +12,4 @@ import "github.com/go-kit/kit/endpoint"
 // endpoints. Users are expected to provide their own factory functions that
 // assume specific transports, or can deduce transports by parsing the
 // instance string.
-type Factory func(instance string) (endpoint.Endpoint, Closer, error)
-
-// Closer is returned by factory functions as a way to close a generated
-// endpoint.
-type Closer chan struct{}
+type Factory func(instance string) (endpoint.Endpoint, io.Closer, error)

--- a/loadbalancer/publisher.go
+++ b/loadbalancer/publisher.go
@@ -1,10 +1,6 @@
 package loadbalancer
 
-import (
-	"errors"
-
-	"github.com/go-kit/kit/endpoint"
-)
+import "github.com/go-kit/kit/endpoint"
 
 // Publisher describes something that provides a set of identical endpoints.
 // Different publisher implementations exist for different kinds of service
@@ -12,7 +8,3 @@ import (
 type Publisher interface {
 	Endpoints() ([]endpoint.Endpoint, error)
 }
-
-// ErrPublisherStopped is returned by publishers when the underlying
-// implementation has been terminated and can no longer serve requests.
-var ErrPublisherStopped = errors.New("publisher stopped")

--- a/loadbalancer/random_test.go
+++ b/loadbalancer/random_test.go
@@ -35,7 +35,9 @@ func TestRandomDistribution(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		e(ctx, struct{}{})
+		if _, err := e(ctx, struct{}{}); err != nil {
+			t.Error(err)
+		}
 	}
 
 	for i, have := range counts {

--- a/loadbalancer/round_robin_test.go
+++ b/loadbalancer/round_robin_test.go
@@ -36,7 +36,9 @@ func TestRoundRobinDistribution(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		e(ctx, struct{}{})
+		if _, err := e(ctx, struct{}{}); err != nil {
+			t.Error(err)
+		}
 		if have := counts; !reflect.DeepEqual(want, have) {
 			t.Fatalf("%d: want %v, have %v", i, want, have)
 		}

--- a/loadbalancer/static/publisher.go
+++ b/loadbalancer/static/publisher.go
@@ -12,7 +12,7 @@ type Publisher struct{ publisher *fixed.Publisher }
 
 // NewPublisher returns a static endpoint Publisher.
 func NewPublisher(instances []string, factory loadbalancer.Factory, logger log.Logger) Publisher {
-	logger = log.NewContext(logger).With("component", "Fixed Publisher")
+	logger = log.NewContext(logger).With("component", "Static Publisher")
 	endpoints := []endpoint.Endpoint{}
 	for _, instance := range instances {
 		e, _, err := factory(instance) // never close

--- a/loadbalancer/static/publisher_test.go
+++ b/loadbalancer/static/publisher_test.go
@@ -2,12 +2,12 @@ package static_test
 
 import (
 	"fmt"
+	"io"
 	"testing"
 
 	"golang.org/x/net/context"
 
 	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/loadbalancer"
 	"github.com/go-kit/kit/loadbalancer/static"
 	"github.com/go-kit/kit/log"
 )
@@ -20,9 +20,9 @@ func TestStatic(t *testing.T) {
 			"bar": func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
 			"baz": func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
 		}
-		factory = func(instance string) (endpoint.Endpoint, loadbalancer.Closer, error) {
+		factory = func(instance string) (endpoint.Endpoint, io.Closer, error) {
 			if e, ok := endpoints[instance]; ok {
-				return e, make(loadbalancer.Closer), nil
+				return e, nil, nil
 			}
 			return nil, nil, fmt.Errorf("%s: not found", instance)
 		}

--- a/loadbalancer/static/publisher_test.go
+++ b/loadbalancer/static/publisher_test.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/loadbalancer"
 	"github.com/go-kit/kit/loadbalancer/static"
 	"github.com/go-kit/kit/log"
 )
@@ -19,11 +20,11 @@ func TestStatic(t *testing.T) {
 			"bar": func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
 			"baz": func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
 		}
-		factory = func(instance string) (endpoint.Endpoint, error) {
+		factory = func(instance string) (endpoint.Endpoint, loadbalancer.Closer, error) {
 			if e, ok := endpoints[instance]; ok {
-				return e, nil
+				return e, make(loadbalancer.Closer), nil
 			}
-			return nil, fmt.Errorf("%s: not found", instance)
+			return nil, nil, fmt.Errorf("%s: not found", instance)
 		}
 	)
 	p := static.NewPublisher(instances, factory, log.NewNopLogger())


### PR DESCRIPTION
This PR introduces a change that allows endpoints to be closed. This is useful for factories which create endpoints that need some kind of lifecycle management. Closes #122.