### PR TITLE
replace fmt.Errorf with Exported Err type

### DIFF
--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -75,11 +74,11 @@ func (c Client) Endpoint() endpoint.Endpoint {
 
 		req, err := http.NewRequest(c.method, c.tgt.String(), nil)
 		if err != nil {
-			return nil, fmt.Errorf("NewRequest: %v", err)
+			return nil, Err{"NewRequest", err}
 		}
 
 		if err = c.enc(req, request); err != nil {
-			return nil, fmt.Errorf("Encode: %v", err)
+			return nil, Err{"Encode", err}
 		}
 
 		for _, f := range c.before {
@@ -88,7 +87,7 @@ func (c Client) Endpoint() endpoint.Endpoint {
 
 		resp, err := ctxhttp.Do(ctx, c.client, req)
 		if err != nil {
-			return nil, fmt.Errorf("Do: %v", err)
+			return nil, Err{"Do", err}
 		}
 		if !c.bufferedStream {
 			defer resp.Body.Close()
@@ -96,7 +95,7 @@ func (c Client) Endpoint() endpoint.Endpoint {
 
 		response, err := c.dec(resp)
 		if err != nil {
-			return nil, fmt.Errorf("Decode: %v", err)
+			return nil, Err{"Decode", err}
 		}
 
 		return response, nil

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -74,11 +74,11 @@ func (c Client) Endpoint() endpoint.Endpoint {
 
 		req, err := http.NewRequest(c.method, c.tgt.String(), nil)
 		if err != nil {
-			return nil, Err{"NewRequest", err}
+			return nil, TransportError{DomainNewRequest, err}
 		}
 
 		if err = c.enc(req, request); err != nil {
-			return nil, Err{"Encode", err}
+			return nil, TransportError{DomainEncode, err}
 		}
 
 		for _, f := range c.before {
@@ -87,7 +87,7 @@ func (c Client) Endpoint() endpoint.Endpoint {
 
 		resp, err := ctxhttp.Do(ctx, c.client, req)
 		if err != nil {
-			return nil, Err{"Do", err}
+			return nil, TransportError{DomainDo, err}
 		}
 		if !c.bufferedStream {
 			defer resp.Body.Close()
@@ -95,7 +95,7 @@ func (c Client) Endpoint() endpoint.Endpoint {
 
 		response, err := c.dec(resp)
 		if err != nil {
-			return nil, Err{"Decode", err}
+			return nil, TransportError{DomainDecode, err}
 		}
 
 		return response, nil

--- a/transport/http/err.go
+++ b/transport/http/err.go
@@ -4,8 +4,28 @@ import (
 	"fmt"
 )
 
-// Err represents an Error occurred in the Client transport level.
-type Err struct {
+// These are some pre-generated constants that can be used to check against
+// for the DomainErrors.
+const (
+	// DomainNewRequest represents an error at the Request Generation
+	// Scope.
+	DomainNewRequest = "NewRequest"
+
+	// DomainEncode represent an error that has occurred at the Encode
+	// level of the request.
+	DomainEncode = "Encode"
+
+	// DomainDo represents an error that has occurred at the Do, or
+	// execution phase of the request.
+	DomainDo = "Do"
+
+	// DomainDecode represents an error that has occured at the Decode
+	// phase of the request.
+	DomainDecode = "Decode"
+)
+
+// TransportError represents an Error occurred in the Client transport level.
+type TransportError struct {
 	// Domain represents the domain of the error encountered.
 	// Simply, this refers to the phase in which the error was
 	// generated

--- a/transport/http/err.go
+++ b/transport/http/err.go
@@ -37,6 +37,6 @@ type TransportError struct {
 }
 
 // Error implements the error interface
-func (e Err) Error() string {
+func (e TransportError) Error() string {
 	return fmt.Sprintf("%s: %s", e.Domain, e.Err)
 }

--- a/transport/http/err.go
+++ b/transport/http/err.go
@@ -1,0 +1,22 @@
+package http
+
+import (
+	"fmt"
+)
+
+// Err represents an Error occurred in the Client transport level.
+type Err struct {
+	// Domain represents the domain of the error encountered.
+	// Simply, this refers to the phase in which the error was
+	// generated
+	Domain string
+
+	// Err references the underlying error that caused this error
+	// overall.
+	Err error
+}
+
+// Error implements the error interface
+func (e Err) Error() string {
+	return fmt.Sprintf("%s: %s", e.Domain, e.Err)
+}

--- a/transport/http/err_test.go
+++ b/transport/http/err_test.go
@@ -37,7 +37,7 @@ func TestClientEndpointEncodeError(t *testing.T) {
 		t.Error("err == nil")
 	}
 
-	e, ok := err.(httptransport.Err)
+	e, ok := err.(httptransport.TransportError)
 	if !ok {
 		t.Error("err is not of type github.com/go-kit/kit/transport/http.Err")
 	}
@@ -49,7 +49,7 @@ func TestClientEndpointEncodeError(t *testing.T) {
 
 func ExampleErrOutput() {
 	sampleErr := errors.New("Oh no, an error")
-	err := httptransport.Err{"Do", sampleErr}
+	err := httptransport.TransportError{"Do", sampleErr}
 	fmt.Println(err)
 	// Output:
 	// Do: Oh no, an error

--- a/transport/http/err_test.go
+++ b/transport/http/err_test.go
@@ -5,23 +5,18 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"testing"
 
 	"golang.org/x/net/context"
 
-	transporthttp "github.com/go-kit/kit/transport/http"
-
-	"testing"
+	httptransport "github.com/go-kit/kit/transport/http"
 )
 
 func TestClientEndpointEncodeError(t *testing.T) {
 	var (
 		sampleErr = errors.New("Oh no, an error")
-		enc       = func(r *http.Request, request interface{}) error {
-			return sampleErr
-		}
-		dec = func(r *http.Response) (response interface{}, err error) {
-			return nil, nil
-		}
+		enc       = func(r *http.Request, request interface{}) error { return sampleErr }
+		dec       = func(r *http.Response) (response interface{}, err error) { return nil, nil }
 	)
 
 	u := &url.URL{
@@ -30,7 +25,7 @@ func TestClientEndpointEncodeError(t *testing.T) {
 		Path:   "/does/not/matter",
 	}
 
-	c := transporthttp.NewClient(
+	c := httptransport.NewClient(
 		"GET",
 		u,
 		enc,
@@ -39,25 +34,22 @@ func TestClientEndpointEncodeError(t *testing.T) {
 
 	_, err := c.Endpoint()(context.Background(), nil)
 	if err == nil {
-		t.Log("err == nil")
-		t.Fail()
+		t.Error("err == nil")
 	}
 
-	e, ok := err.(transporthttp.Err)
+	e, ok := err.(httptransport.Err)
 	if !ok {
-		t.Log("err is not of type github.com/go-kit/kit/transport/http.Err")
-		t.Fail()
+		t.Error("err is not of type github.com/go-kit/kit/transport/http.Err")
 	}
 
-	if e.Err != sampleErr {
-		t.Logf("e.Err != sampleErr, %s vs %s", e.Err, sampleErr)
-		t.Fail()
+	if want, have := sampleErr, e.Err; want != have {
+		t.Error("want %v, have %v", want, have)
 	}
 }
 
 func ExampleErrOutput() {
 	sampleErr := errors.New("Oh no, an error")
-	err := transporthttp.Err{"Do", sampleErr}
+	err := httptransport.Err{"Do", sampleErr}
 	fmt.Println(err)
 	// Output:
 	// Do: Oh no, an error

--- a/transport/http/err_test.go
+++ b/transport/http/err_test.go
@@ -1,0 +1,64 @@
+package http_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/context"
+
+	transporthttp "github.com/go-kit/kit/transport/http"
+
+	"testing"
+)
+
+func TestClientEndpointEncodeError(t *testing.T) {
+	var (
+		sampleErr = errors.New("Oh no, an error")
+		enc       = func(r *http.Request, request interface{}) error {
+			return sampleErr
+		}
+		dec = func(r *http.Response) (response interface{}, err error) {
+			return nil, nil
+		}
+	)
+
+	u := &url.URL{
+		Scheme: "https",
+		Host:   "localhost",
+		Path:   "/does/not/matter",
+	}
+
+	c := transporthttp.NewClient(
+		"GET",
+		u,
+		enc,
+		dec,
+	)
+
+	_, err := c.Endpoint()(context.Background(), nil)
+	if err == nil {
+		t.Log("err == nil")
+		t.Fail()
+	}
+
+	e, ok := err.(transporthttp.Err)
+	if !ok {
+		t.Log("err is not of type github.com/go-kit/kit/transport/http.Err")
+		t.Fail()
+	}
+
+	if e.Err != sampleErr {
+		t.Logf("e.Err != sampleErr, %s vs %s", e.Err, sampleErr)
+		t.Fail()
+	}
+}
+
+func ExampleErrOutput() {
+	sampleErr := errors.New("Oh no, an error")
+	err := transporthttp.Err{"Do", sampleErr}
+	fmt.Println(err)
+	// Output:
+	// Do: Oh no, an error
+}

--- a/transport/http/err_test.go
+++ b/transport/http/err_test.go
@@ -39,11 +39,11 @@ func TestClientEndpointEncodeError(t *testing.T) {
 
 	e, ok := err.(httptransport.TransportError)
 	if !ok {
-		t.Error("err is not of type github.com/go-kit/kit/transport/http.Err")
+		t.Fatal("err is not of type github.com/go-kit/kit/transport/http.Err")
 	}
 
 	if want, have := sampleErr, e.Err; want != have {
-		t.Error("want %v, have %v", want, have)
+		t.Errorf("want %v, have %v", want, have)
 	}
 }
 


### PR DESCRIPTION
This PR references issue https://github.com/go-kit/kit/issues/231

Create a new Err type that is able to represent the domain of the
error, as well as maintain a reference to the underlying error for
user reference.

Add test to ensure that the error formats in a similar way to the
previous errors being returned.

Add test to ensure that the new Err type is being returned from
Client.Endpoint when a failure occurs instead of an anonymous
errors.New error.