### PR TITLE
Minimal Binary Annotations Support

### DIFF
--- a/tracing/zipkin/span.go
+++ b/tracing/zipkin/span.go
@@ -26,8 +26,8 @@ type Span struct {
 	spanID       int64
 	parentSpanID int64
 
-	annotations []annotation
-	//binaryAnnotations []BinaryAnnotation // TODO
+	annotations       []annotation
+	binaryAnnotations []binaryAnnotation
 }
 
 // NewSpan returns a new Span, which can be annotated and collected by a
@@ -94,6 +94,26 @@ func (s *Span) Annotate(value string) {
 	s.AnnotateDuration(value, 0)
 }
 
+// AnnotateBinary annotates the span with a key and a byte value.
+func (s *Span) AnnotateBinary(key string, value []byte) {
+	s.binaryAnnotations = append(s.binaryAnnotations, binaryAnnotation{
+		key:            key,
+		value:          value,
+		annotationType: zipkincore.AnnotationType_BYTES,
+		host:           s.host,
+	})
+}
+
+// AnnotateString annotates the span with a key and a string value.
+func (s *Span) AnnotateString(key, value string) {
+	s.binaryAnnotations = append(s.binaryAnnotations, binaryAnnotation{
+		key:            key,
+		value:          []byte(value),
+		annotationType: zipkincore.AnnotationType_STRING,
+		host:           s.host,
+	})
+}
+
 // AnnotateDuration annotates the span with the given value and duration.
 func (s *Span) AnnotateDuration(value string, duration time.Duration) {
 	s.annotations = append(s.annotations, annotation{
@@ -109,16 +129,18 @@ func (s *Span) Encode() *zipkincore.Span {
 	// TODO lots of garbage here. We can improve by preallocating e.g. the
 	// Thrift stuff into an encoder struct, owned by the ScribeCollector.
 	zs := zipkincore.Span{
-		TraceId:           s.traceID,
-		Name:              s.methodName,
-		Id:                s.spanID,
-		BinaryAnnotations: []*zipkincore.BinaryAnnotation{}, // TODO
-		Debug:             true,                             // TODO
+		TraceId: s.traceID,
+		Name:    s.methodName,
+		Id:      s.spanID,
+		// BinaryAnnotations: []*zipkincore.BinaryAnnotation{}, // TODO
+		Debug: true, // TODO
 	}
+
 	if s.parentSpanID != 0 {
 		zs.ParentId = new(int64)
 		(*zs.ParentId) = s.parentSpanID
 	}
+
 	zs.Annotations = make([]*zipkincore.Annotation, len(s.annotations))
 	for i, a := range s.annotations {
 		zs.Annotations[i] = &zipkincore.Annotation{
@@ -126,11 +148,23 @@ func (s *Span) Encode() *zipkincore.Span {
 			Value:     a.value,
 			Host:      a.host,
 		}
+
 		if a.duration > 0 {
 			zs.Annotations[i].Duration = new(int32)
 			*(zs.Annotations[i].Duration) = int32(a.duration / time.Microsecond)
 		}
 	}
+
+	zs.BinaryAnnotations = make([]*zipkincore.BinaryAnnotation, len(s.binaryAnnotations))
+	for i, a := range s.binaryAnnotations {
+		zs.BinaryAnnotations[i] = &zipkincore.BinaryAnnotation{
+			Key:            a.key,
+			Value:          a.value,
+			AnnotationType: a.annotationType,
+			Host:           a.host,
+		}
+	}
+
 	return &zs
 }
 
@@ -139,4 +173,11 @@ type annotation struct {
 	value     string
 	duration  time.Duration // optional
 	host      *zipkincore.Endpoint
+}
+
+type binaryAnnotation struct {
+	key            string
+	value          []byte
+	annotationType zipkincore.AnnotationType
+	host           *zipkincore.Endpoint
 }

--- a/tracing/zipkin/span.go
+++ b/tracing/zipkin/span.go
@@ -132,8 +132,7 @@ func (s *Span) Encode() *zipkincore.Span {
 		TraceId: s.traceID,
 		Name:    s.methodName,
 		Id:      s.spanID,
-		// BinaryAnnotations: []*zipkincore.BinaryAnnotation{}, // TODO
-		Debug: true, // TODO
+		Debug:   true, // TODO
 	}
 
 	if s.parentSpanID != 0 {

--- a/tracing/zipkin/span_test.go
+++ b/tracing/zipkin/span_test.go
@@ -1,6 +1,7 @@
 package zipkin_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/go-kit/kit/tracing/zipkin"
@@ -16,12 +17,16 @@ func TestAnnotateBinaryEncodesKeyValueAsBytes(t *testing.T) {
 	encodedSpan := span.Encode()
 	annotations := encodedSpan.GetBinaryAnnotations()
 
-	if annotations[0].Key != key {
-		t.Errorf("Error: expected %s got %s", key, annotations[0].Key)
+	if len(annotations) == 0 {
+		t.Error("want non-zero length slice, have empty slice")
 	}
 
-	if string(annotations[0].Value) != string(value) {
-		t.Errorf("Error: expected %s got %s", string(value), string(annotations[0].Value))
+	if want, have := key, annotations[0].Key; want != have {
+		t.Errorf("want %q, got %q", want, have)
+	}
+
+	if want, have := value, annotations[0].Value; bytes.Compare(want, have) != 0 {
+		t.Errorf("want %s, got %s", want, have)
 	}
 }
 
@@ -35,11 +40,15 @@ func TestAnnotateStringEncodesKeyValueAsBytes(t *testing.T) {
 	encodedSpan := span.Encode()
 	annotations := encodedSpan.GetBinaryAnnotations()
 
-	if annotations[0].Key != key {
-		t.Errorf("Error: expected %s got %s", key, annotations[0].Key)
+	if len(annotations) == 0 {
+		t.Error("want non-zero length slice, have empty slice")
 	}
 
-	if string(annotations[0].Value) != value {
-		t.Errorf("Error: expected %s got %s", value, string(annotations[0].Value))
+	if want, have := key, annotations[0].Key; want != have {
+		t.Errorf("want %q, got %q", want, have)
+	}
+
+	if want, have := value, annotations[0].Value; bytes.Compare([]byte(want), have) != 0 {
+		t.Errorf("want %s, got %s", want, have)
 	}
 }

--- a/tracing/zipkin/span_test.go
+++ b/tracing/zipkin/span_test.go
@@ -1,0 +1,45 @@
+package zipkin_test
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/tracing/zipkin"
+)
+
+func TestAnnotateBinaryEncodesKeyValueAsBytes(t *testing.T) {
+	key := "awesome-bytes-test"
+	value := []byte("this is neat")
+
+	span := &zipkin.Span{}
+	span.AnnotateBinary(key, value)
+
+	encodedSpan := span.Encode()
+	annotations := encodedSpan.GetBinaryAnnotations()
+
+	if annotations[0].Key != key {
+		t.Errorf("Error: expected %s got %s", key, annotations[0].Key)
+	}
+
+	if string(annotations[0].Value) != string(value) {
+		t.Errorf("Error: expected %s got %s", string(value), string(annotations[0].Value))
+	}
+}
+
+func TestAnnotateStringEncodesKeyValueAsBytes(t *testing.T) {
+	key := "awesome-string-test"
+	value := "this is neat"
+
+	span := &zipkin.Span{}
+	span.AnnotateString(key, value)
+
+	encodedSpan := span.Encode()
+	annotations := encodedSpan.GetBinaryAnnotations()
+
+	if annotations[0].Key != key {
+		t.Errorf("Error: expected %s got %s", key, annotations[0].Key)
+	}
+
+	if string(annotations[0].Value) != value {
+		t.Errorf("Error: expected %s got %s", value, string(annotations[0].Value))
+	}
+}


### PR DESCRIPTION
Hello,
This pull requests adds minimal support for [Binary Annotations](http://zipkin.io/Instrumenting.html#core-data-structures).

The following api is now exposed:
  - `AnnotateBinary(key string, value []byte)` corresponding to `AnnotationType_BYTES`
  - `AnnotateString(key, value string)` corresponding to `AnnotationType_STRING`
