### PR TITLE
Add filtered leveled logging and error promotion

### DIFF
--- a/log/levels/levels_test.go
+++ b/log/levels/levels_test.go
@@ -54,6 +54,99 @@ func TestModifiedLevels(t *testing.T) {
 	}
 }
 
+func TestFilteredLevels(t *testing.T) {
+	buf := bytes.Buffer{}
+	logger := levels.New(
+		log.NewLogfmtLogger(&buf),
+		levels.FilterLogLevel(levels.Warn),
+	)
+
+	debugValuerCalled := false
+	logger.Debug().Log("msg", "a debug log", "other", log.Valuer(func() interface{} { debugValuerCalled = true; return 42 }))
+	if want, have := "", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+	if debugValuerCalled {
+		t.Error("Evaluated valuer in a filtered debug log unnecessarily")
+	}
+
+	buf.Reset()
+	infoValuerCalled := false
+	logger.Info().Log("msg", "an info log", "other", log.Valuer(func() interface{} { debugValuerCalled = true; return 42 }))
+	if want, have := "", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+	if infoValuerCalled {
+		t.Error("Evaluated valuer in a filtered debug log unnecessarily")
+	}
+
+	buf.Reset()
+	logger.Warn().Log("msg", "a warning log")
+	if want, have := "level=warn msg=\"a warning log\"\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	buf.Reset()
+	logger.Error().Log("msg", "an error log")
+	if want, have := "level=error msg=\"an error log\"\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	buf.Reset()
+	logger.Crit().Log("msg", "a critical log")
+	if want, have := "level=crit msg=\"a critical log\"\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+}
+
+func TestErrorPromotion(t *testing.T) {
+	buf := bytes.Buffer{}
+	logger := levels.New(
+		log.NewLogfmtLogger(&buf),
+		levels.PromoteErrors(true),
+		levels.FilterLogLevel(levels.Error),
+	)
+	// Should promote past filtering.
+	logger.Debug().Log("error", "some error")
+	if want, have := "level=error error=\"some error\"\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	// Should not promote if log level is already higher than the error level.
+	buf.Reset()
+	logger.Crit().Log("error", "some error")
+	if want, have := "level=crit error=\"some error\"\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	buf.Reset()
+	logger = levels.New(
+		log.NewLogfmtLogger(&buf),
+		levels.PromoteErrors(true),
+		levels.PromoteErrorToLevel(levels.Warn),
+		levels.ErrorKey("err"),
+	)
+	// Should respect the configured ErrorKey
+	logger.Debug().Log("error", "some error")
+	if want, have := "level=debug error=\"some error\"\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	// Should promote to the configured level
+	buf.Reset()
+	logger.Debug().Log("err", "some error")
+	if want, have := "level=warn err=\"some error\"\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	// Should treat nil errors as not an error
+	buf.Reset()
+	logger.Debug().Log("err", nil)
+	if want, have := "level=debug err=null\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+}
+
 func ExampleLevels() {
 	logger := levels.New(log.NewLogfmtLogger(os.Stdout))
 	logger.Debug().Log("msg", "hello")

--- a/log/log.go
+++ b/log/log.go
@@ -140,6 +140,28 @@ func (l *Context) WithPrefix(keyvals ...interface{}) *Context {
 	}
 }
 
+// HasValue returns true if any key (even index) is equal to the argument, and
+// the value associated with that key (subsequent odd index) is not nil or
+// ErrMissingValue.
+func (l *Context) HasValue(key interface{}) bool {
+	kvs := l.keyvals
+	// Loop over all the full key/value pairs. If there is a dangling key
+	// at the end of the list, ignore it: it can't have a value.
+	for i, j, kvl := 0, 1, len(kvs); j < kvl; i, j = i+2, j+2 {
+		if kvs[i] == key {
+			// We found a matching key, so check that the value
+			// is non-nil, potentially evaluating it if it is a
+			// Valuer.
+			val := kvs[j]
+			if vv, isValuer := val.(Valuer); isValuer {
+				val = vv()
+			}
+			return val != nil && val != ErrMissingValue
+		}
+	}
+	return false
+}
+
 // LoggerFunc is an adapter to allow use of ordinary functions as Loggers. If
 // f is a function with the appropriate signature, LoggerFunc(f) is a Logger
 // object that calls f.

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -163,6 +163,38 @@ func TestWithConcurrent(t *testing.T) {
 	}
 }
 
+func TestHasValue(t *testing.T) {
+	expensiveCallWasMade := false
+
+	logger := log.NewContext(log.LoggerFunc(func(kv ...interface{}) error { return nil })).
+		With(
+			"foo", 42,
+			"bar", nil,
+			"baz", log.Valuer(func() interface{} { return "happy" }),
+			"qux", log.Valuer(func() interface{} { return nil }),
+			"corge", log.Valuer(func() interface{} { expensiveCallWasMade = true; return nil }),
+			"grault")
+
+	tests := map[string]bool{
+		"foo":    true,  // Has a value
+		"bar":    false, // Value is nil
+		"baz":    true,  // Has a valuer that evaluates to a value
+		"qux":    false, // Has a valuer that evaluates to nil
+		"grault": false, // Maps to ErrMissingValue
+		"garply": false, // Key isn't in the context at all
+	}
+
+	for key, want := range tests {
+		if have := logger.HasValue(key); want != have {
+			t.Errorf("\nkey: %s, want: %v, have: %v", key, want, have)
+		}
+	}
+
+	if expensiveCallWasMade {
+		t.Error("\nValuer was evaluated unnecessarily")
+	}
+}
+
 func BenchmarkDiscard(b *testing.B) {
 	logger := log.NewNopLogger()
 	b.ReportAllocs()


### PR DESCRIPTION
Addresses https://github.com/go-kit/kit/issues/250

Adds a couple new options to levels.Levels, including:

- FilterLogLevel: specify the minimum log level you want to see
  actually hit your logs. Anything below this will be discarded
  in as cheap a fashion as possible. Defaults to Debug, that is,
  showing everything.
- PromoteErrors: if true, a log line that contains an error will
  be promoted to a higher log level, potentially bypassing the
  FilterLogLevel. This allows a developer to do a bunch of debug
  logging of function call results and, in production, not see any
  of them unless the log line actually has an error. By default
  this flag is set to false.
- ErrorKey: the key in the context where we should search for the
  existence of an error. If we find a `nil` value at that location,
  or if that is not a key in the context, we treat it as not having
  an error. Defaults to "error".
- PromoteErrorToLogLevel: the log level that error logs should be
  promoted to. Promotion only occurs if the log level explicitly
  specified is lower than this value, so if you log at critical
  level and include an error, it doesn't get downgraded. Default
  for this is Error.

Creates an ordered enumeration of LogLevels from Debug up to Crit,
so users can specify the FilterLogLevel and PromoteErrorToLogLevel
options noted above.

To detect the presence of errors in the context, I had to add a
HasValue utility method on log.Context. I would have preferred that
this method not be exported at all, but because levels and log are
different packages, it is not visible to be used in levels unless
it is exported.