### PR TITLE
Use transport.grpc in addsvc example server

### DIFF
--- a/examples/addsvc/endpoint.go
+++ b/examples/addsvc/endpoint.go
@@ -9,7 +9,7 @@ import (
 
 func makeSumEndpoint(svc server.AddService) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(server.SumRequest)
+		req := request.(*server.SumRequest)
 		v := svc.Sum(req.A, req.B)
 		return server.SumResponse{V: v}, nil
 	}
@@ -17,7 +17,7 @@ func makeSumEndpoint(svc server.AddService) endpoint.Endpoint {
 
 func makeConcatEndpoint(svc server.AddService) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(server.ConcatRequest)
+		req := request.(*server.ConcatRequest)
 		v := svc.Concat(req.A, req.B)
 		return server.ConcatResponse{V: v}, nil
 	}

--- a/examples/addsvc/grpc_binding.go
+++ b/examples/addsvc/grpc_binding.go
@@ -5,16 +5,27 @@ import (
 
 	"github.com/go-kit/kit/examples/addsvc/pb"
 	"github.com/go-kit/kit/examples/addsvc/server"
+	servergrpc "github.com/go-kit/kit/examples/addsvc/server/grpc"
+	"github.com/go-kit/kit/transport/grpc"
 )
 
 type grpcBinding struct {
-	server.AddService
+	sum, concat grpc.Handler
+}
+
+func newGRPCBinding(ctx context.Context, svc server.AddService) grpcBinding {
+	return grpcBinding{
+		sum:    grpc.NewServer(ctx, makeSumEndpoint(svc), servergrpc.DecodeSumRequest, servergrpc.EncodeSumResponse),
+		concat: grpc.NewServer(ctx, makeConcatEndpoint(svc), servergrpc.DecodeConcatRequest, servergrpc.EncodeConcatResponse),
+	}
 }
 
 func (b grpcBinding) Sum(ctx context.Context, req *pb.SumRequest) (*pb.SumReply, error) {
-	return &pb.SumReply{V: int64(b.AddService.Sum(int(req.A), int(req.B)))}, nil
+	_, resp, err := b.sum.ServeGRPC(ctx, req)
+	return resp.(*pb.SumReply), err
 }
 
 func (b grpcBinding) Concat(ctx context.Context, req *pb.ConcatRequest) (*pb.ConcatReply, error) {
-	return &pb.ConcatReply{V: b.AddService.Concat(req.A, req.B)}, nil
+	_, resp, err := b.concat.ServeGRPC(ctx, req)
+	return resp.(*pb.ConcatReply), err
 }

--- a/examples/addsvc/main.go
+++ b/examples/addsvc/main.go
@@ -173,7 +173,7 @@ func main() {
 			return
 		}
 		s := grpc.NewServer() // uses its own, internal context
-		pb.RegisterAddServer(s, grpcBinding{svc})
+		pb.RegisterAddServer(s, newGRPCBinding(root, svc))
 		transportLogger.Log("addr", *grpcAddr)
 		errc <- s.Serve(ln)
 	}()

--- a/examples/addsvc/server/grpc/encode_decode.go
+++ b/examples/addsvc/server/grpc/encode_decode.go
@@ -1,0 +1,42 @@
+package grpc
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/go-kit/kit/examples/addsvc/pb"
+	"github.com/go-kit/kit/examples/addsvc/server"
+)
+
+func DecodeSumRequest(ctx context.Context, req interface{}) (interface{}, error) {
+	sumRequest := req.(*pb.SumRequest)
+
+	return &server.SumRequest{
+		A: int(sumRequest.A),
+		B: int(sumRequest.B),
+	}, nil
+}
+
+func DecodeConcatRequest(ctx context.Context, req interface{}) (interface{}, error) {
+	concatRequest := req.(*pb.ConcatRequest)
+
+	return &server.ConcatRequest{
+		A: concatRequest.A,
+		B: concatRequest.B,
+	}, nil
+}
+
+func EncodeSumResponse(ctx context.Context, resp interface{}) (interface{}, error) {
+	domainResponse := resp.(server.SumResponse)
+
+	return &pb.SumReply{
+		V: int64(domainResponse.V),
+	}, nil
+}
+
+func EncodeConcatResponse(ctx context.Context, resp interface{}) (interface{}, error) {
+	domainResponse := resp.(server.ConcatResponse)
+
+	return &pb.ConcatReply{
+		V: domainResponse.V,
+	}, nil
+}


### PR DESCRIPTION
This change modifies the addsvc example server to use ```grpc.transport```. It's change 2/2 needed to resolve issue #217 