### PR TITLE
Add support for metrics.Histogram.Distribution

### DIFF
--- a/examples/addsvc/main.go
+++ b/examples/addsvc/main.go
@@ -70,6 +70,7 @@ func main() {
 	var requestDuration metrics.TimeHistogram
 	{
 		requestDuration = metrics.NewTimeHistogram(time.Nanosecond, metrics.NewMultiHistogram(
+			"request_duration_ns",
 			expvar.NewHistogram("request_duration_ns", 0, 5e9, 1, 50, 95, 99),
 			prometheus.NewSummary(stdprometheus.SummaryOpts{
 				Namespace: "myorg",

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -13,7 +13,11 @@ It has **[counters][]**, **[gauges][]**, and **[histograms][]**,
 
 ## Rationale
 
-TODO
+Code instrumentation is absolutely essential to achieve [observability][] into a distributed system.
+Metrics and instrumentation tools have coalesced around a few well-defined idioms.
+`package metrics` provides a common, minimal interface those idioms for service authors. 
+
+[observability]: https://speakerdeck.com/mattheath/observability-in-micro-service-architectures
 
 ## Usage
 
@@ -53,6 +57,7 @@ func handleRequest() {
 ```
 
 A gauge for the number of goroutines currently running, exported via statsd.
+
 ```go
 import (
 	"net"
@@ -66,14 +71,13 @@ import (
 func main() {
 	statsdWriter, err := net.Dial("udp", "127.0.0.1:8126")
 	if err != nil {
-		os.Exit(1)
+		panic(err)
 	}
 
-	reportingDuration := 5 * time.Second
-	goroutines := statsd.NewGauge(statsdWriter, "total_goroutines", reportingDuration)
-	for range time.Tick(reportingDuration) {
+	reportInterval := 5 * time.Second
+	goroutines := statsd.NewGauge(statsdWriter, "total_goroutines", reportInterval)
+	for range time.Tick(reportInterval) {
 		goroutines.Set(float64(runtime.NumGoroutine()))
 	}
 }
-
 ```

--- a/metrics/expvar/expvar_test.go
+++ b/metrics/expvar/expvar_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestHistogramQuantiles(t *testing.T) {
 	var (
-		name      = "test_histogram"
+		name      = "test_histogram_quantiles"
 		quantiles = []int{50, 90, 95, 99}
 		h         = expvar.NewHistogram(name, 0, 100, 3, quantiles...).With(metrics.Field{Key: "ignored", Value: "field"})
 	)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -9,6 +9,7 @@ package metrics
 // between measurements of a counter over intervals of time, an aggregation
 // layer can derive rates, acceleration, etc.
 type Counter interface {
+	Name() string
 	With(Field) Counter
 	Add(delta uint64)
 }
@@ -16,6 +17,7 @@ type Counter interface {
 // Gauge captures instantaneous measurements of something using signed, 64-bit
 // floats. The value does not need to be monotonic.
 type Gauge interface {
+	Name() string
 	With(Field) Gauge
 	Set(value float64)
 	Add(delta float64)
@@ -25,8 +27,10 @@ type Gauge interface {
 // milliseconds it takes to handle requests). Implementations may choose to
 // add gauges for values at meaningful quantiles.
 type Histogram interface {
+	Name() string
 	With(Field) Histogram
 	Observe(value int64)
+	Distribution() []Bucket
 }
 
 // Field is a key/value pair associated with an observation for a specific
@@ -34,4 +38,11 @@ type Histogram interface {
 type Field struct {
 	Key   string
 	Value string
+}
+
+// Bucket is a range in a histogram which aggregates observations.
+type Bucket struct {
+	From  int64
+	To    int64
+	Count int64
 }

--- a/metrics/multi.go
+++ b/metrics/multi.go
@@ -1,73 +1,107 @@
 package metrics
 
-type multiCounter []Counter
-
-// NewMultiCounter returns a wrapper around multiple Counters.
-func NewMultiCounter(counters ...Counter) Counter {
-	c := make(multiCounter, 0, len(counters))
-	return append(c, counters...)
+type multiCounter struct {
+	name string
+	a    []Counter
 }
 
+// NewMultiCounter returns a wrapper around multiple Counters.
+func NewMultiCounter(name string, counters ...Counter) Counter {
+	return &multiCounter{
+		name: name,
+		a:    counters,
+	}
+}
+
+func (c multiCounter) Name() string { return c.name }
+
 func (c multiCounter) With(f Field) Counter {
-	next := make(multiCounter, len(c))
-	for i, counter := range c {
-		next[i] = counter.With(f)
+	next := &multiCounter{
+		name: c.name,
+		a:    make([]Counter, len(c.a)),
+	}
+	for i, counter := range c.a {
+		next.a[i] = counter.With(f)
 	}
 	return next
 }
 
 func (c multiCounter) Add(delta uint64) {
-	for _, counter := range c {
+	for _, counter := range c.a {
 		counter.Add(delta)
 	}
 }
 
-type multiGauge []Gauge
+type multiGauge struct {
+	name string
+	a    []Gauge
+}
+
+func (g multiGauge) Name() string { return g.name }
 
 // NewMultiGauge returns a wrapper around multiple Gauges.
-func NewMultiGauge(gauges ...Gauge) Gauge {
-	g := make(multiGauge, 0, len(gauges))
-	return append(g, gauges...)
+func NewMultiGauge(name string, gauges ...Gauge) Gauge {
+	return &multiGauge{
+		name: name,
+		a:    gauges,
+	}
 }
 
 func (g multiGauge) With(f Field) Gauge {
-	next := make(multiGauge, len(g))
-	for i, gauge := range g {
-		next[i] = gauge.With(f)
+	next := &multiGauge{
+		name: g.name,
+		a:    make([]Gauge, len(g.a)),
+	}
+	for i, gauge := range g.a {
+		next.a[i] = gauge.With(f)
 	}
 	return next
 }
 
 func (g multiGauge) Set(value float64) {
-	for _, gauge := range g {
+	for _, gauge := range g.a {
 		gauge.Set(value)
 	}
 }
 
 func (g multiGauge) Add(delta float64) {
-	for _, gauge := range g {
+	for _, gauge := range g.a {
 		gauge.Add(delta)
 	}
 }
 
-type multiHistogram []Histogram
-
-// NewMultiHistogram returns a wrapper around multiple Histograms.
-func NewMultiHistogram(histograms ...Histogram) Histogram {
-	h := make(multiHistogram, 0, len(histograms))
-	return append(h, histograms...)
+type multiHistogram struct {
+	name string
+	a    []Histogram
 }
 
+// NewMultiHistogram returns a wrapper around multiple Histograms.
+func NewMultiHistogram(name string, histograms ...Histogram) Histogram {
+	return &multiHistogram{
+		name: name,
+		a:    histograms,
+	}
+}
+
+func (h multiHistogram) Name() string { return h.name }
+
 func (h multiHistogram) With(f Field) Histogram {
-	next := make(multiHistogram, len(h))
-	for i, histogram := range h {
-		next[i] = histogram.With(f)
+	next := &multiHistogram{
+		name: h.name,
+		a:    make([]Histogram, len(h.a)),
+	}
+	for i, histogram := range h.a {
+		next.a[i] = histogram.With(f)
 	}
 	return next
 }
 
 func (h multiHistogram) Observe(value int64) {
-	for _, histogram := range h {
+	for _, histogram := range h.a {
 		histogram.Observe(value)
 	}
+}
+
+func (h multiHistogram) Distribution() []Bucket {
+	return []Bucket{} // TODO(pb): can this be statistically valid?
 }

--- a/metrics/multi_test.go
+++ b/metrics/multi_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestMultiWith(t *testing.T) {
 	c := metrics.NewMultiCounter(
+		"multifoo",
 		expvar.NewCounter("foo"),
 		prometheus.NewCounter(stdprometheus.CounterOpts{
 			Namespace: "test",
@@ -47,6 +48,7 @@ func TestMultiWith(t *testing.T) {
 
 func TestMultiCounter(t *testing.T) {
 	metrics.NewMultiCounter(
+		"multialpha",
 		expvar.NewCounter("alpha"),
 		prometheus.NewCounter(stdprometheus.CounterOpts{
 			Namespace: "test",
@@ -71,6 +73,7 @@ func TestMultiCounter(t *testing.T) {
 
 func TestMultiGauge(t *testing.T) {
 	g := metrics.NewMultiGauge(
+		"multidelta",
 		expvar.NewGauge("delta"),
 		prometheus.NewGauge(stdprometheus.GaugeOpts{
 			Namespace: "test",
@@ -111,6 +114,7 @@ func TestMultiGauge(t *testing.T) {
 func TestMultiHistogram(t *testing.T) {
 	quantiles := []int{50, 90, 99}
 	h := metrics.NewMultiHistogram(
+		"multiomicron",
 		expvar.NewHistogram("omicron", 0, 100, 3, quantiles...),
 		prometheus.NewSummary(stdprometheus.SummaryOpts{
 			Namespace: "test",

--- a/metrics/multi_test.go
+++ b/metrics/multi_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -18,6 +17,7 @@ import (
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/expvar"
 	"github.com/go-kit/kit/metrics/prometheus"
+	"github.com/go-kit/kit/metrics/teststat"
 )
 
 func TestMultiWith(t *testing.T) {
@@ -125,17 +125,9 @@ func TestMultiHistogram(t *testing.T) {
 	)
 
 	const seed, mean, stdev int64 = 123, 50, 10
-	populateNormalHistogram(t, h, seed, mean, stdev)
+	teststat.PopulateNormalHistogram(t, h, seed, mean, stdev)
 	assertExpvarNormalHistogram(t, "omicron", mean, stdev, quantiles)
 	assertPrometheusNormalHistogram(t, `test_multi_histogram_nu`, mean, stdev)
-}
-
-func populateNormalHistogram(t *testing.T, h metrics.Histogram, seed int64, mean, stdev int64) {
-	rand.Seed(seed)
-	for i := 0; i < 1234; i++ {
-		sample := int64(rand.NormFloat64()*float64(stdev) + float64(mean))
-		h.Observe(sample)
-	}
 }
 
 func assertExpvarNormalHistogram(t *testing.T, metricName string, mean, stdev int64, quantiles []int) {

--- a/metrics/print.go
+++ b/metrics/print.go
@@ -1,0 +1,39 @@
+package metrics
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+)
+
+const (
+	bs  = "####################################################################################################"
+	bsz = float64(len(bs))
+)
+
+// PrintDistribution writes a human-readable graph of the distribution to the
+// passed writer.
+func PrintDistribution(w io.Writer, name string, buckets []Bucket) {
+	fmt.Fprintf(w, "name: %v\n", name)
+
+	var total float64
+	for _, bucket := range buckets {
+		total += float64(bucket.Count)
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	fmt.Fprintf(tw, "From\tTo\tCount\tProb\tBar\n")
+
+	axis := "|"
+	for _, bucket := range buckets {
+		if bucket.Count > 0 {
+			p := float64(bucket.Count) / total
+			fmt.Fprintf(tw, "%d\t%d\t%d\t%.4f\t%s%s\n", bucket.From, bucket.To, bucket.Count, p, axis, bs[:int(p*bsz)])
+			axis = "|"
+		} else {
+			axis = ":" // show that some bars were skipped
+		}
+	}
+
+	tw.Flush() // to buf
+}

--- a/metrics/print.go
+++ b/metrics/print.go
@@ -35,5 +35,5 @@ func PrintDistribution(w io.Writer, name string, buckets []Bucket) {
 		}
 	}
 
-	tw.Flush() // to buf
+	tw.Flush()
 }

--- a/metrics/print_test.go
+++ b/metrics/print_test.go
@@ -1,8 +1,10 @@
 package metrics_test
 
 import (
-	"os"
+	"bytes"
 	"testing"
+
+	"math"
 
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/expvar"
@@ -19,5 +21,21 @@ func TestPrintDistribution(t *testing.T) {
 		stdev     = int64(1)
 	)
 	teststat.PopulateNormalHistogram(t, h, seed, mean, stdev)
-	metrics.PrintDistribution(os.Stdout, name, h.Distribution())
+
+	var buf bytes.Buffer
+	metrics.PrintDistribution(&buf, name, h.Distribution())
+	t.Logf("\n%s\n", buf.String())
+
+	// Count the number of bar chart characters.
+	// We should have roughly 100 in any distribution.
+
+	var n int
+	for _, r := range buf.String() {
+		if r == '#' {
+			n++
+		}
+	}
+	if want, have, tol := 100, n, 5; int(math.Abs(float64(want-have))) > tol {
+		t.Errorf("want %d, have %d (tolerance %d)", want, have, tol)
+	}
 }

--- a/metrics/print_test.go
+++ b/metrics/print_test.go
@@ -1,0 +1,23 @@
+package metrics_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/expvar"
+	"github.com/go-kit/kit/metrics/teststat"
+)
+
+func TestPrintDistribution(t *testing.T) {
+	var (
+		name      = "foobar"
+		quantiles = []int{50, 90, 95, 99}
+		h         = expvar.NewHistogram("test_print_distribution", 1, 10, 3, quantiles...)
+		seed      = int64(555)
+		mean      = int64(5)
+		stdev     = int64(1)
+	)
+	teststat.PopulateNormalHistogram(t, h, seed, mean, stdev)
+	metrics.PrintDistribution(os.Stdout, name, h.Distribution())
+}

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -16,6 +16,7 @@ var PrometheusLabelValueUnknown = "unknown"
 
 type prometheusCounter struct {
 	*prometheus.CounterVec
+	name  string
 	Pairs map[string]string
 }
 
@@ -30,13 +31,17 @@ func NewCounter(opts prometheus.CounterOpts, fieldKeys []string) metrics.Counter
 	}
 	return prometheusCounter{
 		CounterVec: m,
+		name:       opts.Name,
 		Pairs:      p,
 	}
 }
 
+func (c prometheusCounter) Name() string { return c.name }
+
 func (c prometheusCounter) With(f metrics.Field) metrics.Counter {
 	return prometheusCounter{
 		CounterVec: c.CounterVec,
+		name:       c.name,
 		Pairs:      merge(c.Pairs, f),
 	}
 }
@@ -47,6 +52,7 @@ func (c prometheusCounter) Add(delta uint64) {
 
 type prometheusGauge struct {
 	*prometheus.GaugeVec
+	name  string
 	Pairs map[string]string
 }
 
@@ -57,13 +63,17 @@ func NewGauge(opts prometheus.GaugeOpts, fieldKeys []string) metrics.Gauge {
 	prometheus.MustRegister(m)
 	return prometheusGauge{
 		GaugeVec: m,
+		name:     opts.Name,
 		Pairs:    pairsFrom(fieldKeys),
 	}
 }
 
+func (g prometheusGauge) Name() string { return g.name }
+
 func (g prometheusGauge) With(f metrics.Field) metrics.Gauge {
 	return prometheusGauge{
 		GaugeVec: g.GaugeVec,
+		name:     g.name,
 		Pairs:    merge(g.Pairs, f),
 	}
 }
@@ -86,6 +96,7 @@ func RegisterCallbackGauge(opts prometheus.GaugeOpts, callback func() float64) {
 
 type prometheusSummary struct {
 	*prometheus.SummaryVec
+	name  string
 	Pairs map[string]string
 }
 
@@ -99,13 +110,17 @@ func NewSummary(opts prometheus.SummaryOpts, fieldKeys []string) metrics.Histogr
 	prometheus.MustRegister(m)
 	return prometheusSummary{
 		SummaryVec: m,
+		name:       opts.Name,
 		Pairs:      pairsFrom(fieldKeys),
 	}
 }
 
+func (s prometheusSummary) Name() string { return s.name }
+
 func (s prometheusSummary) With(f metrics.Field) metrics.Histogram {
 	return prometheusSummary{
 		SummaryVec: s.SummaryVec,
+		name:       s.name,
 		Pairs:      merge(s.Pairs, f),
 	}
 }
@@ -114,8 +129,14 @@ func (s prometheusSummary) Observe(value int64) {
 	s.SummaryVec.With(prometheus.Labels(s.Pairs)).Observe(float64(value))
 }
 
+func (s prometheusSummary) Distribution() []metrics.Bucket {
+	// TODO(pb): see https://github.com/prometheus/client_golang/issues/58
+	return []metrics.Bucket{}
+}
+
 type prometheusHistogram struct {
 	*prometheus.HistogramVec
+	name  string
 	Pairs map[string]string
 }
 
@@ -129,19 +150,28 @@ func NewHistogram(opts prometheus.HistogramOpts, fieldKeys []string) metrics.His
 	prometheus.MustRegister(m)
 	return prometheusHistogram{
 		HistogramVec: m,
+		name:         opts.Name,
 		Pairs:        pairsFrom(fieldKeys),
 	}
 }
 
+func (h prometheusHistogram) Name() string { return h.name }
+
 func (h prometheusHistogram) With(f metrics.Field) metrics.Histogram {
 	return prometheusHistogram{
 		HistogramVec: h.HistogramVec,
+		name:         h.name,
 		Pairs:        merge(h.Pairs, f),
 	}
 }
 
 func (h prometheusHistogram) Observe(value int64) {
 	h.HistogramVec.With(prometheus.Labels(h.Pairs)).Observe(float64(value))
+}
+
+func (h prometheusHistogram) Distribution() []metrics.Bucket {
+	// TODO(pb): see https://github.com/prometheus/client_golang/issues/58
+	return []metrics.Bucket{}
 }
 
 func pairsFrom(fieldKeys []string) map[string]string {

--- a/metrics/scaled_histogram_test.go
+++ b/metrics/scaled_histogram_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/expvar"
+	"github.com/go-kit/kit/metrics/teststat"
 )
 
 func TestScaledHistogram(t *testing.T) {
@@ -19,7 +20,7 @@ func TestScaledHistogram(t *testing.T) {
 	h = metrics.NewScaledHistogram(h, scale)
 	h = h.With(metrics.Field{Key: "a", Value: "b"})
 
-	const seed, mean, stdev = 333, 500, 100          // input values
-	populateNormalHistogram(t, h, seed, mean, stdev) // will be scaled down
+	const seed, mean, stdev = 333, 500, 100                   // input values
+	teststat.PopulateNormalHistogram(t, h, seed, mean, stdev) // will be scaled down
 	assertExpvarNormalHistogram(t, metricName, mean/scale, stdev/scale, quantiles)
 }

--- a/metrics/teststat/common.go
+++ b/metrics/teststat/common.go
@@ -15,9 +15,9 @@ const population = 1234
 // PopulateNormalHistogram populates the Histogram with a normal distribution
 // of observations.
 func PopulateNormalHistogram(t *testing.T, h metrics.Histogram, seed int64, mean, stdev int64) {
-	rand.Seed(seed)
+	r := rand.New(rand.NewSource(seed))
 	for i := 0; i < population; i++ {
-		sample := int64(rand.NormFloat64()*float64(stdev) + float64(mean))
+		sample := int64(r.NormFloat64()*float64(stdev) + float64(mean))
 		if sample < 0 {
 			sample = 0
 		}

--- a/metrics/time_histogram_test.go
+++ b/metrics/time_histogram_test.go
@@ -21,9 +21,10 @@ func TestTimeHistogram(t *testing.T) {
 	)
 
 	const seed, mean, stdev int64 = 321, 100, 20
+	r := rand.New(rand.NewSource(seed))
 
 	for i := 0; i < 4321; i++ {
-		sample := time.Duration(rand.NormFloat64()*float64(stdev)+float64(mean)) * time.Millisecond
+		sample := time.Duration(r.NormFloat64()*float64(stdev)+float64(mean)) * time.Millisecond
 		th.Observe(sample)
 	}
 


### PR DESCRIPTION
Histograms gain a method to read the distribution (slice of buckets) that has been observed so far. In this PR, the only implementation that supports Distribution is expvar (via codahale/hdrhistogram). Prometheus support is possible and planned.

- Each metrics type gains a Name() method
- metrics.Histogram gains Distribution()
- metrics package gains PrintDistribution()
- Minor updates to README