### PR TITLE
OpenTracing integration

### DIFF
--- a/examples/addsvc/client/grpc/factory.go
+++ b/examples/addsvc/client/grpc/factory.go
@@ -13,9 +13,10 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
-// SumEndpointFactory transforms GRPC host:port strings into Endpoints that call the Sum method on a GRPC server
+// MakeSumEndpointFactory returns a loadbalancer.Factory that transforms GRPC
+// host:port strings into Endpoints that call the Sum method on a GRPC server
 // at that address.
-func NewSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
+func MakeSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
 	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
 		cc, err := grpc.Dial(instance, grpc.WithInsecure())
 		return grpctransport.NewClient(
@@ -30,9 +31,10 @@ func NewSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
 	}
 }
 
-// ConcatEndpointFactory transforms GRPC host:port strings into Endpoints that call the Concat method on a GRPC server
-// at that address.
-func NewConcatEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
+// MakeConcatEndpointFactory returns a loadbalancer.Factory that transforms
+// GRPC host:port strings into Endpoints that call the Concat method on a GRPC
+// server at that address.
+func MakeConcatEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
 	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
 		cc, err := grpc.Dial(instance, grpc.WithInsecure())
 		return grpctransport.NewClient(

--- a/examples/addsvc/client/grpc/factory.go
+++ b/examples/addsvc/client/grpc/factory.go
@@ -3,15 +3,15 @@ package grpc
 import (
 	"io"
 
+	kitot "github.com/go-kit/kit/tracing/opentracing"
+	"github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 
 	"github.com/go-kit/kit/endpoint"
 	"github.com/go-kit/kit/examples/addsvc/pb"
 	"github.com/go-kit/kit/loadbalancer"
 	"github.com/go-kit/kit/log"
-	kitot "github.com/go-kit/kit/tracing/opentracing"
 	grpctransport "github.com/go-kit/kit/transport/grpc"
-	"github.com/opentracing/opentracing-go"
 )
 
 // MakeSumEndpointFactory returns a loadbalancer.Factory that transforms GRPC

--- a/examples/addsvc/client/grpc/factory.go
+++ b/examples/addsvc/client/grpc/factory.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/go-kit/kit/examples/addsvc/pb"
 	"github.com/go-kit/kit/loadbalancer"
+	"github.com/go-kit/kit/log"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	grpctransport "github.com/go-kit/kit/transport/grpc"
 	"github.com/opentracing/opentracing-go"
@@ -16,7 +17,7 @@ import (
 // MakeSumEndpointFactory returns a loadbalancer.Factory that transforms GRPC
 // host:port strings into Endpoints that call the Sum method on a GRPC server
 // at that address.
-func MakeSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
+func MakeSumEndpointFactory(tracer opentracing.Tracer, tracingLogger log.Logger) loadbalancer.Factory {
 	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
 		cc, err := grpc.Dial(instance, grpc.WithInsecure())
 		return grpctransport.NewClient(
@@ -26,7 +27,7 @@ func MakeSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
 			encodeSumRequest,
 			decodeSumResponse,
 			pb.SumReply{},
-			grpctransport.SetClientBefore(kitot.ToGRPCRequest(tracer)),
+			grpctransport.SetClientBefore(kitot.ToGRPCRequest(tracer, tracingLogger)),
 		).Endpoint(), cc, err
 	}
 }
@@ -34,7 +35,7 @@ func MakeSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
 // MakeConcatEndpointFactory returns a loadbalancer.Factory that transforms
 // GRPC host:port strings into Endpoints that call the Concat method on a GRPC
 // server at that address.
-func MakeConcatEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
+func MakeConcatEndpointFactory(tracer opentracing.Tracer, tracingLogger log.Logger) loadbalancer.Factory {
 	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
 		cc, err := grpc.Dial(instance, grpc.WithInsecure())
 		return grpctransport.NewClient(
@@ -44,7 +45,7 @@ func MakeConcatEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
 			encodeConcatRequest,
 			decodeConcatResponse,
 			pb.ConcatReply{},
-			grpctransport.SetClientBefore(kitot.ToGRPCRequest(tracer)),
+			grpctransport.SetClientBefore(kitot.ToGRPCRequest(tracer, tracingLogger)),
 		).Endpoint(), cc, err
 	}
 }

--- a/examples/addsvc/client/grpc/factory.go
+++ b/examples/addsvc/client/grpc/factory.go
@@ -7,33 +7,42 @@ import (
 
 	"github.com/go-kit/kit/endpoint"
 	"github.com/go-kit/kit/examples/addsvc/pb"
+	"github.com/go-kit/kit/loadbalancer"
+	kitot "github.com/go-kit/kit/tracing/opentracing"
 	grpctransport "github.com/go-kit/kit/transport/grpc"
+	"github.com/opentracing/opentracing-go"
 )
 
 // SumEndpointFactory transforms GRPC host:port strings into Endpoints that call the Sum method on a GRPC server
 // at that address.
-func SumEndpointFactory(instance string) (endpoint.Endpoint, io.Closer, error) {
-	cc, err := grpc.Dial(instance, grpc.WithInsecure())
-	return grpctransport.NewClient(
-		cc,
-		"Add",
-		"Sum",
-		encodeSumRequest,
-		decodeSumResponse,
-		pb.SumReply{},
-	).Endpoint(), cc, err
+func NewSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
+	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
+		cc, err := grpc.Dial(instance, grpc.WithInsecure())
+		return grpctransport.NewClient(
+			cc,
+			"Add",
+			"Sum",
+			encodeSumRequest,
+			decodeSumResponse,
+			pb.SumReply{},
+			grpctransport.SetClientBefore(kitot.ToGRPCRequest(tracer)),
+		).Endpoint(), cc, err
+	}
 }
 
 // ConcatEndpointFactory transforms GRPC host:port strings into Endpoints that call the Concat method on a GRPC server
 // at that address.
