### PR TITLE
Stop using gopkg.in for stack package.

### DIFF
--- a/log/log_test.go
+++ b/log/log_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-kit/kit/log"
-	"gopkg.in/stack.v1"
+	"github.com/go-stack/stack"
 )
 
 func TestContext(t *testing.T) {

--- a/log/value.go
+++ b/log/value.go
@@ -3,7 +3,7 @@ package log
 import (
 	"time"
 
-	"gopkg.in/stack.v1"
+	"github.com/go-stack/stack"
 )
 
 // A Valuer generates a log value. When passed to Context.With in a value


### PR DESCRIPTION
The latest release of [github.com/go-stack/stack](https://github.com/go-stack/stack) has an updated release policy that no longer recommends use of gopkg.in.

See #197 for discussion.