### PR TITLE
log: Fix StdlibAdapter parsing of Windows file paths when stdlib log has the Llongfile flag set.

### DIFF
--- a/log/stdlib.go
+++ b/log/stdlib.go
@@ -95,7 +95,7 @@ func (a StdlibAdapter) Write(p []byte) (int, error) {
 const (
 	logRegexpDate = `(?P<date>[0-9]{4}/[0-9]{2}/[0-9]{2})?[ ]?`
 	logRegexpTime = `(?P<time>[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?)?[ ]?`
-	logRegexpFile = `(?P<file>[^:]+:[0-9]+)?`
+	logRegexpFile = `(?P<file>.+:[0-9]+)?`
 	logRegexpMsg  = `(: )?(?P<msg>.*)`
 )
 

--- a/log/stdlib_test.go
+++ b/log/stdlib_test.go
@@ -134,6 +134,36 @@ func TestStdlibAdapterSubexps(t *testing.T) {
 			"file": "/a/b/c/d.go:23",
 			"msg":  "hello world",
 		},
+		"2009/01/23 01:23:23.123123 C:/a/b/c/d.go:23: hello world": map[string]string{
+			"date": "2009/01/23",
+			"time": "01:23:23.123123",
+			"file": "C:/a/b/c/d.go:23",
+			"msg":  "hello world",
+		},
+		"01:23:23.123123 C:/a/b/c/d.go:23: hello world": map[string]string{
+			"date": "",
+			"time": "01:23:23.123123",
+			"file": "C:/a/b/c/d.go:23",
+			"msg":  "hello world",
+		},
+		"2009/01/23 01:23:23 C:/a/b/c/d.go:23: hello world": map[string]string{
+			"date": "2009/01/23",
+			"time": "01:23:23",
+			"file": "C:/a/b/c/d.go:23",
+			"msg":  "hello world",
+		},
+		"2009/01/23 C:/a/b/c/d.go:23: hello world": map[string]string{
+			"date": "2009/01/23",
+			"time": "",
+			"file": "C:/a/b/c/d.go:23",
+			"msg":  "hello world",
+		},
+		"C:/a/b/c/d.go:23: hello world": map[string]string{
+			"date": "",
+			"time": "",
+			"file": "C:/a/b/c/d.go:23",
+			"msg":  "hello world",
+		},
 	} {
 		haveMap := subexps([]byte(input))
 		for key, want := range wantMap {


### PR DESCRIPTION
the following code should generate the specified output 

# code
```
	stdlog.SetFlags(stdlog.Ldate | stdlog.Ltime | stdlog.Llongfile)
	logger := kitlog.NewJSONLogger(os.Stdout)
	stdlog.SetOutput(kitlog.NewStdlibAdapter(logger))
	stdlog.Println("log...")
```
# output
**expected:**
`{"file":"C:/Dev/go/src/github.com/juRiii/gokittest/gokit_test.go:14","msg":"log...","ts":"2015/10/09 18:29:50"}`
**received:**
`{"msg":"C:/Dev/go/src/github.com/juRiii/test/gokit_test.go:13: log...","ts":"2015/10/09 18:47:07"}`

looks like, this occurs only on windows with the flag `stdlog.Llongfile`. is there a reason, why `(?P<file>[^:]+:[0-9]+)?` was used instead of `(?P<file>.+:[0-9]+)?`?