### PR TITLE
Remove go1.4 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 script: go test -race -v ./...
 
 go:
-    - 1.4.2
     - 1.5.3
     - 1.6
     #- tip


### PR DESCRIPTION
Upstream etcd removed support for go1.4, making travis builds fail.