### PR TITLE
Histogram extensions to support distributions

### DIFF
--- a/metrics/expvar/expvar.go
+++ b/metrics/expvar/expvar.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/codahale/hdrhistogram"
 
-	"github.com/adrianco/kit/metrics"
+	"github.com/go-kit/kit/metrics"
 )
 
 type counter struct {


### PR DESCRIPTION
Added Name getter for histogram
Added histogram observation count
Added counter and gauge String()
Added histogram String()

Depends on latest codahale/hdrhistogram, which was updated earlier today, to export Distribution data

Example:
```
name: netflixoss.*.*.www00....www.denominator:net
count: 127
gauges: map[50:7167 99:151551]
    From,      To,   Count,   Prob, Bar
    1024,    1535,       1, 0.0079, |
    2048,    2559,       1, 0.0079, |
    3072,    3583,       1, 0.0079, |
    4096,    4607,       1, 0.0079, |
    4608,    5119,       2, 0.0157, |#
    5632,    6143,      28, 0.2205, |######################
    6144,    6655,      28, 0.2205, |######################
    6656,    7167,      36, 0.2835, |############################
    7168,    7679,      17, 0.1339, |#############
    7680,    8191,       3, 0.0236, |##
    8192,    8703,       1, 0.0079, |
    8704,    9215,       1, 0.0079, |
    9728,   10239,       2, 0.0157, |#
   10752,   11263,       1, 0.0079, |
   48128,   48639,       1, 0.0079, |
  134144,  135167,       1, 0.0079, |
  150528,  151551,       1, 0.0079, |
  532480,  536575,       1, 0.0079, |
```