### PR TITLE
Unify logging idioms

### DIFF
--- a/examples/addsvc/client/main.go
+++ b/examples/addsvc/client/main.go
@@ -55,7 +55,7 @@ func main() {
 	case "grpc":
 		cc, err := grpc.Dial(*grpcAddr)
 		if err != nil {
-			_ = logger.Log("err", err)
+			logger.Log("err", err)
 			os.Exit(1)
 		}
 		defer cc.Close()
@@ -68,7 +68,7 @@ func main() {
 		}
 		baseurl, err := url.Parse(rawurl)
 		if err != nil {
-			_ = logger.Log("err", err)
+			logger.Log("err", err)
 			os.Exit(1)
 		}
 		svc = httpjsonclient.New(root, baseurl, logger, nil)
@@ -76,7 +76,7 @@ func main() {
 	case "netrpc":
 		cli, err := rpc.DialHTTP("tcp", *netrpcAddr)
 		if err != nil {
-			_ = logger.Log("err", err)
+			logger.Log("err", err)
 			os.Exit(1)
 		}
 		defer cli.Close()
@@ -94,7 +94,7 @@ func main() {
 		case "binary", "":
 			protocolFactory = thrift.NewTBinaryProtocolFactoryDefault()
 		default:
-			_ = logger.Log("protocol", *thriftProtocol, "err", "invalid protocol")
+			logger.Log("protocol", *thriftProtocol, "err", "invalid protocol")
 			os.Exit(1)
 		}
 		var transportFactory thrift.TTransportFactory
@@ -108,20 +108,20 @@ func main() {
 		}
 		transportSocket, err := thrift.NewTSocket(*thriftAddr)
 		if err != nil {
-			_ = logger.Log("during", "thrift.NewTSocket", "err", err)
+			logger.Log("during", "thrift.NewTSocket", "err", err)
 			os.Exit(1)
 		}
 		trans := transportFactory.GetTransport(transportSocket)
 		defer trans.Close()
 		if err := trans.Open(); err != nil {
-			_ = logger.Log("during", "thrift transport.Open", "err", err)
+			logger.Log("during", "thrift transport.Open", "err", err)
 			os.Exit(1)
 		}
 		cli := thriftadd.NewAddServiceClientFactory(trans, protocolFactory)
 		svc = thriftclient.New(cli, logger)
 
 	default:
-		_ = logger.Log("err", "invalid transport")
+		logger.Log("err", "invalid transport")
 		os.Exit(1)
 	}
 
@@ -131,15 +131,15 @@ func main() {
 		a, _ := strconv.Atoi(s1)
 		b, _ := strconv.Atoi(s2)
 		v := svc.Sum(a, b)
-		_ = logger.Log("method", "sum", "a", a, "b", b, "v", v, "took", time.Since(begin))
+		logger.Log("method", "sum", "a", a, "b", b, "v", v, "took", time.Since(begin))
 
 	case "concat":
 		a, b := s1, s2
 		v := svc.Concat(a, b)
-		_ = logger.Log("method", "concat", "a", a, "b", b, "v", v, "took", time.Since(begin))
+		logger.Log("method", "concat", "a", a, "b", b, "v", v, "took", time.Since(begin))
 
 	default:
-		_ = logger.Log("err", "invalid method "+method)
+		logger.Log("err", "invalid method "+method)
 		os.Exit(1)
 	}
 }

--- a/examples/addsvc/main.go
+++ b/examples/addsvc/main.go
@@ -94,7 +94,7 @@ func main() {
 				zipkin.ScribeBatchInterval(*zipkinCollectorBatchInterval),
 				zipkin.ScribeLogger(zipkinLogger),
 			); err != nil {
-				_ = zipkinLogger.Log("err", err)
+				zipkinLogger.Log("err", err)
 				os.Exit(1)
 			}
 		}
