### PR TITLE
transport/http: expose BadRequestError raw error

### DIFF
--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -118,4 +118,11 @@ func defaultErrorEncoder(w http.ResponseWriter, err error) {
 }
 
 // BadRequestError is an error in decoding the request.
-type BadRequestError struct{ error }
+type BadRequestError struct {
+	Err error
+}
+
+// Error implements the error interface.
+func (err BadRequestError) Error() string {
+	return err.Err.Error()
+}

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -118,3 +118,20 @@ func testServer(t *testing.T) (cancel, step func(), resp <-chan *http.Response) 
 	}()
 	return cancelfn, func() { stepch <- true }, response
 }
+
+type testBadRequestError struct {
+	code int
+}
+
+func (err testBadRequestError) Error() string {
+	return "Bad Request"
+}
+
+func TestBadRequestError(t *testing.T) {
+	inner := testBadRequestError{1234}
+	var outer error = httptransport.BadRequestError{inner}
+	err := outer.(httptransport.BadRequestError)
+	if want, have := inner, err.Err; want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+}


### PR DESCRIPTION
Alternative solution 2.

Expose BadRequestError embedded error value as BadRequestError.Err.

Fixes #144.