### PR TITLE
transport/http: change error and encoder definitions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -170,7 +170,7 @@ func main() {
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
-func decodeUppercaseRequest(r *http.Request) (interface{}, error) {
+func decodeUppercaseRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var request uppercaseRequest
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ func decodeUppercaseRequest(r *http.Request) (interface{}, error) {
 	return request, nil
 }
 
-func decodeCountRequest(r *http.Request) (interface{}, error) {
+func decodeCountRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var request countRequest
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
@@ -186,7 +186,7 @@ func decodeCountRequest(r *http.Request) (interface{}, error) {
 	return request, nil
 }
 
-func encodeResponse(w http.ResponseWriter, response interface{}) error {
+func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	return json.NewEncoder(w).Encode(response)
 }
 ```

--- a/examples/addsvc/server/encode_decode.go
+++ b/examples/addsvc/server/encode_decode.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+
+	"golang.org/x/net/context"
 )
 
 // DecodeSumRequest decodes the request from the provided HTTP request, simply
 // by JSON decoding from the request body. It's designed to be used in
 // transport/http.Server.
-func DecodeSumRequest(r *http.Request) (interface{}, error) {
+func DecodeSumRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var request SumRequest
 	err := json.NewDecoder(r.Body).Decode(&request)
 	return &request, err
@@ -19,14 +21,14 @@ func DecodeSumRequest(r *http.Request) (interface{}, error) {
 // EncodeSumResponse encodes the response to the provided HTTP response
 // writer, simply by JSON encoding to the writer. It's designed to be used in
 // transport/http.Server.
-func EncodeSumResponse(w http.ResponseWriter, response interface{}) error {
+func EncodeSumResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	return json.NewEncoder(w).Encode(response)
 }
 
 // DecodeConcatRequest decodes the request from the provided HTTP request,
 // simply by JSON decoding from the request body. It's designed to be used in
 // transport/http.Server.
-func DecodeConcatRequest(r *http.Request) (interface{}, error) {
+func DecodeConcatRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var request ConcatRequest
 	err := json.NewDecoder(r.Body).Decode(&request)
 	return &request, err
@@ -35,14 +37,14 @@ func DecodeConcatRequest(r *http.Request) (interface{}, error) {
 // EncodeConcatResponse encodes the response to the provided HTTP response
 // writer, simply by JSON encoding to the writer. It's designed to be used in
 // transport/http.Server.
-func EncodeConcatResponse(w http.ResponseWriter, response interface{}) error {
+func EncodeConcatResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	return json.NewEncoder(w).Encode(response)
 }
 
 // EncodeSumRequest encodes the request to the provided HTTP request, simply
 // by JSON encoding to the request body. It's designed to be used in
 // transport/http.Client.
-func EncodeSumRequest(r *http.Request, request interface{}) error {
+func EncodeSumRequest(_ context.Context, r *http.Request, request interface{}) error {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(request); err != nil {
 		return err
@@ -54,7 +56,7 @@ func EncodeSumRequest(r *http.Request, request interface{}) error {
 // DecodeSumResponse decodes the response from the provided HTTP response,
 // simply by JSON decoding from the response body. It's designed to be used in
 // transport/http.Client.
-func DecodeSumResponse(resp *http.Response) (interface{}, error) {
+func DecodeSumResponse(_ context.Context, resp *http.Response) (interface{}, error) {
 	var response SumResponse
 	err := json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
@@ -63,7 +65,7 @@ func DecodeSumResponse(resp *http.Response) (interface{}, error) {
 // EncodeConcatRequest encodes the request to the provided HTTP request,
 // simply by JSON encoding to the request body. It's designed to be used in
 // transport/http.Client.
-func EncodeConcatRequest(r *http.Request, request interface{}) error {
+func EncodeConcatRequest(_ context.Context, r *http.Request, request interface{}) error {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(request); err != nil {
 		return err
@@ -75,7 +77,7 @@ func EncodeConcatRequest(r *http.Request, request interface{}) error {
 // DecodeConcatResponse decodes the response from the provided HTTP response,
 // simply by JSON decoding from the response body. It's designed to be used in
 // transport/http.Client.
-func DecodeConcatResponse(resp *http.Response) (interface{}, error) {
+func DecodeConcatResponse(_ context.Context, resp *http.Response) (interface{}, error) {
 	var response ConcatResponse
 	err := json.NewDecoder(resp.Body).Decode(&response)
 	return response, err

--- a/examples/apigateway/main.go
+++ b/examples/apigateway/main.go
@@ -173,12 +173,12 @@ func httpFactory(ctx context.Context, method, path string) loadbalancer.Factory 
 	}
 }
 
-func passEncode(r *http.Request, request interface{}) error {
+func passEncode(_ context.Context, r *http.Request, request interface{}) error {
 	r.Body = request.(io.ReadCloser)
 	return nil
 }
 
-func passDecode(r *http.Response) (interface{}, error) {
+func passDecode(_ context.Context, r *http.Response) (interface{}, error) {
 	return ioutil.ReadAll(r.Body)
 }
 

--- a/examples/profilesvc/transport.go
+++ b/examples/profilesvc/transport.go
@@ -255,7 +255,7 @@ func codeFrom(err error) int {
 	case errAlreadyExists, errInconsistentIDs:
 		return stdhttp.StatusBadRequest
 	default:
-		if e, ok := err.(kithttp.TransportError); ok {
+		if e, ok := err.(kithttp.Error); ok {
 			switch e.Domain {
 			case kithttp.DomainDecode:
 				return stdhttp.StatusBadRequest

--- a/examples/shipping/booking/transport.go
+++ b/examples/shipping/booking/transport.go
@@ -88,7 +88,7 @@ func MakeHandler(ctx context.Context, bs Service, logger kitlog.Logger) http.Han
 
 var errBadRoute = errors.New("bad route")
 
-func decodeBookCargoRequest(r *http.Request) (interface{}, error) {
+func decodeBookCargoRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var body struct {
 		Origin          string    `json:"origin"`
 		Destination     string    `json:"destination"`
@@ -106,7 +106,7 @@ func decodeBookCargoRequest(r *http.Request) (interface{}, error) {
 	}, nil
 }
 
-func decodeLoadCargoRequest(r *http.Request) (interface{}, error) {
+func decodeLoadCargoRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	vars := mux.Vars(r)
 	id, ok := vars["id"]
 	if !ok {
@@ -115,7 +115,7 @@ func decodeLoadCargoRequest(r *http.Request) (interface{}, error) {
 	return loadCargoRequest{ID: cargo.TrackingID(id)}, nil
 }
 
-func decodeRequestRoutesRequest(r *http.Request) (interface{}, error) {
+func decodeRequestRoutesRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	vars := mux.Vars(r)
 	id, ok := vars["id"]
 	if !ok {
@@ -124,7 +124,7 @@ func decodeRequestRoutesRequest(r *http.Request) (interface{}, error) {
 	return requestRoutesRequest{ID: cargo.TrackingID(id)}, nil
 }
 
-func decodeAssignToRouteRequest(r *http.Request) (interface{}, error) {
+func decodeAssignToRouteRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	vars := mux.Vars(r)
 	id, ok := vars["id"]
 	if !ok {
@@ -142,7 +142,7 @@ func decodeAssignToRouteRequest(r *http.Request) (interface{}, error) {
 	}, nil
 }
 
-func decodeChangeDestinationRequest(r *http.Request) (interface{}, error) {
+func decodeChangeDestinationRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	vars := mux.Vars(r)
 	id, ok := vars["id"]
 	if !ok {
@@ -163,17 +163,17 @@ func decodeChangeDestinationRequest(r *http.Request) (interface{}, error) {
 	}, nil
 }
 
-func decodeListCargosRequest(r *http.Request) (interface{}, error) {
+func decodeListCargosRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	return listCargosRequest{}, nil
 }
 
-func decodeListLocationsRequest(r *http.Request) (interface{}, error) {
+func decodeListLocationsRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	return listLocationsRequest{}, nil
 }
 
-func encodeResponse(w http.ResponseWriter, response interface{}) error {
+func encodeResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
 	if e, ok := response.(errorer); ok && e.error() != nil {
-		encodeError(w, e.error())
+		encodeError(ctx, e.error(), w)
 		return nil
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -185,7 +185,7 @@ type errorer interface {
 }
 
 // encode errors from business-logic
-func encodeError(w http.ResponseWriter, err error) {
+func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch err {
 	case cargo.ErrUnknown:
 		w.WriteHeader(http.StatusNotFound)

--- a/examples/shipping/handling/transport.go
+++ b/examples/shipping/handling/transport.go
@@ -37,7 +37,7 @@ func MakeHandler(ctx context.Context, hs Service, logger kitlog.Logger) http.Han
 	return r
 }
 
-func decodeRegisterIncidentRequest(r *http.Request) (interface{}, error) {
+func decodeRegisterIncidentRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var body struct {
 		CompletionTime time.Time `json:"completion_time"`
 		TrackingID     string    `json:"tracking_id"`
@@ -70,9 +70,9 @@ func stringToEventType(s string) cargo.HandlingEventType {
 	return types[s]
 }
 
-func encodeResponse(w http.ResponseWriter, response interface{}) error {
+func encodeResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
 	if e, ok := response.(errorer); ok && e.error() != nil {
-		encodeError(w, e.error())
+		encodeError(ctx, e.error(), w)
 		return nil
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -84,7 +84,7 @@ type errorer interface {
 }
 
 // encode errors from business-logic
-func encodeError(w http.ResponseWriter, err error) {
+func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch err {
 	case cargo.ErrUnknown:
 		w.WriteHeader(http.StatusNotFound)

--- a/examples/shipping/routing/proxying.go
+++ b/examples/shipping/routing/proxying.go
@@ -97,7 +97,7 @@ func makeFetchRoutesEndpoint(ctx context.Context, instance string) endpoint.Endp
 	).Endpoint()
 }
 
-func decodeFetchRoutesResponse(resp *http.Response) (interface{}, error) {
+func decodeFetchRoutesResponse(_ context.Context, resp *http.Response) (interface{}, error) {
 	var response fetchRoutesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return nil, err
@@ -105,7 +105,7 @@ func decodeFetchRoutesResponse(resp *http.Response) (interface{}, error) {
 	return response, nil
 }
 
-func encodeFetchRoutesRequest(r *http.Request, request interface{}) error {
+func encodeFetchRoutesRequest(_ context.Context, r *http.Request, request interface{}) error {
 	req := request.(fetchRoutesRequest)
 
 	vals := r.URL.Query()

--- a/examples/shipping/tracking/transport.go
+++ b/examples/shipping/tracking/transport.go
@@ -35,7 +35,7 @@ func MakeHandler(ctx context.Context, ts Service, logger kitlog.Logger) http.Han
 	return r
 }
 
-func decodeTrackCargoRequest(r *http.Request) (interface{}, error) {
+func decodeTrackCargoRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	vars := mux.Vars(r)
 	id, ok := vars["id"]
 	if !ok {
@@ -44,9 +44,9 @@ func decodeTrackCargoRequest(r *http.Request) (interface{}, error) {
 	return trackCargoRequest{ID: id}, nil
 }
 
-func encodeResponse(w http.ResponseWriter, response interface{}) error {
+func encodeResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
 	if e, ok := response.(errorer); ok && e.error() != nil {
-		encodeError(w, e.error())
+		encodeError(ctx, e.error(), w)
 		return nil
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -58,7 +58,7 @@ type errorer interface {
 }
 
 // encode errors from business-logic
-func encodeError(w http.ResponseWriter, err error) {
+func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch err {
 	case cargo.ErrUnknown:
 		w.WriteHeader(http.StatusNotFound)

--- a/examples/stringsvc1/main.go
+++ b/examples/stringsvc1/main.go
@@ -74,7 +74,7 @@ func makeCountEndpoint(svc StringService) endpoint.Endpoint {
 	}
 }
 
-func decodeUppercaseRequest(r *http.Request) (interface{}, error) {
+func decodeUppercaseRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var request uppercaseRequest
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func decodeUppercaseRequest(r *http.Request) (interface{}, error) {
 	return request, nil
 }
 
-func decodeCountRequest(r *http.Request) (interface{}, error) {
+func decodeCountRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var request countRequest
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func decodeCountRequest(r *http.Request) (interface{}, error) {
 	return request, nil
 }
 
-func encodeResponse(w http.ResponseWriter, response interface{}) error {
+func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	return json.NewEncoder(w).Encode(response)
 }
 

--- a/examples/stringsvc2/transport.go
+++ b/examples/stringsvc2/transport.go
@@ -28,7 +28,7 @@ func makeCountEndpoint(svc StringService) endpoint.Endpoint {
 	}
 }
 
-func decodeUppercaseRequest(r *http.Request) (interface{}, error) {
+func decodeUppercaseRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var request uppercaseRequest
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func decodeUppercaseRequest(r *http.Request) (interface{}, error) {
 	return request, nil
 }
 
-func decodeCountRequest(r *http.Request) (interface{}, error) {
+func decodeCountRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var request countRequest
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func decodeCountRequest(r *http.Request) (interface{}, error) {
 	return request, nil
 }
 
-func encodeResponse(w http.ResponseWriter, response interface{}) error {
+func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	return json.NewEncoder(w).Encode(response)
 }
 

--- a/examples/stringsvc3/transport.go
+++ b/examples/stringsvc3/transport.go
@@ -30,7 +30,7 @@ func makeCountEndpoint(svc StringService) endpoint.Endpoint {
 	}
 }
 
-func decodeUppercaseRequest(r *http.Request) (interface{}, error) {
+func decodeUppercaseRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var request uppercaseRequest
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func decodeUppercaseRequest(r *http.Request) (interface{}, error) {
 	return request, nil
 }
 
-func decodeCountRequest(r *http.Request) (interface{}, error) {
+func decodeCountRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	var request countRequest
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, err
@@ -46,7 +46,7 @@ func decodeCountRequest(r *http.Request) (interface{}, error) {
 	return request, nil
 }
 
-func decodeUppercaseResponse(r *http.Response) (interface{}, error) {
+func decodeUppercaseResponse(_ context.Context, r *http.Response) (interface{}, error) {
 	var response uppercaseResponse
 	if err := json.NewDecoder(r.Body).Decode(&response); err != nil {
 		return nil, err
@@ -54,11 +54,11 @@ func decodeUppercaseResponse(r *http.Response) (interface{}, error) {
 	return response, nil
 }
 
-func encodeResponse(w http.ResponseWriter, response interface{}) error {
+func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	return json.NewEncoder(w).Encode(response)
 }
 
-func encodeRequest(r *http.Request, request interface{}) error {
+func encodeRequest(_ context.Context, r *http.Request, request interface{}) error {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(request); err != nil {
 		return err

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -74,11 +74,11 @@ func (c Client) Endpoint() endpoint.Endpoint {
 
 		req, err := http.NewRequest(c.method, c.tgt.String(), nil)
 		if err != nil {
-			return nil, TransportError{DomainNewRequest, err}
+			return nil, TransportError{Domain: DomainNewRequest, Err: err}
 		}
 
-		if err = c.enc(req, request); err != nil {
-			return nil, TransportError{DomainEncode, err}
+		if err = c.enc(ctx, req, request); err != nil {
+			return nil, TransportError{Domain: DomainEncode, Err: err}
 		}
 
 		for _, f := range c.before {
@@ -87,15 +87,15 @@ func (c Client) Endpoint() endpoint.Endpoint {
 
 		resp, err := ctxhttp.Do(ctx, c.client, req)
 		if err != nil {
-			return nil, TransportError{DomainDo, err}
+			return nil, TransportError{Domain: DomainDo, Err: err}
 		}
 		if !c.bufferedStream {
 			defer resp.Body.Close()
 		}
 
-		response, err := c.dec(resp)
+		response, err := c.dec(ctx, resp)
 		if err != nil {
-			return nil, TransportError{DomainDecode, err}
+			return nil, TransportError{Domain: DomainDecode, Err: err}
 		}
 
 		return response, nil

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -74,11 +74,11 @@ func (c Client) Endpoint() endpoint.Endpoint {
 
 		req, err := http.NewRequest(c.method, c.tgt.String(), nil)
 		if err != nil {
-			return nil, TransportError{Domain: DomainNewRequest, Err: err}
+			return nil, Error{Domain: DomainNewRequest, Err: err}
 		}
 
 		if err = c.enc(ctx, req, request); err != nil {
-			return nil, TransportError{Domain: DomainEncode, Err: err}
+			return nil, Error{Domain: DomainEncode, Err: err}
 		}
 
 		for _, f := range c.before {
@@ -87,7 +87,7 @@ func (c Client) Endpoint() endpoint.Endpoint {
 
 		resp, err := ctxhttp.Do(ctx, c.client, req)
 		if err != nil {
-			return nil, TransportError{Domain: DomainDo, Err: err}
+			return nil, Error{Domain: DomainDo, Err: err}
 		}
 		if !c.bufferedStream {
 			defer resp.Body.Close()
@@ -95,7 +95,7 @@ func (c Client) Endpoint() endpoint.Endpoint {
 
 		response, err := c.dec(ctx, resp)
 		if err != nil {
-			return nil, TransportError{Domain: DomainDecode, Err: err}
+			return nil, Error{Domain: DomainDecode, Err: err}
 		}
 
 		return response, nil

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -21,8 +21,8 @@ type TestResponse struct {
 func TestHTTPClient(t *testing.T) {
 	var (
 		testbody = "testbody"
-		encode   = func(*http.Request, interface{}) error { return nil }
-		decode   = func(r *http.Response) (interface{}, error) {
+		encode   = func(context.Context, *http.Request, interface{}) error { return nil }
+		decode   = func(_ context.Context, r *http.Response) (interface{}, error) {
 			buffer := make([]byte, len(testbody))
 			r.Body.Read(buffer)
 			return TestResponse{r.Body, string(buffer)}, nil
@@ -85,8 +85,8 @@ func TestHTTPClient(t *testing.T) {
 func TestHTTPClientBufferedStream(t *testing.T) {
 	var (
 		testbody = "testbody"
-		encode   = func(*http.Request, interface{}) error { return nil }
-		decode   = func(r *http.Response) (interface{}, error) {
+		encode   = func(context.Context, *http.Request, interface{}) error { return nil }
+		decode   = func(_ context.Context, r *http.Response) (interface{}, error) {
 			return TestResponse{r.Body, ""}, nil
 		}
 	)

--- a/transport/http/encode_decode.go
+++ b/transport/http/encode_decode.go
@@ -1,27 +1,31 @@
 package http
 
-import "net/http"
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
 
 // DecodeRequestFunc extracts a user-domain request object from an HTTP
 // request object. It's designed to be used in HTTP servers, for server-side
 // endpoints. One straightforward DecodeRequestFunc could be something that
 // JSON decodes from the request body to the concrete response type.
-type DecodeRequestFunc func(*http.Request) (request interface{}, err error)
+type DecodeRequestFunc func(context.Context, *http.Request) (request interface{}, err error)
 
 // EncodeRequestFunc encodes the passed request object into the HTTP request
 // object. It's designed to be used in HTTP clients, for client-side
 // endpoints. One straightforward EncodeRequestFunc could something that JSON
 // encodes the object directly to the request body.
-type EncodeRequestFunc func(*http.Request, interface{}) error
+type EncodeRequestFunc func(context.Context, *http.Request, interface{}) error
 
 // EncodeResponseFunc encodes the passed response object to the HTTP response
 // writer. It's designed to be used in HTTP servers, for server-side
 // endpoints. One straightforward EncodeResponseFunc could be something that
 // JSON encodes the object directly to the response body.
-type EncodeResponseFunc func(http.ResponseWriter, interface{}) error
+type EncodeResponseFunc func(context.Context, http.ResponseWriter, interface{}) error
 
 // DecodeResponseFunc extracts a user-domain response object from an HTTP
 // response object. It's designed to be used in HTTP clients, for client-side
 // endpoints. One straightforward DecodeResponseFunc could be something that
 // JSON decodes from the response body to the concrete response type.
-type DecodeResponseFunc func(*http.Response) (response interface{}, err error)
+type DecodeResponseFunc func(context.Context, *http.Response) (response interface{}, err error)

--- a/transport/http/err.go
+++ b/transport/http/err.go
@@ -4,39 +4,30 @@ import (
 	"fmt"
 )
 
-// These are some pre-generated constants that can be used to check against
-// for the DomainErrors.
 const (
-	// DomainNewRequest represents an error at the Request Generation
-	// Scope.
+	// DomainNewRequest is an error during request generation.
 	DomainNewRequest = "NewRequest"
 
-	// DomainEncode represent an error that has occurred at the Encode
-	// level of the request.
+	// DomainEncode is an error during request or response encoding.
 	DomainEncode = "Encode"
 
-	// DomainDo represents an error that has occurred at the Do, or
-	// execution phase of the request.
+	// DomainDo is an error during the execution phase of the request.
 	DomainDo = "Do"
 
-	// DomainDecode represents an error that has occurred at the Decode
-	// phase of the request.
+	// DomainDecode is an error during request or response decoding.
 	DomainDecode = "Decode"
 )
 
-// TransportError represents an Error occurred in the Client transport level.
+// TransportError is an error that occurred at some phase within the transport.
 type TransportError struct {
-	// Domain represents the domain of the error encountered.
-	// Simply, this refers to the phase in which the error was
-	// generated
+	// Domain is the phase in which the error was generated.
 	Domain string
 
-	// Err references the underlying error that caused this error
-	// overall.
+	// Err is the concrete error.
 	Err error
 }
 
-// Error implements the error interface
+// Error implements the error interface.
 func (e TransportError) Error() string {
 	return fmt.Sprintf("%s: %s", e.Domain, e.Err)
 }

--- a/transport/http/err.go
+++ b/transport/http/err.go
@@ -18,8 +18,8 @@ const (
 	DomainDecode = "Decode"
 )
 
-// TransportError is an error that occurred at some phase within the transport.
-type TransportError struct {
+// Error is an error that occurred at some phase within the transport.
+type Error struct {
 	// Domain is the phase in which the error was generated.
 	Domain string
 
@@ -28,6 +28,6 @@ type TransportError struct {
 }
 
 // Error implements the error interface.
-func (e TransportError) Error() string {
+func (e Error) Error() string {
 	return fmt.Sprintf("%s: %s", e.Domain, e.Err)
 }

--- a/transport/http/err_test.go
+++ b/transport/http/err_test.go
@@ -49,7 +49,7 @@ func TestClientEndpointEncodeError(t *testing.T) {
 
 func ExampleErrOutput() {
 	sampleErr := errors.New("Oh no, an error")
-	err := httptransport.TransportError{"Do", sampleErr}
+	err := httptransport.TransportError{Domain: httptransport.DomainDo, Err: sampleErr}
 	fmt.Println(err)
 	// Output:
 	// Do: Oh no, an error

--- a/transport/http/err_test.go
+++ b/transport/http/err_test.go
@@ -37,9 +37,9 @@ func TestClientEndpointEncodeError(t *testing.T) {
 		t.Fatal("err == nil")
 	}
 
-	e, ok := err.(httptransport.TransportError)
+	e, ok := err.(httptransport.Error)
 	if !ok {
-		t.Fatal("err is not of type github.com/go-kit/kit/transport/http.Err")
+		t.Fatal("err is not of type github.com/go-kit/kit/transport/http.Error")
 	}
 
 	if want, have := sampleErr, e.Err; want != have {
@@ -48,9 +48,9 @@ func TestClientEndpointEncodeError(t *testing.T) {
 }
 
 func ExampleErrOutput() {
-	sampleErr := errors.New("Oh no, an error")
-	err := httptransport.TransportError{Domain: httptransport.DomainDo, Err: sampleErr}
+	sampleErr := errors.New("oh no, an error")
+	err := httptransport.Error{Domain: httptransport.DomainDo, Err: sampleErr}
 	fmt.Println(err)
 	// Output:
-	// Do: Oh no, an error
+	// Do: oh no, an error
 }

--- a/transport/http/err_test.go
+++ b/transport/http/err_test.go
@@ -15,8 +15,8 @@ import (
 func TestClientEndpointEncodeError(t *testing.T) {
 	var (
 		sampleErr = errors.New("Oh no, an error")
-		enc       = func(r *http.Request, request interface{}) error { return sampleErr }
-		dec       = func(r *http.Response) (response interface{}, err error) { return nil, nil }
+		enc       = func(context.Context, *http.Request, interface{}) error { return sampleErr }
+		dec       = func(context.Context, *http.Response) (interface{}, error) { return nil, nil }
 	)
 
 	u := &url.URL{

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -83,7 +83,7 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ctx = f(ctx, r)
 	}
 
-	request, err := s.dec(r)
+	request, err := s.dec(ctx, r)
 	if err != nil {
 		s.logger.Log("err", err)
 		s.errorEncoder(ctx, TransportError{Domain: DomainDecode, Err: err}, w)
@@ -101,7 +101,7 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		f(ctx, w)
 	}
 
-	if err := s.enc(w, response); err != nil {
+	if err := s.enc(ctx, w, response); err != nil {
 		s.logger.Log("err", err)
 		s.errorEncoder(ctx, TransportError{Domain: DomainEncode, Err: err}, w)
 		return

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -60,7 +60,7 @@ func TestServerBadEncode(t *testing.T) {
 func TestServerErrorEncoder(t *testing.T) {
 	errTeapot := errors.New("teapot")
 	code := func(err error) int {
-		if e, ok := err.(httptransport.TransportError); ok && e.Err == errTeapot {
+		if e, ok := err.(httptransport.Error); ok && e.Err == errTeapot {
 			return http.StatusTeapot
 		}
 		return http.StatusInternalServerError

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -16,8 +16,8 @@ func TestServerBadDecode(t *testing.T) {
 	handler := httptransport.NewServer(
 		context.Background(),
 		func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
-		func(*http.Request) (interface{}, error) { return struct{}{}, errors.New("dang") },
-		func(http.ResponseWriter, interface{}) error { return nil },
+		func(context.Context, *http.Request) (interface{}, error) { return struct{}{}, errors.New("dang") },
+		func(context.Context, http.ResponseWriter, interface{}) error { return nil },
 	)
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -31,8 +31,8 @@ func TestServerBadEndpoint(t *testing.T) {
 	handler := httptransport.NewServer(
 		context.Background(),
 		func(context.Context, interface{}) (interface{}, error) { return struct{}{}, errors.New("dang") },
-		func(*http.Request) (interface{}, error) { return struct{}{}, nil },
-		func(http.ResponseWriter, interface{}) error { return nil },
+		func(context.Context, *http.Request) (interface{}, error) { return struct{}{}, nil },
+		func(context.Context, http.ResponseWriter, interface{}) error { return nil },
 	)
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -46,8 +46,8 @@ func TestServerBadEncode(t *testing.T) {
 	handler := httptransport.NewServer(
 		context.Background(),
 		func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
-		func(*http.Request) (interface{}, error) { return struct{}{}, nil },
-		func(http.ResponseWriter, interface{}) error { return errors.New("dang") },
+		func(context.Context, *http.Request) (interface{}, error) { return struct{}{}, nil },
+		func(context.Context, http.ResponseWriter, interface{}) error { return errors.New("dang") },
 	)
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -68,8 +68,8 @@ func TestServerErrorEncoder(t *testing.T) {
 	handler := httptransport.NewServer(
 		context.Background(),
 		func(context.Context, interface{}) (interface{}, error) { return struct{}{}, errTeapot },
-		func(*http.Request) (interface{}, error) { return struct{}{}, nil },
-		func(http.ResponseWriter, interface{}) error { return nil },
+		func(context.Context, *http.Request) (interface{}, error) { return struct{}{}, nil },
+		func(context.Context, http.ResponseWriter, interface{}) error { return nil },
 		httptransport.ServerErrorEncoder(func(_ context.Context, err error, w http.ResponseWriter) { w.WriteHeader(code(err)) }),
 	)
 	server := httptest.NewServer(handler)
@@ -100,8 +100,8 @@ func testServer(t *testing.T) (cancel, step func(), resp <-chan *http.Response) 
 		handler       = httptransport.NewServer(
 			ctx,
 			endpoint,
-			func(*http.Request) (interface{}, error) { return struct{}{}, nil },
-			func(http.ResponseWriter, interface{}) error { return nil },
+			func(context.Context, *http.Request) (interface{}, error) { return struct{}{}, nil },
+			func(context.Context, http.ResponseWriter, interface{}) error { return nil },
 			httptransport.ServerBefore(func(ctx context.Context, r *http.Request) context.Context { return ctx }),
 			httptransport.ServerAfter(func(ctx context.Context, w http.ResponseWriter) { return }),
 		)


### PR DESCRIPTION
- ErrorEndoer takes a context.Context as a first parameter
- Encoders and decoders also take context.Context as first parameter
- Refactor BadRequestError as a TransportError
- Rename TransportError to Error, to reduce stuttering
- Improve defaultErrorEncoder behavior

@thomshutt does this look good for you?