@@ -120,7 +120,7 @@ func main() {
 	// Debug/instrumentation
 	go func() {
 		transportLogger := log.NewContext(logger).With("transport", "debug")
-		_ = transportLogger.Log("addr", *debugAddr)
+		transportLogger.Log("addr", *debugAddr)
 		errc <- http.ListenAndServe(*debugAddr, nil) // DefaultServeMux
 	}()
 
@@ -159,7 +159,7 @@ func main() {
 			httptransport.ServerErrorLogger(transportLogger),
 		))
 
-		_ = transportLogger.Log("addr", *httpAddr)
+		transportLogger.Log("addr", *httpAddr)
 		errc <- http.ListenAndServe(*httpAddr, mux)
 	}()
 
@@ -173,7 +173,7 @@ func main() {
 		}
 		s := grpc.NewServer() // uses its own, internal context
 		pb.RegisterAddServer(s, grpcBinding{svc})
-		_ = transportLogger.Log("addr", *grpcAddr)
+		transportLogger.Log("addr", *grpcAddr)
 		errc <- s.Serve(ln)
 	}()
 
@@ -186,7 +186,7 @@ func main() {
 			return
 		}
 		s.HandleHTTP(rpc.DefaultRPCPath, rpc.DefaultDebugPath)
-		_ = transportLogger.Log("addr", *netrpcAddr)
+		transportLogger.Log("addr", *netrpcAddr)
 		errc <- http.ListenAndServe(*netrpcAddr, s)
 	}()
 
@@ -221,7 +221,7 @@ func main() {
 			return
 		}
 		transportLogger := log.NewContext(logger).With("transport", "net/rpc")
-		_ = transportLogger.Log("addr", *thriftAddr)
+		transportLogger.Log("addr", *thriftAddr)
 		errc <- thrift.NewTSimpleServer4(
 			thriftadd.NewAddServiceProcessor(thriftBinding{svc}),
 			transport,
@@ -230,7 +230,7 @@ func main() {
 		).Serve()
 	}()
 