-func ConcatEndpointFactory(instance string) (endpoint.Endpoint, io.Closer, error) {
-	cc, err := grpc.Dial(instance, grpc.WithInsecure())
-	return grpctransport.NewClient(
-		cc,
-		"Add",
-		"Concat",
-		encodeConcatRequest,
-		decodeConcatResponse,
-		pb.ConcatReply{},
-	).Endpoint(), cc, err
+func NewConcatEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
+	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
+		cc, err := grpc.Dial(instance, grpc.WithInsecure())
+		return grpctransport.NewClient(
+			cc,
+			"Add",
+			"Concat",
+			encodeConcatRequest,
+			decodeConcatResponse,
+			pb.ConcatReply{},
+			grpctransport.SetClientBefore(kitot.ToGRPCRequest(tracer)),
+		).Endpoint(), cc, err
+	}
 }

--- a/examples/addsvc/client/httpjson/factory.go
+++ b/examples/addsvc/client/httpjson/factory.go
@@ -12,11 +12,11 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
-// SumEndpointFactory generates a Factory that transforms an http url into an
-// Endpoint.
+// MakeSumEndpointFactory generates a Factory that transforms an http url into
+// an Endpoint.
 //
 // The path of the url is reset to /sum.
-func NewSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
+func MakeSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
 	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
 		sumURL, err := url.Parse(instance)
 		if err != nil {
@@ -37,11 +37,11 @@ func NewSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
 	}
 }
 
-// NewConcatEndpointFactory generates a Factory that transforms an http url
+// MakeConcatEndpointFactory generates a Factory that transforms an http url
 // into an Endpoint.
 //
 // The path of the url is reset to /concat.
