### PR TITLE
Zipkin NewChildSpan bugfix

### DIFF
--- a/tracing/zipkin/span.go
+++ b/tracing/zipkin/span.go
@@ -272,6 +272,9 @@ func NewChildSpan(ctx context.Context, collector Collector, methodName string, o
 		traceID:      span.traceID,
 		spanID:       newID(),
 		parentSpanID: span.spanID,
+		debug:        span.debug,
+		sampled:      span.sampled,
+		runSampler:   span.runSampler,
 	}
 	childSpan.Annotate(ClientSend)
 	for _, option := range options {


### PR DESCRIPTION
NewChildSpan did not properly take into account the sampling and debug
settings from the parent span.