-	_ = logger.Log("fatal", <-errc)
+	logger.Log("fatal", <-errc)
 }
 
 func interrupt() error {
@@ -247,7 +247,7 @@ func (c loggingCollector) Collect(s *zipkin.Span) error {
 	for i, a := range annotations {
 		values[i] = a.Value
 	}
-	_ = c.Logger.Log(
+	c.Logger.Log(
 		"trace_id", s.TraceID(),
 		"span_id", s.SpanID(),
 		"parent_span_id", s.ParentSpanID(),

--- a/examples/stringsvc2/main.go
+++ b/examples/stringsvc2/main.go
@@ -60,6 +60,6 @@ func main() {
 	http.Handle("/uppercase", uppercaseHandler)
 	http.Handle("/count", countHandler)
 	http.Handle("/metrics", stdprometheus.Handler())
-	_ = logger.Log("msg", "HTTP", "addr", ":8080")
-	_ = logger.Log("err", http.ListenAndServe(":8080", nil))
+	logger.Log("msg", "HTTP", "addr", ":8080")
+	logger.Log("err", http.ListenAndServe(":8080", nil))
 }

--- a/examples/stringsvc3/main.go
+++ b/examples/stringsvc3/main.go
@@ -70,6 +70,6 @@ func main() {
 	http.Handle("/uppercase", uppercaseHandler)
 	http.Handle("/count", countHandler)
 	http.Handle("/metrics", stdprometheus.Handler())
-	_ = logger.Log("msg", "HTTP", "addr", *listen)
-	_ = logger.Log("err", http.ListenAndServe(*listen, nil))
+	logger.Log("msg", "HTTP", "addr", *listen)
+	logger.Log("err", http.ListenAndServe(*listen, nil))
 }

--- a/examples/stringsvc3/proxying.go
+++ b/examples/stringsvc3/proxying.go
@@ -23,11 +23,11 @@ import (
 
 func proxyingMiddleware(proxyList string, ctx context.Context, logger log.Logger) ServiceMiddleware {
 	if proxyList == "" {
-		_ = logger.Log("proxy_to", "none")
+		logger.Log("proxy_to", "none")
 		return func(next StringService) StringService { return next }
 	}
 	proxies := split(proxyList)
-	_ = logger.Log("proxy_to", fmt.Sprint(proxies))
+	logger.Log("proxy_to", fmt.Sprint(proxies))
 
 	return func(next StringService) StringService {
 		var (

--- a/loadbalancer/dnssrv/publisher.go
+++ b/loadbalancer/dnssrv/publisher.go
@@ -35,10 +35,10 @@ func NewPublisher(name string, ttl time.Duration, factory loadbalancer.Factory, 
 	}
 
 	instances, err := p.resolve()
-	if err != nil {
-		logger.Log(name, len(instances))
+	if err == nil {
+		logger.Log("name", name, "instances", len(instances))
 	} else {
-		logger.Log(name, err)
+		logger.Log("name", name, "err", err)
 	}
 	p.cache.Replace(instances)
 

--- a/loadbalancer/etcd/publisher.go
+++ b/loadbalancer/etcd/publisher.go
@@ -31,9 +31,9 @@ func NewPublisher(c Client, prefix string, f loadbalancer.Factory, logger log.Lo
 
 	instances, err := p.client.GetEntries(p.prefix)
 	if err == nil {
-		logger.Log(p.prefix, len(instances))
+		logger.Log("prefix", p.prefix, "instances", len(instances))
 	} else {
-		logger.Log("msg", "failed to retrieve entries", "err", err)
+		logger.Log("prefix", p.prefix, "err", err)
 	}
 	p.cache.Replace(instances)
 

--- a/loadbalancer/static/publisher.go
+++ b/loadbalancer/static/publisher.go
@@ -17,7 +17,7 @@ func NewPublisher(instances []string, factory loadbalancer.Factory, logger log.L
 	for _, instance := range instances {
 		e, _, err := factory(instance) // never close
 		if err != nil {
-			_ = logger.Log("instance", instance, "err", err)
+			logger.Log("instance", instance, "err", err)
 			continue
 		}
 		endpoints = append(endpoints, e)

--- a/log/nop_logger.go
+++ b/log/nop_logger.go
@@ -2,6 +2,7 @@ package log
 
 type nopLogger struct{}
 
-func (nopLogger) Log(...interface{}) error { return nil }
-
+// NewNopLogger returns a logger that doesn't do anything.
 func NewNopLogger() Logger { return nopLogger{} }
+
+func (nopLogger) Log(...interface{}) error { return nil }

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -85,14 +85,14 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	request, err := s.dec(r)
 	if err != nil {
-		_ = s.logger.Log("err", err)
+		s.logger.Log("err", err)
 		s.errorEncoder(w, BadRequestError{err})
 		return
 	}
 
 	response, err := s.e(ctx, request)
 	if err != nil {
-		_ = s.logger.Log("err", err)
+		s.logger.Log("err", err)
 		s.errorEncoder(w, err)
 		return
 	}
@@ -102,7 +102,7 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.enc(w, response); err != nil {
-		_ = s.logger.Log("err", err)
+		s.logger.Log("err", err)
 		s.errorEncoder(w, err)
 		return
 	}

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -129,7 +129,7 @@ func (err testBadRequestError) Error() string {
 
 func TestBadRequestError(t *testing.T) {
 	inner := testBadRequestError{1234}
-	var outer error = httptransport.BadRequestError{inner}
+	var outer error = httptransport.BadRequestError{Err: inner}
 	err := outer.(httptransport.BadRequestError)
 	if want, have := inner, err.Err; want != have {
 		t.Errorf("want %#v, have %#v", want, have)


### PR DESCRIPTION
- Context shall be provided by caller, not in constructor
- Don't bother with _ = logger.Log; turn off that lint complaint
- Minor linter fixes

Closes #148