### PR TITLE
Added lb.Retry function

### DIFF
--- a/sd/lb/retry.go
+++ b/sd/lb/retry.go
@@ -1,0 +1,62 @@
+package lb
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+// Retry wraps a service load balancer and returns an endpoint oriented load
+// balancer for the specified service method.
+// Requests to the endpoint will be automatically load balanced via the load
+// balancer. Requests that return errors will be retried until they succeed,
+// up to max times, or until the timeout is elapsed, whichever comes first.
+func Retry(max int, timeout time.Duration, b Balancer, method string) endpoint.Endpoint {
+	if b == nil {
+		panic("nil Balancer")
+	}
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		var (
+			newctx, cancel = context.WithTimeout(ctx, timeout)
+			responses      = make(chan interface{}, 1)
+			errs           = make(chan error, 1)
+			a              = []string{}
+		)
+		defer cancel()
+		for i := 1; i <= max; i++ {
+			go func() {
+				svc, err := b.Service()
+				if err != nil {
+					errs <- err
+					return
+				}
+				e, err := svc.Endpoint(method)
+				if err != nil {
+					errs <- err
+					return
+				}
+				response, err := e(newctx, request)
+				if err != nil {
+					errs <- err
+					return
+				}
+				responses <- response
+			}()
+
+			select {
+			case <-newctx.Done():
+				return nil, newctx.Err()
+			case response := <-responses:
+				return response, nil
+			case err := <-errs:
+				a = append(a, err.Error())
+				continue
+			}
+		}
+		return nil, fmt.Errorf("retry attempts exceeded (%s)", strings.Join(a, "; "))
+	}
+}

--- a/sd/lb/retry_test.go
+++ b/sd/lb/retry_test.go
@@ -1,0 +1,91 @@
+package lb_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/sd"
+	loadbalancer "github.com/go-kit/kit/sd/lb"
+	"github.com/go-kit/kit/service"
+)
+
+func TestRetryMaxTotalFail(t *testing.T) {
+	var (
+		services = sd.FixedSubscriber{} // no services
+		lb       = loadbalancer.NewRoundRobin(services)
+		retry    = loadbalancer.Retry(999, time.Second, lb, "m") // lots of retries
+		ctx      = context.Background()
+	)
+	if _, err := retry(ctx, struct{}{}); err == nil {
+		t.Errorf("expected error, got none") // should fail
+	}
+}
+
+func TestRetryMaxPartialFail(t *testing.T) {
+	var (
+		endpoints = []endpoint.Endpoint{
+			func(context.Context, interface{}) (interface{}, error) { return nil, errors.New("error one") },
+			func(context.Context, interface{}) (interface{}, error) { return nil, errors.New("error two") },
+			func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil /* OK */ },
+		}
+		services = sd.FixedSubscriber{
+			0: service.Fixed{"m": endpoints[0]},
+			1: service.Fixed{"m": endpoints[1]},
+			2: service.Fixed{"m": endpoints[2]},
+		}
+		retries = len(services) - 1 // not quite enough retries
+		lb      = loadbalancer.NewRoundRobin(services)
+		ctx     = context.Background()
+	)
+	if _, err := loadbalancer.Retry(retries, time.Second, lb, "m")(ctx, struct{}{}); err == nil {
+		t.Errorf("expected error, got none")
+	}
+}
+
+func TestRetryMaxSuccess(t *testing.T) {
+	var (
+		endpoints = []endpoint.Endpoint{
+			func(context.Context, interface{}) (interface{}, error) { return nil, errors.New("error one") },
+			func(context.Context, interface{}) (interface{}, error) { return nil, errors.New("error two") },
+			func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil /* OK */ },
+		}
+		services = sd.FixedSubscriber{
+			0: service.Fixed{"m": endpoints[0]},
+			1: service.Fixed{"m": endpoints[1]},
+			2: service.Fixed{"m": endpoints[2]},
+		}
+		retries = len(services) // exactly enough retries
+		lb      = loadbalancer.NewRoundRobin(services)
+		ctx     = context.Background()
+	)
+	if _, err := loadbalancer.Retry(retries, time.Second, lb, "m")(ctx, struct{}{}); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestRetryTimeout(t *testing.T) {
+	var (
+		step    = make(chan struct{})
+		e       = func(context.Context, interface{}) (interface{}, error) { <-step; return struct{}{}, nil }
+		timeout = time.Millisecond
+		retry   = loadbalancer.Retry(999, timeout, loadbalancer.NewRoundRobin(sd.FixedSubscriber{0: service.Fixed{"m": e}}), "m")
+		errs    = make(chan error, 1)
+		invoke  = func() { _, err := retry(context.Background(), struct{}{}); errs <- err }
+	)
+
+	go func() { step <- struct{}{} }() // queue up a flush of the endpoint
+	invoke()                           // invoke the endpoint and trigger the flush
+	if err := <-errs; err != nil {     // that should succeed
+		t.Error(err)
+	}
+
+	go func() { time.Sleep(10 * timeout); step <- struct{}{} }() // a delayed flush
+	invoke()                                                     // invoke the endpoint
+	if err := <-errs; err != context.DeadlineExceeded {          // that should not succeed
+		t.Errorf("wanted %v, got none", context.DeadlineExceeded)
+	}
+}


### PR DESCRIPTION
This function allows for calling an endpoint with load balanced retry logic using the new sd package in the same way as we had available in the old loadbalancer package.