-func NewConcatEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
+func MakeConcatEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
 	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
 		concatURL, err := url.Parse(instance)
 		if err != nil {

--- a/examples/addsvc/client/httpjson/factory.go
+++ b/examples/addsvc/client/httpjson/factory.go
@@ -4,13 +4,14 @@ import (
 	"io"
 	"net/url"
 
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/go-kit/kit/endpoint"
 	"github.com/go-kit/kit/examples/addsvc/server"
 	"github.com/go-kit/kit/loadbalancer"
 	"github.com/go-kit/kit/log"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	httptransport "github.com/go-kit/kit/transport/http"
-	"github.com/opentracing/opentracing-go"
 )
 
 // MakeSumEndpointFactory generates a Factory that transforms an http url into

--- a/examples/addsvc/client/httpjson/factory.go
+++ b/examples/addsvc/client/httpjson/factory.go
@@ -6,45 +6,58 @@ import (
 
 	"github.com/go-kit/kit/endpoint"
 	"github.com/go-kit/kit/examples/addsvc/server"
+	"github.com/go-kit/kit/loadbalancer"
+	kitot "github.com/go-kit/kit/tracing/opentracing"
 	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/opentracing/opentracing-go"
 )
 
-// SumEndpointFactory transforms a http url into an Endpoint.
+// SumEndpointFactory generates a Factory that transforms an http url into an
+// Endpoint.
+//
 // The path of the url is reset to /sum.
-func SumEndpointFactory(instance string) (endpoint.Endpoint, io.Closer, error) {
-	sumURL, err := url.Parse(instance)
-	if err != nil {
-		return nil, nil, err
+func NewSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
+	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
+		sumURL, err := url.Parse(instance)
+		if err != nil {
+			return nil, nil, err
+		}
+		sumURL.Path = "/sum"
+
+		client := httptransport.NewClient(
+			"GET",
+			sumURL,
+			server.EncodeSumRequest,
+			server.DecodeSumResponse,
+			httptransport.SetClient(nil),
+			httptransport.SetClientBefore(kitot.ToHTTPRequest(tracer)),
+		)
+
+		return client.Endpoint(), nil, nil
 	}
-	sumURL.Path = "/sum"
-
-	client := httptransport.NewClient(
-		"GET",
-		sumURL,
-		server.EncodeSumRequest,
-		server.DecodeSumResponse,
-		httptransport.SetClient(nil),
-	)
-
-	return client.Endpoint(), nil, nil
 }
 
-// ConcatEndpointFactory transforms a http url into an Endpoint.
+// NewConcatEndpointFactory generates a Factory that transforms an http url
+// into an Endpoint.
+//
 // The path of the url is reset to /concat.
-func ConcatEndpointFactory(instance string) (endpoint.Endpoint, io.Closer, error) {
-	concatURL, err := url.Parse(instance)
-	if err != nil {
-		return nil, nil, err
+func NewConcatEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
+	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
+		concatURL, err := url.Parse(instance)
+		if err != nil {
+			return nil, nil, err
+		}
+		concatURL.Path = "/concat"
+
+		client := httptransport.NewClient(
+			"GET",
+			concatURL,
+			server.EncodeConcatRequest,
+			server.DecodeConcatResponse,
+			httptransport.SetClient(nil),
+			httptransport.SetClientBefore(kitot.ToHTTPRequest(tracer)),
+		)
+
+		return client.Endpoint(), nil, nil
 	}
-	concatURL.Path = "/concat"
-
-	client := httptransport.NewClient(
-		"GET",
-		concatURL,
-		server.EncodeConcatRequest,
-		server.DecodeConcatResponse,
-		httptransport.SetClient(nil),
-	)
-
-	return client.Endpoint(), nil, nil
 }

--- a/examples/addsvc/client/httpjson/factory.go
+++ b/examples/addsvc/client/httpjson/factory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/go-kit/kit/examples/addsvc/server"
 	"github.com/go-kit/kit/loadbalancer"
+	"github.com/go-kit/kit/log"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/opentracing/opentracing-go"
@@ -16,7 +17,7 @@ import (
 // an Endpoint.
 //
 // The path of the url is reset to /sum.
-func MakeSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
+func MakeSumEndpointFactory(tracer opentracing.Tracer, tracingLogger log.Logger) loadbalancer.Factory {
 	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
 		sumURL, err := url.Parse(instance)
 		if err != nil {
@@ -30,7 +31,7 @@ func MakeSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
 			server.EncodeSumRequest,
 			server.DecodeSumResponse,
 			httptransport.SetClient(nil),
-			httptransport.SetClientBefore(kitot.ToHTTPRequest(tracer)),
+			httptransport.SetClientBefore(kitot.ToHTTPRequest(tracer, tracingLogger)),
 		)
 
 		return client.Endpoint(), nil, nil
@@ -41,7 +42,7 @@ func MakeSumEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
 // into an Endpoint.
 //
 // The path of the url is reset to /concat.
-func MakeConcatEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
+func MakeConcatEndpointFactory(tracer opentracing.Tracer, tracingLogger log.Logger) loadbalancer.Factory {
 	return func(instance string) (endpoint.Endpoint, io.Closer, error) {
 		concatURL, err := url.Parse(instance)
 		if err != nil {
@@ -55,7 +56,7 @@ func MakeConcatEndpointFactory(tracer opentracing.Tracer) loadbalancer.Factory {
 			server.EncodeConcatRequest,
 			server.DecodeConcatResponse,
 			httptransport.SetClient(nil),
-			httptransport.SetClientBefore(kitot.ToHTTPRequest(tracer)),
+			httptransport.SetClientBefore(kitot.ToHTTPRequest(tracer, tracingLogger)),
 		)
 
 		return client.Endpoint(), nil, nil

--- a/examples/addsvc/client/main.go
+++ b/examples/addsvc/client/main.go
@@ -85,8 +85,8 @@ func main() {
 	switch *transport {
 	case "grpc":
 		instances = strings.Split(*grpcAddrs, ",")
-		sumFactory = grpcclient.NewSumEndpointFactory(tracer)
-		concatFactory = grpcclient.NewConcatEndpointFactory(tracer)
+		sumFactory = grpcclient.MakeSumEndpointFactory(tracer)
+		concatFactory = grpcclient.MakeConcatEndpointFactory(tracer)
 
 	case "httpjson":
 		instances = strings.Split(*httpAddrs, ",")
@@ -95,8 +95,8 @@ func main() {
 				instances[i] = "http://" + rawurl
 			}
 		}
-		sumFactory = httpjsonclient.NewSumEndpointFactory(tracer)
-		concatFactory = httpjsonclient.NewConcatEndpointFactory(tracer)
+		sumFactory = httpjsonclient.MakeSumEndpointFactory(tracer)
+		concatFactory = httpjsonclient.MakeConcatEndpointFactory(tracer)
 
 	case "netrpc":
 		instances = strings.Split(*netrpcAddrs, ",")

--- a/examples/addsvc/client/main.go
+++ b/examples/addsvc/client/main.go
@@ -9,7 +9,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lightstep/lightstep-tracer-go"
+	"github.com/opentracing/opentracing-go"
+	appdashot "github.com/sourcegraph/appdash/opentracing"
 	"golang.org/x/net/context"
+	"sourcegraph.com/sourcegraph/appdash"
 
 	"github.com/go-kit/kit/endpoint"
 	grpcclient "github.com/go-kit/kit/examples/addsvc/client/grpc"
@@ -20,10 +24,6 @@ import (
 	"github.com/go-kit/kit/loadbalancer/static"
 	"github.com/go-kit/kit/log"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
-	"github.com/lightstep/lightstep-tracer-go"
-	"github.com/opentracing/opentracing-go"
-	appdashot "github.com/sourcegraph/appdash/opentracing"
-	"sourcegraph.com/sourcegraph/appdash"
 )
 
 func main() {

--- a/examples/addsvc/grpc_binding.go
+++ b/examples/addsvc/grpc_binding.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-kit/kit/examples/addsvc/pb"
 	"github.com/go-kit/kit/examples/addsvc/server"
 	servergrpc "github.com/go-kit/kit/examples/addsvc/server/grpc"
+	"github.com/go-kit/kit/log"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	"github.com/go-kit/kit/transport/grpc"
 	"github.com/opentracing/opentracing-go"
@@ -15,21 +16,21 @@ type grpcBinding struct {
 	sum, concat grpc.Handler
 }
 
-func newGRPCBinding(ctx context.Context, tracer opentracing.Tracer, svc server.AddService) grpcBinding {
+func newGRPCBinding(ctx context.Context, tracer opentracing.Tracer, svc server.AddService, tracingLogger log.Logger) grpcBinding {
 	return grpcBinding{
 		sum: grpc.NewServer(
 			ctx,
 			kitot.TraceServer(tracer, "sum")(makeSumEndpoint(svc)),
 			servergrpc.DecodeSumRequest,
 			servergrpc.EncodeSumResponse,
-			grpc.ServerBefore(kitot.FromGRPCRequest(tracer, "")),
+			grpc.ServerBefore(kitot.FromGRPCRequest(tracer, "", tracingLogger)),
 		),
 		concat: grpc.NewServer(
 			ctx,
 			kitot.TraceServer(tracer, "concat")(makeConcatEndpoint(svc)),
 			servergrpc.DecodeConcatRequest,
 			servergrpc.EncodeConcatResponse,
-			grpc.ServerBefore(kitot.FromGRPCRequest(tracer, "")),
+			grpc.ServerBefore(kitot.FromGRPCRequest(tracer, "", tracingLogger)),
 		),
 	}
 }

--- a/examples/addsvc/grpc_binding.go
+++ b/examples/addsvc/grpc_binding.go
@@ -3,13 +3,14 @@ package main
 import (
 	"golang.org/x/net/context"
 
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/go-kit/kit/examples/addsvc/pb"
 	"github.com/go-kit/kit/examples/addsvc/server"
 	servergrpc "github.com/go-kit/kit/examples/addsvc/server/grpc"
 	"github.com/go-kit/kit/log"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	"github.com/go-kit/kit/transport/grpc"
-	"github.com/opentracing/opentracing-go"
 )
 
 type grpcBinding struct {

--- a/examples/addsvc/main.go
+++ b/examples/addsvc/main.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	kitot "github.com/go-kit/kit/tracing/opentracing"
 	"github.com/lightstep/lightstep-tracer-go"
 	"github.com/opentracing/opentracing-go"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
@@ -32,6 +31,7 @@ import (
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/expvar"
 	"github.com/go-kit/kit/metrics/prometheus"
+	kitot "github.com/go-kit/kit/tracing/opentracing"
 	"github.com/go-kit/kit/tracing/zipkin"
 	httptransport "github.com/go-kit/kit/transport/http"
 )

--- a/examples/addsvc/service.go
+++ b/examples/addsvc/service.go
@@ -10,7 +10,9 @@ import (
 
 type pureAddService struct{}
 
-func (pureAddService) Sum(a, b int) int { return a + b }
+func (pureAddService) Sum(a, b int) int {
+	return a + b
+}
 
 func (pureAddService) Concat(a, b string) string { return a + b }
 

--- a/examples/addsvc/service.go
+++ b/examples/addsvc/service.go
@@ -10,9 +10,7 @@ import (
 
 type pureAddService struct{}
 
-func (pureAddService) Sum(a, b int) int {
-	return a + b
-}
+func (pureAddService) Sum(a, b int) int { return a + b }
 
 func (pureAddService) Concat(a, b string) string { return a + b }
 

--- a/examples/apigateway/main.go
+++ b/examples/apigateway/main.go
@@ -78,8 +78,8 @@ func main() {
 		factory loadbalancer.Factory
 	}{
 		"addsvc": {
-			{path: "/api/addsvc/concat", factory: grpc.MakeConcatEndpointFactory(opentracing.GlobalTracer())},
-			{path: "/api/addsvc/sum", factory: grpc.MakeSumEndpointFactory(opentracing.GlobalTracer())},
+			{path: "/api/addsvc/concat", factory: grpc.MakeConcatEndpointFactory(opentracing.GlobalTracer(), nil)},
+			{path: "/api/addsvc/sum", factory: grpc.MakeSumEndpointFactory(opentracing.GlobalTracer(), nil)},
 		},
 		"stringsvc": {
 			{path: "/api/stringsvc/uppercase", factory: httpFactory(ctx, "GET", "uppercase/")},

--- a/examples/apigateway/main.go
+++ b/examples/apigateway/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/hashicorp/consul/api"
+	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 
 	"github.com/go-kit/kit/endpoint"
@@ -77,8 +78,8 @@ func main() {
 		factory loadbalancer.Factory
 	}{
 		"addsvc": {
-			{path: "/api/addsvc/concat", factory: grpc.ConcatEndpointFactory},
-			{path: "/api/addsvc/sum", factory: grpc.SumEndpointFactory},
+			{path: "/api/addsvc/concat", factory: grpc.NewConcatEndpointFactory(opentracing.GlobalTracer())},
+			{path: "/api/addsvc/sum", factory: grpc.NewSumEndpointFactory(opentracing.GlobalTracer())},
 		},
 		"stringsvc": {
 			{path: "/api/stringsvc/uppercase", factory: httpFactory(ctx, "GET", "uppercase/")},

--- a/examples/apigateway/main.go
+++ b/examples/apigateway/main.go
@@ -78,8 +78,8 @@ func main() {
 		factory loadbalancer.Factory
 	}{
 		"addsvc": {
-			{path: "/api/addsvc/concat", factory: grpc.NewConcatEndpointFactory(opentracing.GlobalTracer())},
-			{path: "/api/addsvc/sum", factory: grpc.NewSumEndpointFactory(opentracing.GlobalTracer())},
+			{path: "/api/addsvc/concat", factory: grpc.MakeConcatEndpointFactory(opentracing.GlobalTracer())},
+			{path: "/api/addsvc/sum", factory: grpc.MakeSumEndpointFactory(opentracing.GlobalTracer())},
 		},
 		"stringsvc": {
 			{path: "/api/stringsvc/uppercase", factory: httpFactory(ctx, "GET", "uppercase/")},

--- a/tracing/opentracing/endpoint.go
+++ b/tracing/opentracing/endpoint.go
@@ -22,9 +22,9 @@ func TraceServer(tracer opentracing.Tracer, operationName string) endpoint.Middl
 			} else {
 				serverSpan.SetOperationName(operationName)
 			}
+			defer serverSpan.Finish()
 			otext.SpanKind.Set(serverSpan, otext.SpanKindRPCServer)
 			ctx = opentracing.ContextWithSpan(ctx, serverSpan)
-			defer serverSpan.Finish()
 			return next(ctx, request)
 		}
 	}
@@ -40,9 +40,9 @@ func TraceClient(tracer opentracing.Tracer, operationName string) endpoint.Middl
 				OperationName: operationName,
 				Parent:        parentSpan, // may be nil
 			})
+			defer clientSpan.Finish()
 			otext.SpanKind.Set(clientSpan, otext.SpanKindRPCClient)
 			ctx = opentracing.ContextWithSpan(ctx, clientSpan)
-			defer clientSpan.Finish()
 			return next(ctx, request)
 		}
 	}

--- a/tracing/opentracing/endpoint.go
+++ b/tracing/opentracing/endpoint.go
@@ -3,6 +3,7 @@ package opentracing
 import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/opentracing/opentracing-go"
+	otext "github.com/opentracing/opentracing-go/ext"
 	"golang.org/x/net/context"
 )
 
@@ -21,7 +22,7 @@ func TraceServer(tracer opentracing.Tracer, operationName string) endpoint.Middl
 			} else {
 				serverSpan.SetOperationName(operationName)
 			}
-			serverSpan.SetTag("span.kind", "server")
+			otext.SpanKind.Set(serverSpan, otext.SpanKindRPCServer)
 			ctx = opentracing.ContextWithSpan(ctx, serverSpan)
 			defer serverSpan.Finish()
 			return next(ctx, request)
@@ -39,7 +40,7 @@ func TraceClient(tracer opentracing.Tracer, operationName string) endpoint.Middl
 				OperationName: operationName,
 				Parent:        parentSpan, // may be nil
 			})
-			clientSpan.SetTag("span.kind", "client")
+			otext.SpanKind.Set(clientSpan, otext.SpanKindRPCClient)
 			ctx = opentracing.ContextWithSpan(ctx, clientSpan)
 			defer clientSpan.Finish()
 			return next(ctx, request)

--- a/tracing/opentracing/endpoint.go
+++ b/tracing/opentracing/endpoint.go
@@ -1,10 +1,11 @@
 package opentracing
 
 import (
-	"github.com/go-kit/kit/endpoint"
 	"github.com/opentracing/opentracing-go"
 	otext "github.com/opentracing/opentracing-go/ext"
 	"golang.org/x/net/context"
+
+	"github.com/go-kit/kit/endpoint"
 )
 
 // TraceServer returns a Middleware that wraps the `next` Endpoint in an

--- a/tracing/opentracing/endpoint.go
+++ b/tracing/opentracing/endpoint.go
@@ -1,0 +1,48 @@
+package opentracing
+
+import (
+	"github.com/go-kit/kit/endpoint"
+	"github.com/opentracing/opentracing-go"
+	"golang.org/x/net/context"
+)
+
+// TraceServer returns a Middleware that wraps the `next` Endpoint in an
+// OpenTracing Span called `operationName`.
+//
+// If `ctx` already has a Span, it is re-used and the operation name is
+// overwritten. If `ctx` does not yet have a Span, one is created here.
+func TraceServer(tracer opentracing.Tracer, operationName string) endpoint.Middleware {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, request interface{}) (interface{}, error) {
+			serverSpan := opentracing.SpanFromContext(ctx)
+			if serverSpan == nil {
+				// All we can do is create a new root span.
+				serverSpan = tracer.StartSpan(operationName)
+			} else {
+				serverSpan.SetOperationName(operationName)
+			}
+			serverSpan.SetTag("span.kind", "server")
+			ctx = opentracing.ContextWithSpan(ctx, serverSpan)
+			defer serverSpan.Finish()
+			return next(ctx, request)
+		}
+	}
+}
+
+// TraceClient returns a Middleware that wraps the `next` Endpoint in an
+// OpenTracing Span called `operationName`.
+func TraceClient(tracer opentracing.Tracer, operationName string) endpoint.Middleware {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, request interface{}) (interface{}, error) {
+			parentSpan := opentracing.SpanFromContext(ctx)
+			clientSpan := tracer.StartSpanWithOptions(opentracing.StartSpanOptions{
+				OperationName: operationName,
+				Parent:        parentSpan, // may be nil
+			})
+			clientSpan.SetTag("span.kind", "client")
+			ctx = opentracing.ContextWithSpan(ctx, clientSpan)
+			defer clientSpan.Finish()
+			return next(ctx, request)
+		}
+	}
+}

--- a/tracing/opentracing/endpoint_test.go
+++ b/tracing/opentracing/endpoint_test.go
@@ -3,11 +3,12 @@ package opentracing_test
 import (
 	"testing"
 
-	"github.com/go-kit/kit/endpoint"
-	kitot "github.com/go-kit/kit/tracing/opentracing"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"golang.org/x/net/context"
+
+	"github.com/go-kit/kit/endpoint"
+	kitot "github.com/go-kit/kit/tracing/opentracing"
 )
 
 func TestTraceServer(t *testing.T) {

--- a/tracing/opentracing/endpoint_test.go
+++ b/tracing/opentracing/endpoint_test.go
@@ -1,0 +1,95 @@
+package opentracing_test
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/endpoint"
+	kitot "github.com/go-kit/kit/tracing/opentracing"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"golang.org/x/net/context"
+)
+
+func TestTraceServer(t *testing.T) {
+	tracer := mocktracer.New()
+
+	// Initialize the ctx with a nameless Span.
+	contextSpan := tracer.StartSpan("").(*mocktracer.MockSpan)
+	ctx := opentracing.ContextWithSpan(context.Background(), contextSpan)
+
+	var innerEndpoint endpoint.Endpoint
+	innerEndpoint = func(context.Context, interface{}) (interface{}, error) {
+		return struct{}{}, nil
+	}
+	tracedEndpoint := kitot.TraceServer(tracer, "testOp")(innerEndpoint)
+	if _, err := tracedEndpoint(ctx, struct{}{}); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := 1, len(tracer.FinishedSpans); want != have {
+		t.Fatalf("Want %v span(s), found %v", want, have)
+	}
+
+	endpointSpan := tracer.FinishedSpans[0]
+	// Test that the op name is updated
+	if want, have := "testOp", endpointSpan.OperationName; want != have {
+		t.Fatalf("Want %q, have %q", want, have)
+	}
+	// ... and that the ID is unmodified.
+	if want, have := contextSpan.SpanID, endpointSpan.SpanID; want != have {
+		t.Errorf("Want SpanID %q, have %q", want, have)
+	}
+}
+
+func TestTraceServerNoContextSpan(t *testing.T) {
+	tracer := mocktracer.New()
+
+	var innerEndpoint endpoint.Endpoint
+	innerEndpoint = func(context.Context, interface{}) (interface{}, error) {
+		return struct{}{}, nil
+	}
+	tracedEndpoint := kitot.TraceServer(tracer, "testOp")(innerEndpoint)
+	// Empty/background context:
+	if _, err := tracedEndpoint(context.Background(), struct{}{}); err != nil {
+		t.Fatal(err)
+	}
+	// tracedEndpoint created a new Span:
+	if want, have := 1, len(tracer.FinishedSpans); want != have {
+		t.Fatalf("Want %v span(s), found %v", want, have)
+	}
+
+	endpointSpan := tracer.FinishedSpans[0]
+	if want, have := "testOp", endpointSpan.OperationName; want != have {
+		t.Fatalf("Want %q, have %q", want, have)
+	}
+}
+
+func TestTraceClient(t *testing.T) {
+	tracer := mocktracer.New()
+
+	// Initialize the ctx with a parent Span.
+	parentSpan := tracer.StartSpan("parent").(*mocktracer.MockSpan)
+	defer parentSpan.Finish()
+	ctx := opentracing.ContextWithSpan(context.Background(), parentSpan)
+
+	var innerEndpoint endpoint.Endpoint
+	innerEndpoint = func(context.Context, interface{}) (interface{}, error) {
+		return struct{}{}, nil
+	}
+	tracedEndpoint := kitot.TraceClient(tracer, "testOp")(innerEndpoint)
+	if _, err := tracedEndpoint(ctx, struct{}{}); err != nil {
+		t.Fatal(err)
+	}
+	// tracedEndpoint created a new Span:
+	if want, have := 1, len(tracer.FinishedSpans); want != have {
+		t.Fatalf("Want %v span(s), found %v", want, have)
+	}
+
+	endpointSpan := tracer.FinishedSpans[0]
+	if want, have := "testOp", endpointSpan.OperationName; want != have {
+		t.Fatalf("Want %q, have %q", want, have)
+	}
+	// ... and that the parent ID is set appropriately.
+	if want, have := parentSpan.SpanID, endpointSpan.ParentID; want != have {
+		t.Errorf("Want ParentID %q, have %q", want, have)
+	}
+}

--- a/tracing/opentracing/grpc.go
+++ b/tracing/opentracing/grpc.go
@@ -1,10 +1,11 @@
 package opentracing
 
 import (
-	"github.com/go-kit/kit/log"
 	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/go-kit/kit/log"
 )
 
 // ToGRPCRequest returns a grpc RequestFunc that injects an OpenTracing Span

--- a/tracing/opentracing/grpc.go
+++ b/tracing/opentracing/grpc.go
@@ -1,0 +1,56 @@
+package opentracing
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/metadata"
+)
+
+// ToGRPCRequest returns a grpc RequestFunc that injects an OpenTracing Span
+// found in `ctx` into the grpc Metadata. If no such Span can be found, the
+// RequestFunc is a noop.
+func ToGRPCRequest(tracer opentracing.Tracer) func(ctx context.Context, md *metadata.MD) context.Context {
+	return func(ctx context.Context, md *metadata.MD) context.Context {
+		if span := opentracing.SpanFromContext(ctx); span != nil {
+			// There's nothing we can do with an error here.
+			_ = tracer.Inject(span, opentracing.TextMap, metadataReaderWriter{md})
+		}
+		return ctx
+	}
+}
+
+// FromGRPCRequest returns a grpc RequestFunc that tries to join with an
+// OpenTracing trace found in `req` and starts a new Span called
+// `operationName` accordingly. If no trace could be found in `req`, the Span
+// will be a trace root. The Span is incorporated in the returned Context and
+// can be retrieved with opentracing.SpanFromContext(ctx).
+func FromGRPCRequest(tracer opentracing.Tracer, operationName string) func(ctx context.Context, md *metadata.MD) context.Context {
+	return func(ctx context.Context, md *metadata.MD) context.Context {
+		span, err := tracer.Join(operationName, opentracing.TextMap, metadataReaderWriter{md})
+		if err != nil || span == nil {
+			span = tracer.StartSpan(operationName)
+		}
+		return opentracing.ContextWithSpan(ctx, span)
+	}
+}
+
+// A type that conforms to opentracing.TextMapReader and
+// opentracing.TextMapWriter.
+type metadataReaderWriter struct {
+	*metadata.MD
+}
+
+func (w metadataReaderWriter) Set(key, val string) {
+	(*w.MD)[key] = append((*w.MD)[key], val)
+}
+
+func (w metadataReaderWriter) ForeachKey(handler func(key, val string) error) error {
+	for k, vals := range *w.MD {
+		for _, v := range vals {
+			if err := handler(k, v); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/tracing/opentracing/grpc_test.go
+++ b/tracing/opentracing/grpc_test.go
@@ -1,0 +1,55 @@
+package opentracing_test
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+
+	kitot "github.com/go-kit/kit/tracing/opentracing"
+	"github.com/go-kit/kit/transport/grpc"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"golang.org/x/net/context"
+)
+
+func TestTraceGRPCRequestRoundtrip(t *testing.T) {
+	tracer := mocktracer.New()
+
+	// Initialize the ctx with a Span to inject.
+	beforeSpan := tracer.StartSpan("to_inject").(*mocktracer.MockSpan)
+	defer beforeSpan.Finish()
+	beforeCtx := opentracing.ContextWithSpan(context.Background(), beforeSpan)
+
+	var toGRPCFunc grpc.RequestFunc = kitot.ToGRPCRequest(tracer)
+	md := metadata.Pairs()
+	// Call the RequestFunc.
+	afterCtx := toGRPCFunc(beforeCtx, &md)
+
+	// The Span should not have changed.
+	afterSpan := opentracing.SpanFromContext(afterCtx)
+	if beforeSpan != afterSpan {
+		t.Errorf("Should not swap in a new span")
+	}
+
+	// No spans should have finished yet.
+	if want, have := 0, len(tracer.FinishedSpans); want != have {
+		t.Errorf("Want %v span(s), found %v", want, have)
+	}
+
+	// Use FromGRPCRequest to verify that we can join with the trace given MD.
+	var fromGRPCFunc grpc.RequestFunc = kitot.FromGRPCRequest(tracer, "joined")
+	joinCtx := fromGRPCFunc(afterCtx, &md)
+	joinedSpan := opentracing.SpanFromContext(joinCtx).(*mocktracer.MockSpan)
+
+	if joinedSpan.SpanID == beforeSpan.SpanID {
+		t.Error("SpanID should have changed", joinedSpan.SpanID, beforeSpan.SpanID)
+	}
+
+	// Check that the parent/child relationship is as expected for the joined span.
+	if want, have := beforeSpan.SpanID, joinedSpan.ParentID; want != have {
+		t.Errorf("Want ParentID %q, have %q", want, have)
+	}
+	if want, have := "joined", joinedSpan.OperationName; want != have {
+		t.Errorf("Want %q, have %q", want, have)
+	}
+}

--- a/tracing/opentracing/grpc_test.go
+++ b/tracing/opentracing/grpc_test.go
@@ -3,13 +3,13 @@ package opentracing_test
 import (
 	"testing"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	"github.com/go-kit/kit/transport/grpc"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/mocktracer"
-	"golang.org/x/net/context"
 )
 
 func TestTraceGRPCRequestRoundtrip(t *testing.T) {

--- a/tracing/opentracing/http.go
+++ b/tracing/opentracing/http.go
@@ -1,0 +1,40 @@
+package opentracing
+
+import (
+	"net/http"
+
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/opentracing/opentracing-go"
+	"golang.org/x/net/context"
+)
+
+// ToHTTPRequest returns an http RequestFunc that injects an OpenTracing Span
+// found in `ctx` into the http headers. If no such Span can be found, the
+// RequestFunc is a noop.
+func ToHTTPRequest(tracer opentracing.Tracer) kithttp.RequestFunc {
+	return func(ctx context.Context, req *http.Request) context.Context {
+		// Try to find a Span in the Context.
+		if span := opentracing.SpanFromContext(ctx); span != nil {
+			// There's nothing we can do with any errors here.
+			_ = tracer.Inject(span, opentracing.TextMap, opentracing.HTTPHeaderTextMapCarrier(req.Header))
+		}
+		return ctx
+	}
+}
+
+// FromHTTPRequest returns an http RequestFunc that tries to join with an
+// OpenTracing trace found in `req` and starts a new Span called
+// `operationName` accordingly. If no trace could be found in `req`, the Span
+// will be a trace root. The Span is incorporated in the returned Context and
+// can be retrieved with opentracing.SpanFromContext(ctx).
+func FromHTTPRequest(tracer opentracing.Tracer, operationName string) kithttp.RequestFunc {
+	return func(ctx context.Context, req *http.Request) context.Context {
+		// Try to join to a trace propagated in `req`. There's nothing we can
+		// do with any errors here, so we ignore them.
+		span, _ := tracer.Join(operationName, opentracing.TextMap, opentracing.HTTPHeaderTextMapCarrier(req.Header))
+		if span == nil {
+			span = opentracing.StartSpan(operationName)
+		}
+		return opentracing.ContextWithSpan(ctx, span)
+	}
+}

--- a/tracing/opentracing/http.go
+++ b/tracing/opentracing/http.go
@@ -1,22 +1,47 @@
 package opentracing
 
 import (
+	"net"
 	"net/http"
+	"strconv"
 
+	"github.com/go-kit/kit/log"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"golang.org/x/net/context"
 )
 
 // ToHTTPRequest returns an http RequestFunc that injects an OpenTracing Span
 // found in `ctx` into the http headers. If no such Span can be found, the
 // RequestFunc is a noop.
-func ToHTTPRequest(tracer opentracing.Tracer) kithttp.RequestFunc {
+//
+// The logger is used to report errors and may be nil.
+func ToHTTPRequest(tracer opentracing.Tracer, logger log.Logger) kithttp.RequestFunc {
 	return func(ctx context.Context, req *http.Request) context.Context {
 		// Try to find a Span in the Context.
 		if span := opentracing.SpanFromContext(ctx); span != nil {
+			// Add standard OpenTracing tags.
+			ext.HTTPMethod.Set(span, req.URL.RequestURI())
+			host, portString, err := net.SplitHostPort(req.URL.Host)
+			if err == nil {
+				ext.PeerHostname.Set(span, host)
+				if port, err := strconv.Atoi(portString); err != nil {
+					ext.PeerPort.Set(span, uint16(port))
+				}
+			} else {
+				ext.PeerHostname.Set(span, req.URL.Host)
+			}
+
 			// There's nothing we can do with any errors here.
-			_ = tracer.Inject(span, opentracing.TextMap, opentracing.HTTPHeaderTextMapCarrier(req.Header))
+			err = tracer.Inject(
+				span,
+				opentracing.TextMap,
+				opentracing.HTTPHeaderTextMapCarrier(req.Header),
+			)
+			if err != nil && logger != nil {
+				logger.Log("msg", "Join failed", "err", err)
+			}
 		}
 		return ctx
 	}
@@ -27,11 +52,20 @@ func ToHTTPRequest(tracer opentracing.Tracer) kithttp.RequestFunc {
 // `operationName` accordingly. If no trace could be found in `req`, the Span
 // will be a trace root. The Span is incorporated in the returned Context and
 // can be retrieved with opentracing.SpanFromContext(ctx).
-func FromHTTPRequest(tracer opentracing.Tracer, operationName string) kithttp.RequestFunc {
+//
+// The logger is used to report errors and may be nil.
+func FromHTTPRequest(tracer opentracing.Tracer, operationName string, logger log.Logger) kithttp.RequestFunc {
 	return func(ctx context.Context, req *http.Request) context.Context {
 		// Try to join to a trace propagated in `req`. There's nothing we can
 		// do with any errors here, so we ignore them.
-		span, _ := tracer.Join(operationName, opentracing.TextMap, opentracing.HTTPHeaderTextMapCarrier(req.Header))
+		span, err := tracer.Join(
+			operationName,
+			opentracing.TextMap,
+			opentracing.HTTPHeaderTextMapCarrier(req.Header),
+		)
+		if err != nil && logger != nil {
+			logger.Log("msg", "Join failed", "err", err)
+		}
 		if span == nil {
 			span = opentracing.StartSpan(operationName)
 		}

--- a/tracing/opentracing/http.go
+++ b/tracing/opentracing/http.go
@@ -5,11 +5,12 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/go-kit/kit/log"
-	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"golang.org/x/net/context"
+
+	"github.com/go-kit/kit/log"
+	kithttp "github.com/go-kit/kit/transport/http"
 )
 
 // ToHTTPRequest returns an http RequestFunc that injects an OpenTracing Span

--- a/tracing/opentracing/http_test.go
+++ b/tracing/opentracing/http_test.go
@@ -4,11 +4,12 @@ import (
 	"net/http"
 	"testing"
 
-	kitot "github.com/go-kit/kit/tracing/opentracing"
-	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"golang.org/x/net/context"
+
+	kitot "github.com/go-kit/kit/tracing/opentracing"
+	kithttp "github.com/go-kit/kit/transport/http"
 )
 
 func TestTraceHTTPRequestRoundtrip(t *testing.T) {

--- a/tracing/opentracing/http_test.go
+++ b/tracing/opentracing/http_test.go
@@ -1,0 +1,54 @@
+package opentracing_test
+
+import (
+	"net/http"
+	"testing"
+
+	kitot "github.com/go-kit/kit/tracing/opentracing"
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"golang.org/x/net/context"
+)
+
+func TestTraceHTTPRequestRoundtrip(t *testing.T) {
+	tracer := mocktracer.New()
+
+	// Initialize the ctx with a Span to inject.
+	beforeSpan := tracer.StartSpan("to_inject").(*mocktracer.MockSpan)
+	defer beforeSpan.Finish()
+	beforeCtx := opentracing.ContextWithSpan(context.Background(), beforeSpan)
+
+	var toHTTPFunc kithttp.RequestFunc = kitot.ToHTTPRequest(tracer)
+	req, _ := http.NewRequest("GET", "http://test.biz/url", nil)
+	// Call the RequestFunc.
+	afterCtx := toHTTPFunc(beforeCtx, req)
+
+	// The Span should not have changed.
+	afterSpan := opentracing.SpanFromContext(afterCtx)
+	if beforeSpan != afterSpan {
+		t.Errorf("Should not swap in a new span")
+	}
+
+	// No spans should have finished yet.
+	if want, have := 0, len(tracer.FinishedSpans); want != have {
+		t.Errorf("Want %v span(s), found %v", want, have)
+	}
+
+	// Use FromHTTPRequest to verify that we can join with the trace given a req.
+	var fromHTTPFunc kithttp.RequestFunc = kitot.FromHTTPRequest(tracer, "joined")
+	joinCtx := fromHTTPFunc(afterCtx, req)
+	joinedSpan := opentracing.SpanFromContext(joinCtx).(*mocktracer.MockSpan)
+
+	if joinedSpan.SpanID == beforeSpan.SpanID {
+		t.Error("SpanID should have changed", joinedSpan.SpanID, beforeSpan.SpanID)
+	}
+
+	// Check that the parent/child relationship is as expected for the joined span.
+	if want, have := beforeSpan.SpanID, joinedSpan.ParentID; want != have {
+		t.Errorf("Want ParentID %q, have %q", want, have)
+	}
+	if want, have := "joined", joinedSpan.OperationName; want != have {
+		t.Errorf("Want %q, have %q", want, have)
+	}
+}


### PR DESCRIPTION
(See #237 for motivation and context)

# "Demo" (sic)
The `addsvc` in this PR uses the generic OpenTracing bindings for the httpjson and grpc transports, and in its `main()` it binds to either Appdash or LightStep (both of which are trivial to set up and have implementations of the Go OpenTracing API). As such, without changing any of the actual instrumentation beyond the `main()` function, both Appdash and LightStep are able to trace addsvc:

## Appdash

```
$ addsvc -appdash_hostport=localhost:7701 &
$ client -transport=grpc -appdash_hostport=localhost:7701 concat open tracing
```
![image](https://cloud.githubusercontent.com/assets/2251553/14947320/20d30592-0fe6-11e6-9239-4db9172c2976.png)

## LightStep

```
$ addsvc -lightstep_access_token=XXX &
$ client -transport=grpc -lightstep_access_token=XXX concat open tracing
```
![image](https://cloud.githubusercontent.com/assets/2251553/14947339/80c04ee2-0fe6-11e6-9d5b-fe1fd2a9158a.png)

# Misc notes

The default implementation of OpenTracing is a noop. As such, rather than forcing users to install these various pieces of middleware/etc, some of this instrumentation could be opt-out, or perhaps downright unavoidable. Again, if the programmer didn't bother binding to OpenTracing, there would be near-zero overhead to support the noop implementation.

Also, the existing Zipkin instrumentation is worth thinking through in more detail. There are major companies that have adopted OpenTracing and bound it to Zipkin internally, so we know it's possible to go that route. If there's interest, we could try to port the `tracing/zipkin` package to be a pure OpenTracing implementation. I don't know how many depend on its API already, though.

# Next steps

I'd like to get basic feedback about the direction. If there's enthusiasm, I can finish up the other transports, add real tests, and merge this in. If there are problems, I'd rather go through them now before finishing up all of the odds and ends.

- - - - - - - - -

Thanks for reviewing!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-kit/kit/247)
<!-- Reviewable:end -->
