### PR TITLE
Adding `metrics/graphite`, `metrics/provider` and `util/conn` packages plus `Emitter` types

### DIFF
--- a/metrics/dogstatsd/dogstatsd_test.go
+++ b/metrics/dogstatsd/dogstatsd_test.go
@@ -3,12 +3,73 @@ package dogstatsd
 import (
 	"bytes"
 	"fmt"
-	"github.com/go-kit/kit/metrics"
+	"net"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/util/conn"
 )
+
+func TestEmitterCounter(t *testing.T) {
+	e, buf := testEmitter()
+
+	c := e.NewCounter("test_statsd_counter")
+	c.Add(1)
+	c.Add(2)
+
+	// give time for things to emit
+	time.Sleep(time.Millisecond * 250)
+	// force a flush and stop
+	e.Stop()
+
+	want := "prefix.test_statsd_counter:1|c\nprefix.test_statsd_counter:2|c\n"
+	have := buf.String()
+	if want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
+}
+
+func TestEmitterGauge(t *testing.T) {
+	e, buf := testEmitter()
+
+	g := e.NewGauge("test_statsd_gauge")
+
+	delta := 1.0
+	g.Add(delta)
+
+	// give time for things to emit
+	time.Sleep(time.Millisecond * 250)
+	// force a flush and stop
+	e.Stop()
+
+	want := fmt.Sprintf("prefix.test_statsd_gauge:+%f|g\n", delta)
+	have := buf.String()
+	if want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
+}
+
+func TestEmitterHistogram(t *testing.T) {
+	e, buf := testEmitter()
+	h := e.NewHistogram("test_statsd_histogram")
+
+	h.Observe(123)
+
+	// give time for things to emit
+	time.Sleep(time.Millisecond * 250)
+	// force a flush and stop
+	e.Stop()
+
+	want := "prefix.test_statsd_histogram:123|ms\n"
+	have := buf.String()
+	if want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
+}
 
 func TestCounter(t *testing.T) {
 	buf := &syncbuf{buf: &bytes.Buffer{}}
@@ -147,4 +208,59 @@ func (s *syncbuf) Reset() {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	s.buf.Reset()
+}
+
+func testEmitter() (*Emitter, *syncbuf) {
+	buf := &syncbuf{buf: &bytes.Buffer{}}
+	e := &Emitter{
+		prefix:  "prefix.",
+		mgr:     conn.NewManager(mockDialer(buf), "", "", time.After, log.NewNopLogger()),
+		logger:  log.NewNopLogger(),
+		keyVals: make(chan keyVal),
+		quitc:   make(chan chan struct{}),
+	}
+	go e.loop(time.Millisecond * 20)
+	return e, buf
+}
+
+func mockDialer(buf *syncbuf) conn.Dialer {
+	return func(net, addr string) (net.Conn, error) {
+		return &mockConn{buf}, nil
+	}
+}
+
+type mockConn struct {
+	buf *syncbuf
+}
+
+func (c *mockConn) Read(b []byte) (n int, err error) {
+	panic("not implemented")
+}
+
+func (c *mockConn) Write(b []byte) (n int, err error) {
+	return c.buf.Write(b)
+}
+
+func (c *mockConn) Close() error {
+	panic("not implemented")
+}
+
+func (c *mockConn) LocalAddr() net.Addr {
+	panic("not implemented")
+}
+
+func (c *mockConn) RemoteAddr() net.Addr {
+	panic("not implemented")
+}
+
+func (c *mockConn) SetDeadline(t time.Time) error {
+	panic("not implemented")
+}
+
+func (c *mockConn) SetReadDeadline(t time.Time) error {
+	panic("not implemented")
+}
+
+func (c *mockConn) SetWriteDeadline(t time.Time) error {
+	panic("not implemented")
 }

--- a/metrics/dogstatsd/emitter.go
+++ b/metrics/dogstatsd/emitter.go
@@ -1,0 +1,159 @@
+package dogstatsd
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/util/conn"
+)
+
+// Emitter is a struct to manage connections and orchestrate the emission of
+// metrics to a Statsd process.
+type Emitter struct {
+	prefix  string
+	keyVals chan keyVal
+	mgr     *conn.Manager
+	logger  log.Logger
+	quitc   chan chan struct{}
+}
+
+type keyVal struct {
+	key string
+	val string
+}
+
+func stringToKeyVal(key string, keyVals chan keyVal) chan string {
+	vals := make(chan string)
+	go func() {
+		for val := range vals {
+			keyVals <- keyVal{key: key, val: val}
+		}
+	}()
+	return vals
+}
+
+// NewEmitter will return an Emitter that will prefix all metrics names with the
+// given prefix. Once started, it will attempt to create a connection with the
+// given network and address via `net.Dial` and periodically post metrics to the
+// connection in the DogStatsD protocol.
+func NewEmitter(network, address string, metricsPrefix string, flushInterval time.Duration, logger log.Logger) *Emitter {
+	return NewEmitterDial(net.Dial, network, address, metricsPrefix, flushInterval, logger)
+}
+
+// NewEmitterDial is the same as NewEmitter, but allows you to specify your own
+// Dialer function. This is primarily useful for tests.
+func NewEmitterDial(dialer conn.Dialer, network, address string, metricsPrefix string, flushInterval time.Duration, logger log.Logger) *Emitter {
+	e := &Emitter{
+		prefix:  metricsPrefix,
+		mgr:     conn.NewManager(dialer, network, address, time.After, logger),
+		logger:  logger,
+		keyVals: make(chan keyVal),
+		quitc:   make(chan chan struct{}),
+	}
+	go e.loop(flushInterval)
+	return e
+}
+
+// NewCounter returns a Counter that emits observations in the DogStatsD protocol
+// via the Emitter's connection manager. Observations are buffered for the
+// report interval or until the buffer exceeds a max packet size, whichever
+// comes first. Fields are ignored.
+func (e *Emitter) NewCounter(key string) metrics.Counter {
+	key = e.prefix + key
+	return &counter{
+		key: key,
+		c:   stringToKeyVal(key, e.keyVals),
+	}
+}
+
+// NewHistogram returns a Histogram that emits observations in the DogStatsD
+// protocol via the Emitter's conection manager. Observations are buffered for
+// the reporting interval or until the buffer exceeds a max packet size,
+// whichever comes first. Fields are ignored.
+//
+// NewHistogram is mapped to a statsd Timing, so observations should represent
+// milliseconds. If you observe in units of nanoseconds, you can make the
+// translation with a ScaledHistogram:
+//
+//    NewScaledHistogram(histogram, time.Millisecond)
+//
+// You can also enforce the constraint in a typesafe way with a millisecond
+// TimeHistogram:
+//
+//    NewTimeHistogram(histogram, time.Millisecond)
+//
+// TODO: support for sampling.
+func (e *Emitter) NewHistogram(key string) metrics.Histogram {
+	key = e.prefix + key
+	return &histogram{
+		key: key,
+		h:   stringToKeyVal(key, e.keyVals),
+	}
+}
+
+// NewGauge returns a Gauge that emits values in the DogStatsD protocol via the
+// the Emitter's connection manager. Values are buffered for the report
+// interval or until the buffer exceeds a max packet size, whichever comes
+// first. Fields are ignored.
+//
+// TODO: support for sampling
+func (e *Emitter) NewGauge(key string) metrics.Gauge {
+	key = e.prefix + key
+	return &gauge{
+		key: key,
+		g:   stringToKeyVal(key, e.keyVals),
+	}
+}
+
+func (e *Emitter) loop(d time.Duration) {
+	ticker := time.NewTicker(d)
+	defer ticker.Stop()
+	buf := &bytes.Buffer{}
+	for {
+		select {
+		case kv := <-e.keyVals:
+			fmt.Fprintf(buf, "%s:%s\n", kv.key, kv.val)
+			if buf.Len() > maxBufferSize {
+				e.Flush(buf)
+			}
+
+		case <-ticker.C:
+			e.Flush(buf)
+
+		case q := <-e.quitc:
+			e.Flush(buf)
+			close(q)
+			return
+		}
+	}
+}
+
+// Stop will flush the current metrics and close the active connection. Calling
+// stop more than once is a programmer error.
+func (e *Emitter) Stop() {
+	q := make(chan struct{})
+	e.quitc <- q
+	<-q
+}
+
+// Flush will write the given buffer to a connection provided by the Emitter's
+// connection manager.
+func (e *Emitter) Flush(buf *bytes.Buffer) {
+	conn := e.mgr.Take()
+	if conn == nil {
+		e.logger.Log("during", "flush", "err", "connection unavailable")
+		return
+	}
+
+	_, err := conn.Write(buf.Bytes())
+	if err != nil {
+		e.logger.Log("during", "flush", "err", err)
+	}
+	buf.Reset()
+
+	e.mgr.Put(err)
+}

--- a/metrics/dogstatsd/emitter.go
+++ b/metrics/dogstatsd/emitter.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Emitter is a struct to manage connections and orchestrate the emission of
-// metrics to a Statsd process.
+// metrics to a DogStatsd process.
 type Emitter struct {
 	prefix  string
 	keyVals chan keyVal

--- a/metrics/graphite/emitter.go
+++ b/metrics/graphite/emitter.go
@@ -1,0 +1,159 @@
+package graphite
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/util/conn"
+)
+
+// Emitter is a struct to manage connections and orchestrate the emission of
+// metrics to a Graphite system.
+type Emitter struct {
+	mtx        sync.Mutex
+	prefix     string
+	mgr        *conn.Manager
+	counters   []*counter
+	histograms []*windowedHistogram
+	gauges     []*gauge
+	logger     log.Logger
+	quitc      chan chan struct{}
+}
+
+// NewEmitter will return an Emitter that will prefix all metrics names with the
+// given prefix. Once started, it will attempt to create a connection with the
+// given network and address via `net.Dial` and periodically post metrics to the
+// connection in the Graphite plaintext protocol.
+func NewEmitter(network, address string, metricsPrefix string, flushInterval time.Duration, logger log.Logger) *Emitter {
+	return NewEmitterDial(net.Dial, network, address, metricsPrefix, flushInterval, logger)
+}
+
+// NewEmitterDial is the same as NewEmitter, but allows you to specify your own
+// Dialer function. This is primarily useful for tests.
+func NewEmitterDial(dialer conn.Dialer, network, address string, metricsPrefix string, flushInterval time.Duration, logger log.Logger) *Emitter {
+	e := &Emitter{
+		prefix: metricsPrefix,
+		mgr:    conn.NewManager(dialer, network, address, time.After, logger),
+		logger: logger,
+		quitc:  make(chan chan struct{}),
+	}
+	go e.loop(flushInterval)
+	return e
+}
+
+// NewCounter returns a Counter whose value will be periodically emitted in
+// a Graphite-compatible format once the Emitter is started. Fields are ignored.
+func (e *Emitter) NewCounter(name string) metrics.Counter {
+	e.mtx.Lock()
+	defer e.mtx.Unlock()
+	c := newCounter(name)
+	e.counters = append(e.counters, c)
+	return c
+}
+
+// NewHistogram is taken from http://github.com/codahale/metrics. It returns a
+// windowed HDR histogram which drops data older than five minutes.
+//
+// The histogram exposes metrics for each passed quantile as gauges. Quantiles
+// should be integers in the range 1..99. The gauge names are assigned by using
+// the passed name as a prefix and appending "_pNN" e.g. "_p50".
+//
+// The values of this histogram will be periodically emitted in a
+// Graphite-compatible format once the Emitter is started. Fields are ignored.
+func (e *Emitter) NewHistogram(name string, minValue, maxValue int64, sigfigs int, quantiles ...int) (metrics.Histogram, error) {
+	gauges := map[int]metrics.Gauge{}
+	for _, quantile := range quantiles {
+		if quantile <= 0 || quantile >= 100 {
+			return nil, fmt.Errorf("invalid quantile %d", quantile)
+		}
+		gauges[quantile] = e.gauge(fmt.Sprintf("%s_p%02d", name, quantile))
+	}
+	h := newWindowedHistogram(name, minValue, maxValue, sigfigs, gauges, e.logger)
+
+	e.mtx.Lock()
+	defer e.mtx.Unlock()
+	e.histograms = append(e.histograms, h)
+	return h, nil
+}
+
+// NewGauge returns a Gauge whose value will be periodically emitted in a
+// Graphite-compatible format once the Emitter is started. Fields are ignored.
+func (e *Emitter) NewGauge(name string) metrics.Gauge {
+	e.mtx.Lock()
+	defer e.mtx.Unlock()
+	return e.gauge(name)
+}
+
+func (e *Emitter) gauge(name string) metrics.Gauge {
+	g := &gauge{name, 0}
+	e.gauges = append(e.gauges, g)
+	return g
+}
+
+func (e *Emitter) loop(d time.Duration) {
+	ticker := time.NewTicker(d)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			e.Flush()
+
+		case q := <-e.quitc:
+			e.Flush()
+			close(q)
+			return
+		}
+	}
+}
+
+// Stop will flush the current metrics and close the active connection. Calling
+// stop more than once is a programmer error.
+func (e *Emitter) Stop() {
+	q := make(chan struct{})
+	e.quitc <- q
+	<-q
+}
+
+// Flush will write the current metrics to the Emitter's connection in the
+// Graphite plaintext protocol.
+func (e *Emitter) Flush() {
+	e.mtx.Lock() // one flush at a time
+	defer e.mtx.Unlock()
+
+	conn := e.mgr.Take()
+	if conn == nil {
+		e.logger.Log("during", "flush", "err", "connection unavailable")
+		return
+	}
+
+	err := e.flush(conn)
+	if err != nil {
+		e.logger.Log("during", "flush", "err", err)
+	}
+	e.mgr.Put(err)
+}
+
+func (e *Emitter) flush(conn io.Writer) error {
+	w := bufio.NewWriter(conn)
+
+	for _, c := range e.counters {
+		c.flush(w, e.prefix)
+	}
+
+	for _, h := range e.histograms {
+		h.flush(w, e.prefix)
+	}
+
+	for _, g := range e.gauges {
+		g.flush(w, e.prefix)
+	}
+
+	return w.Flush()
+}

--- a/metrics/graphite/emitter.go
+++ b/metrics/graphite/emitter.go
@@ -140,20 +140,20 @@ func (e *Emitter) Flush() {
 	e.mgr.Put(err)
 }
 
-func (e *Emitter) flush(conn io.Writer) error {
-	w := bufio.NewWriter(conn)
+func (e *Emitter) flush(w io.Writer) error {
+	bw := bufio.NewWriter(w)
 
 	for _, c := range e.counters {
-		c.flush(w, e.prefix)
+		c.flush(bw, e.prefix)
 	}
 
 	for _, h := range e.histograms {
-		h.flush(w, e.prefix)
+		h.flush(bw, e.prefix)
 	}
 
 	for _, g := range e.gauges {
-		g.flush(w, e.prefix)
+		g.flush(bw, e.prefix)
 	}
 
-	return w.Flush()
+	return bw.Flush()
 }

--- a/metrics/graphite/graphite.go
+++ b/metrics/graphite/graphite.go
@@ -186,7 +186,11 @@ func (e *emitter) Stop() error {
 	// get one last flush in
 	e.Flush()
 	// close the connection
-	return e.conn.Close()
+	err := e.conn.Close()
+	// nil the conn to avoid problems
+	// if Stop() is called more than once.
+	e.conn = nil
+	return err
 }
 
 // Flush will attempt to create a connection with the given address

--- a/metrics/graphite/graphite.go
+++ b/metrics/graphite/graphite.go
@@ -1,0 +1,296 @@
+// Package graphite implements a graphite backend for package metrics.
+//
+// The current implementation ignores fields.
+package graphite
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"net"
+	"sort"
+	"sync"
+	"time"
+
+	"sync/atomic"
+
+	"github.com/codahale/hdrhistogram"
+	"github.com/go-kit/kit/metrics"
+)
+
+// Emitter will keep track of all metrics and, once started,
+// will emit the metrics via the Flush method to the given io.Writer.
+type Emitter interface {
+	NewCounter(string) metrics.Counter
+	NewHistogram(string, int64, int64, int, ...int) metrics.Histogram
+	NewTimeHistogram(string, time.Duration, int64, int64, int, ...int) metrics.TimeHistogram
+	NewGauge(string) metrics.Gauge
+
+	Start(time.Duration)
+	Flush() error
+}
+
+type emitter struct {
+	addr   *net.TCPAddr
+	prefix string
+
+	metricMu   *sync.Mutex
+	counters   []*counter
+	histograms []*windowedHistogram
+	gauges     []*gauge
+}
+
+// NewEmitter will return an Emitter that will prefix all
+// metrics names with the given prefix. Once started, it will attempt to create
+// a TCP connection with the given address and most metrics to the connection
+// in a Graphite-compatible format.
+func NewEmitter(addr *net.TCPAddr, prefix string) Emitter {
+	e := &emitter{
+		addr, prefix, &sync.Mutex{},
+		[]*counter{}, []*windowedHistogram{}, []*gauge{},
+	}
+
+	return e
+}
+
+// NewCounter returns a Counter whose value will be periodically emitted in
+// a Graphite-compatible format once the Emitter is started. Fields are ignored.
+func (e *emitter) NewCounter(name string) metrics.Counter {
+	// only one flush at a time
+	e.metricMu.Lock()
+	defer e.metricMu.Unlock()
+	c := &counter{name, 0}
+	e.counters = append(e.counters, c)
+	return c
+}
+
+// NewHistogram is taken from http://github.com/codahale/metrics. It returns a
+// windowed HDR histogram which drops data older than five minutes.
+//
+// The histogram exposes metrics for each passed quantile as gauges. Quantiles
+// should be integers in the range 1..99. The gauge names are assigned by
+// using the passed name as a prefix and appending "_pNN" e.g. "_p50".
+//
+// The values of this histogram will be periodically emitted in a Graphite-compatible
+// format once the Emitter is started. Fields are ignored.
+func (e *emitter) NewHistogram(name string, minValue, maxValue int64, sigfigs int, quantiles ...int) metrics.Histogram {
+	// only one flush at a time
+	e.metricMu.Lock()
+	defer e.metricMu.Unlock()
+
+	gauges := map[int]metrics.Gauge{}
+	for _, quantile := range quantiles {
+		if quantile <= 0 || quantile >= 100 {
+			panic(fmt.Sprintf("invalid quantile %d", quantile))
+		}
+		gauges[quantile] = e.gauge(fmt.Sprintf("%s_p%02d", name, quantile))
+	}
+	h := newWindowedHistogram(name, minValue, maxValue, sigfigs, gauges)
+	e.histograms = append(e.histograms, h)
+	return h
+}
+
+// NewTimeHistogram returns a TimeHistogram wrapper around the windowed
+// HDR histrogram provided by this package.
+func (e *emitter) NewTimeHistogram(name string, unit time.Duration, minValue, maxValue int64, sigfigs int, quantiles ...int) metrics.TimeHistogram {
+	h := e.NewHistogram(name, minValue, maxValue, sigfigs, quantiles...)
+	return metrics.NewTimeHistogram(unit, h)
+}
+
+// NewGauge returns a Gauge whose value will be periodically emitted in
+// a Graphite-compatible format once the Emitter is started. Fields are ignored.
+func (e *emitter) NewGauge(name string) metrics.Gauge {
+	// only one flush at a time
+	e.metricMu.Lock()
+	defer e.metricMu.Unlock()
+	return e.gauge(name)
+}
+
+func (e *emitter) gauge(name string) metrics.Gauge {
+	g := &gauge{name, 0}
+	e.gauges = append(e.gauges, g)
+	return g
+}
+
+// Start will kick off a background goroutine to
+// call Flush once every interval.
+func (e *emitter) Start(interval time.Duration) {
+	go func() {
+		t := time.Tick(interval)
+		for range t {
+			err := e.Flush()
+			if err != nil {
+				log.Print("error: could not dial graphite host: ", err)
+				continue
+			}
+		}
+	}()
+}
+
+// Flush will attempt to create a connection with the given address
+// and write the current metrics to it in a Graphite-compatible format.
+//
+// Users can call this method on process shutdown to ensure
+// the current metrics are pushed to Graphite.
+func (e *emitter) Flush() error {
+	// open connection
+	conn, err := net.DialTCP("tcp", nil, e.addr)
+	if err != nil {
+		return err
+	}
+
+	// flush stats to connection
+	e.flush(conn)
+
+	// close connection
+	conn.Close()
+	return nil
+}
+
+func (e *emitter) flush(conn io.Writer) {
+	// only one flush at a time
+	e.metricMu.Lock()
+	defer e.metricMu.Unlock()
+
+	// buffer the writer and make sure to flush it
+	w := bufio.NewWriter(conn)
+	defer w.Flush()
+
+	now := time.Now().Unix()
+
+	// emit counter stats
+	for _, c := range e.counters {
+		fmt.Fprintf(w, "%s.%s.count %d %d\n", e.prefix, c.Name(), c.count, now)
+	}
+
+	// emit histogram specific stats
+	for _, h := range e.histograms {
+		hist := h.hist.Merge()
+		fmt.Fprintf(w, "%s.%s.count %d %d\n", e.prefix, h.Name(), hist.TotalCount(), now)
+		fmt.Fprintf(w, "%s.%s.min %d %d\n", e.prefix, h.Name(), hist.Min(), now)
+		fmt.Fprintf(w, "%s.%s.max %d %d\n", e.prefix, h.Name(), hist.Max(), now)
+		fmt.Fprintf(w, "%s.%s.mean %.2f %d\n", e.prefix, h.Name(), hist.Mean(), now)
+		fmt.Fprintf(w, "%s.%s.std-dev %.2f %d\n", e.prefix, h.Name(), hist.StdDev(), now)
+	}
+
+	// emit gauge stats (which can include some histogram quantiles)
+	for _, g := range e.gauges {
+		fmt.Fprintf(w, "%s.%s %.2f %d\n", e.prefix, g.Name(), g.Get(), now)
+	}
+}
+
+type counter struct {
+	key   string
+	count uint64
+}
+
+func (c *counter) Name() string { return c.key }
+
+func (c *counter) With(metrics.Field) metrics.Counter { return c }
+
+func (c *counter) Add(delta uint64) { atomic.AddUint64(&c.count, delta) }
+
+type gauge struct {
+	key   string
+	value uint64 // math.Float64bits
+}
+
+func (g *gauge) Name() string { return g.key }
+
+func (g *gauge) With(metrics.Field) metrics.Gauge { return g }
+
+func (g *gauge) Add(delta float64) {
+	for {
+		old := atomic.LoadUint64(&g.value)
+		new := math.Float64bits(math.Float64frombits(old) + delta)
+		if atomic.CompareAndSwapUint64(&g.value, old, new) {
+			return
+		}
+	}
+}
+
+func (g *gauge) Set(value float64) {
+	atomic.StoreUint64(&g.value, math.Float64bits(value))
+}
+
+func (g *gauge) Get() float64 {
+	return math.Float64frombits(atomic.LoadUint64(&g.value))
+}
+
+type windowedHistogram struct {
+	mu   sync.Mutex
+	hist *hdrhistogram.WindowedHistogram
+
+	name   string
+	gauges map[int]metrics.Gauge
+}
+
+// NewWindowedHistogram is taken from http://github.com/codahale/metrics. It returns a
+// windowed HDR histogram which drops data older than five minutes.
+//
+// The histogram exposes metrics for each passed quantile as gauges. Users are expected
+// to provide their own set of Gauges for quantiles to make this Histogram work across multiple
+// metrics providers.
+func newWindowedHistogram(name string, minValue, maxValue int64, sigfigs int, quantiles map[int]metrics.Gauge) *windowedHistogram {
+	h := &windowedHistogram{
+		hist:   hdrhistogram.NewWindowed(5, minValue, maxValue, sigfigs),
+		name:   name,
+		gauges: quantiles,
+	}
+	go h.rotateLoop(1 * time.Minute)
+	return h
+}
+
+func (h *windowedHistogram) Name() string                         { return h.name }
+func (h *windowedHistogram) With(metrics.Field) metrics.Histogram { return h }
+
+func (h *windowedHistogram) Observe(value int64) {
+	h.mu.Lock()
+	err := h.hist.Current.RecordValue(value)
+	h.mu.Unlock()
+
+	if err != nil {
+		panic(err.Error())
+	}
+
+	for q, gauge := range h.gauges {
+		gauge.Set(float64(h.hist.Current.ValueAtQuantile(float64(q))))
+	}
+}
+
+func (h *windowedHistogram) Distribution() ([]metrics.Bucket, []metrics.Quantile) {
+	bars := h.hist.Merge().Distribution()
+	buckets := make([]metrics.Bucket, len(bars))
+	for i, bar := range bars {
+		buckets[i] = metrics.Bucket{
+			From:  bar.From,
+			To:    bar.To,
+			Count: bar.Count,
+		}
+	}
+	quantiles := make([]metrics.Quantile, 0, len(h.gauges))
+	for quantile, gauge := range h.gauges {
+		quantiles = append(quantiles, metrics.Quantile{
+			Quantile: quantile,
+			Value:    int64(gauge.Get()),
+		})
+	}
+	sort.Sort(quantileSlice(quantiles))
+	return buckets, quantiles
+}
+
+func (h *windowedHistogram) rotateLoop(d time.Duration) {
+	for range time.Tick(d) {
+		h.mu.Lock()
+		h.hist.Rotate()
+		h.mu.Unlock()
+	}
+}
+
+type quantileSlice []metrics.Quantile
+
+func (a quantileSlice) Len() int           { return len(a) }
+func (a quantileSlice) Less(i, j int) bool { return a[i].Quantile < a[j].Quantile }
+func (a quantileSlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/metrics/graphite/graphite.go
+++ b/metrics/graphite/graphite.go
@@ -12,9 +12,8 @@ import (
 	"net"
 	"sort"
 	"sync"
-	"time"
-
 	"sync/atomic"
+	"time"
 
 	"github.com/codahale/hdrhistogram"
 	"github.com/go-kit/kit/metrics"

--- a/metrics/graphite/graphite.go
+++ b/metrics/graphite/graphite.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Emitter will keep track of all metrics and, once started,
-// will emit the metrics via the Flush method to the given io.Writer.
+// will emit the metrics via the Flush method to the given address.
 type Emitter interface {
 	NewCounter(string) metrics.Counter
 	NewHistogram(string, int64, int64, int, ...int) metrics.Histogram
@@ -44,8 +44,8 @@ type emitter struct {
 
 // NewEmitter will return an Emitter that will prefix all
 // metrics names with the given prefix. Once started, it will attempt to create
-// a TCP connection with the given address and most metrics to the connection
-// in a Graphite-compatible format.
+// a TCP connection with the given address and periodically post metrics to the
+// connection in a Graphite-compatible format.
 func NewEmitter(addr *net.TCPAddr, prefix string) Emitter {
 	e := &emitter{
 		addr, prefix, &sync.Mutex{},
@@ -227,7 +227,7 @@ type windowedHistogram struct {
 	gauges map[int]metrics.Gauge
 }
 
-// NewWindowedHistogram is taken from http://github.com/codahale/metrics. It returns a
+// newWindowedHistogram is taken from http://github.com/codahale/metrics. It returns a
 // windowed HDR histogram which drops data older than five minutes.
 //
 // The histogram exposes metrics for each passed quantile as gauges. Users are expected

--- a/metrics/graphite/graphite_test.go
+++ b/metrics/graphite/graphite_test.go
@@ -1,0 +1,80 @@
+package graphite
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/teststat"
+)
+
+func TestHistogramQuantiles(t *testing.T) {
+	prefix := "prefix"
+	e := NewEmitter(nil, prefix)
+	var (
+		name      = "test_histogram_quantiles"
+		quantiles = []int{50, 90, 95, 99}
+		h         = e.NewHistogram(name, 0, 100, 3, quantiles...).With(metrics.Field{Key: "ignored", Value: "field"})
+	)
+	const seed, mean, stdev int64 = 424242, 50, 10
+	teststat.PopulateNormalHistogram(t, h, seed, mean, stdev)
+
+	// flush the current metrics into a buffer to examine
+	var b bytes.Buffer
+	e.(*emitter).flush(&b)
+	teststat.AssertGraphiteNormalHistogram(t, prefix, name, mean, stdev, quantiles, b.String())
+}
+
+func TestCounter(t *testing.T) {
+	var (
+		prefix = "prefix"
+		name   = "m"
+		value  = 123
+		e      = NewEmitter(nil, prefix)
+		b      bytes.Buffer
+	)
+	e.NewCounter(name).With(metrics.Field{Key: "ignored", Value: "field"}).Add(uint64(value))
+	e.(*emitter).flush(&b)
+	want := fmt.Sprintf("%s.%s.count %d", prefix, name, value)
+	payload := b.String()
+	if !strings.HasPrefix(payload, want) {
+		t.Errorf("counter %s want\n%s, have\n%s", name, want, payload)
+	}
+}
+
+func TestGauge(t *testing.T) {
+	var (
+		prefix = "prefix"
+		name   = "xyz"
+		value  = 54321
+		delta  = 12345
+		e      = NewEmitter(nil, prefix)
+		b      bytes.Buffer
+		g      = e.NewGauge(name).With(metrics.Field{Key: "ignored", Value: "field"})
+	)
+
+	g.Set(float64(value))
+	g.Add(float64(delta))
+
+	e.(*emitter).flush(&b)
+	payload := b.String()
+
+	want := fmt.Sprintf("%s.%s %d", prefix, name, value+delta)
+	if !strings.HasPrefix(payload, want) {
+		t.Errorf("gauge %s want\n%s, have\n%s", name, want, payload)
+	}
+}
+
+func TestInvalidQuantile(t *testing.T) {
+	e := NewEmitter(nil, "")
+	defer func() {
+		if err := recover(); err == nil {
+			t.Errorf("expected panic, got none")
+		} else {
+			t.Logf("got expected panic: %v", err)
+		}
+	}()
+	e.NewHistogram("foo", 0.0, 100.0, 3, 50, 90, 95, 99, 101)
+}

--- a/metrics/graphite/graphite_test.go
+++ b/metrics/graphite/graphite_test.go
@@ -27,7 +27,7 @@ func TestHistogramQuantiles(t *testing.T) {
 
 	// flush the current metrics into a buffer to examine
 	var b bytes.Buffer
-	e.(*emitter).flush(&b)
+	e.flush(&b)
 	teststat.AssertGraphiteNormalHistogram(t, prefix, name, mean, stdev, quantiles, b.String())
 }
 
@@ -36,7 +36,7 @@ func TestCounter(t *testing.T) {
 		prefix = "prefix"
 		name   = "m"
 		value  = 123
-		e      = NewEmitter("", true, prefix, nil).(*emitter)
+		e      = NewEmitter("", true, prefix, nil)
 		b      bytes.Buffer
 	)
 	e.NewCounter(name).With(metrics.Field{Key: "ignored", Value: "field"}).Add(uint64(value))
@@ -62,7 +62,7 @@ func TestGauge(t *testing.T) {
 	g.Set(float64(value))
 	g.Add(float64(delta))
 
-	e.(*emitter).flush(&b)
+	e.flush(&b)
 	payload := b.String()
 
 	want := fmt.Sprintf("%s.%s %d", prefix, name, value+delta)

--- a/metrics/graphite/graphite_test.go
+++ b/metrics/graphite/graphite_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestHistogramQuantiles(t *testing.T) {
-	prefix := "prefix"
+	prefix := "prefix."
 	e := NewEmitter("", "", prefix, time.Second, log.NewNopLogger())
 	var (
 		name      = "test_histogram_quantiles"
@@ -35,7 +35,7 @@ func TestHistogramQuantiles(t *testing.T) {
 
 func TestCounter(t *testing.T) {
 	var (
-		prefix = "prefix"
+		prefix = "prefix."
 		name   = "m"
 		value  = 123
 		e      = NewEmitter("", "", prefix, time.Second, log.NewNopLogger())
@@ -43,7 +43,7 @@ func TestCounter(t *testing.T) {
 	)
 	e.NewCounter(name).With(metrics.Field{Key: "ignored", Value: "field"}).Add(uint64(value))
 	e.flush(&b)
-	want := fmt.Sprintf("%s.%s.count %d", prefix, name, value)
+	want := fmt.Sprintf("%s%s.count %d", prefix, name, value)
 	payload := b.String()
 	if !strings.HasPrefix(payload, want) {
 		t.Errorf("counter %s want\n%s, have\n%s", name, want, payload)
@@ -52,7 +52,7 @@ func TestCounter(t *testing.T) {
 
 func TestGauge(t *testing.T) {
 	var (
-		prefix = "prefix"
+		prefix = "prefix."
 		name   = "xyz"
 		value  = 54321
 		delta  = 12345
@@ -67,7 +67,7 @@ func TestGauge(t *testing.T) {
 	e.flush(&b)
 	payload := b.String()
 
-	want := fmt.Sprintf("%s.%s %d", prefix, name, value+delta)
+	want := fmt.Sprintf("%s%s %d", prefix, name, value+delta)
 	if !strings.HasPrefix(payload, want) {
 		t.Errorf("gauge %s want\n%s, have\n%s", name, want, payload)
 	}

--- a/metrics/graphite/graphite_test.go
+++ b/metrics/graphite/graphite_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestHistogramQuantiles(t *testing.T) {
 	prefix := "prefix"
-	e := NewEmitter("", true, prefix, nil)
+	e := NewEmitter("", "", prefix, nil)
 	var (
 		name      = "test_histogram_quantiles"
 		quantiles = []int{50, 90, 95, 99}
@@ -36,7 +36,7 @@ func TestCounter(t *testing.T) {
 		prefix = "prefix"
 		name   = "m"
 		value  = 123
-		e      = NewEmitter("", true, prefix, nil)
+		e      = NewEmitter("", "", prefix, nil)
 		b      bytes.Buffer
 	)
 	e.NewCounter(name).With(metrics.Field{Key: "ignored", Value: "field"}).Add(uint64(value))
@@ -54,7 +54,7 @@ func TestGauge(t *testing.T) {
 		name   = "xyz"
 		value  = 54321
 		delta  = 12345
-		e      = NewEmitter("", true, prefix, nil)
+		e      = NewEmitter("", "", prefix, nil)
 		b      bytes.Buffer
 		g      = e.NewGauge(name).With(metrics.Field{Key: "ignored", Value: "field"})
 	)

--- a/metrics/provider/providers.go
+++ b/metrics/provider/providers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/discard"
 	"github.com/go-kit/kit/metrics/dogstatsd"
 	kitexp "github.com/go-kit/kit/metrics/expvar"
 	"github.com/go-kit/kit/metrics/graphite"
@@ -235,3 +236,27 @@ func (p prometheusProvider) NewGauge(name, help string) metrics.Gauge {
 
 // Stop is a no-op.
 func (prometheusProvider) Stop() {}
+
+var _ Provider = discardProvider{}
+
+// NewDiscardProvider returns a provider that will discard all metrics.
+func NewDiscardProvider(namespace, subsystem string) Provider {
+	return discardProvider{}
+}
+
+type discardProvider struct{}
+
+func (p discardProvider) NewCounter(name string, _ string) metrics.Counter {
+	return discard.NewCounter(name)
+}
+
+func (p discardProvider) NewHistogram(name string, _ string, _ int64, _ int64, _ int, _ ...int) (metrics.Histogram, error) {
+	return discard.NewHistogram(name), nil
+}
+
+func (p discardProvider) NewGauge(name string, _ string) metrics.Gauge {
+	return discard.NewGauge(name)
+}
+
+// Stop is a no-op.
+func (p discardProvider) Stop() {}

--- a/metrics/provider/providers.go
+++ b/metrics/provider/providers.go
@@ -240,7 +240,7 @@ func (prometheusProvider) Stop() {}
 var _ Provider = discardProvider{}
 
 // NewDiscardProvider returns a provider that will discard all metrics.
-func NewDiscardProvider(namespace, subsystem string) Provider {
+func NewDiscardProvider() Provider {
 	return discardProvider{}
 }
 

--- a/metrics/provider/providers.go
+++ b/metrics/provider/providers.go
@@ -1,0 +1,176 @@
+package provider
+
+import (
+	"errors"
+	"net"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/metrics"
+	kitexp "github.com/go-kit/kit/metrics/expvar"
+	"github.com/go-kit/kit/metrics/graphite"
+	kitprom "github.com/go-kit/kit/metrics/prometheus"
+	"github.com/go-kit/kit/metrics/statsd"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Provider represents a union set of constructors and lifecycle management
+// functions for each supported metrics backend. It should be used by those
+// who need to easily swap out implementations, e.g. dynamically, or at a
+// single point in an intermediating framework.
+type Provider interface {
+	NewCounter(name string) metrics.Counter
+	NewHistogram(name string, min, max int64, sigfigs int, quantiles ...int) (metrics.Histogram, error)
+	NewGauge(name string) metrics.Gauge
+
+	Stop()
+}
+
+// NewGraphiteProvider will return a Provider implementation that is a simple
+// wrapper around a graphite.Emitter. All metrics names will get prefixed
+// with the given value and data will be emitted once every interval.
+func NewGraphiteProvider(addr, net, prefix string, interval time.Duration, logger log.Logger) (Provider, error) {
+	if addr == "" {
+		return nil, errors.New("graphite server address is required")
+	}
+	if net == "" {
+		net = "udp"
+	}
+	// nop logger for now :\
+	e := graphite.NewEmitter(addr, net, prefix, interval, logger)
+	return &graphiteProvider{Emitter: e}, nil
+}
+
+type graphiteProvider struct {
+	*graphite.Emitter
+}
+
+// NewStatsdProvider will create a UDP connection for each metric
+// with the given address. All metrics will use the given interval
+// and, if a prefix is provided, it will be included in metric names
+// with this format:
+//    "prefix.name"
+func NewStatsdProvider(addr, prefix string, interval time.Duration, logger log.Logger) (Provider, error) {
+	return &statsdProvider{addr: addr, prefix: prefix, interval: interval}, nil
+}
+
+type statsdProvider struct {
+	addr string
+
+	interval time.Duration
+	prefix   string
+
+	logger log.Logger
+}
+
+func (s *statsdProvider) conn() (net.Conn, error) {
+	return net.Dial("udp", s.addr)
+}
+
+func (s *statsdProvider) pref(name string) string {
+	if len(s.prefix) > 0 {
+		return s.prefix + "." + name
+	}
+	return name
+}
+
+func (s *statsdProvider) NewCounter(name string) metrics.Counter {
+	conn, err := s.conn()
+	if err != nil {
+		s.logger.Log("during", "new counter", "err", err)
+		return nil
+	}
+	return statsd.NewCounter(conn, s.pref(name), s.interval)
+}
+
+func (s *statsdProvider) NewHistogram(name string, min, max int64, sigfigs int, quantiles ...int) (metrics.Histogram, error) {
+	conn, err := s.conn()
+	if err != nil {
+		return nil, err
+	}
+	return statsd.NewHistogram(conn, s.pref(name), s.interval), nil
+}
+
+func (s *statsdProvider) NewGauge(name string) metrics.Gauge {
+	conn, err := s.conn()
+	if err != nil {
+		s.logger.Log("during", "new gauge", "err", err)
+		return nil
+	}
+	return statsd.NewGauge(conn, s.pref(name), s.interval)
+}
+
+// Stop is a no-op  (should we try to close the UDP connections here?)
+func (s *statsdProvider) Stop() {}
+
+// NewExpvarProvider is a very thin wrapper over the expvar package.
+// If a prefix is provided, it will be included in metric names with this
+// format:
+//    "prefix.name"
+func NewExpvarProvider(prefix string) Provider {
+	return &expvarProvider{prefix: prefix}
+}
+
+type expvarProvider struct {
+	prefix string
+}
+
+func (e *expvarProvider) pref(name string) string {
+	if len(e.prefix) > 0 {
+		return e.prefix + "." + name
+	}
+	return name
+}
+
+func (e *expvarProvider) NewCounter(name string) metrics.Counter {
+	return kitexp.NewCounter(e.pref(name))
+}
+
+func (e *expvarProvider) NewHistogram(name string, min, max int64, sigfigs int, quantiles ...int) (metrics.Histogram, error) {
+	return kitexp.NewHistogram(e.pref(name), min, max, sigfigs, quantiles...), nil
+}
+
+func (e *expvarProvider) NewGauge(name string) metrics.Gauge {
+	return kitexp.NewGauge(e.pref(name))
+}
+
+// Stop is a no-op.
+func (e *expvarProvider) Stop() {}
+
+type prometheusProvider struct {
+	ns string
+}
+
+// NewPrometheusProvider will use the given namespace
+// for all metrics' Opts.
+func NewPrometheusProvider(namespace string) Provider {
+	return &prometheusProvider{ns: namespace}
+}
+
+func (p *prometheusProvider) NewCounter(name string) metrics.Counter {
+	opts := prometheus.CounterOpts{
+		Namespace: p.ns,
+		Name:      name,
+	}
+	return kitprom.NewCounter(opts, nil)
+}
+
+// NewHistogram ignores all NewHistogram parameters but `name`.
+func (p *prometheusProvider) NewHistogram(name string, min, max int64, sigfigs int, quantiles ...int) (metrics.Histogram, error) {
+	opts := prometheus.HistogramOpts{
+		Namespace: p.ns,
+		Name:      name,
+	}
+	return kitprom.NewHistogram(opts, nil), nil
+}
+
+func (p *prometheusProvider) NewGauge(name string) metrics.Gauge {
+	opts := prometheus.GaugeOpts{
+		Namespace: p.ns,
+		Name:      name,
+	}
+	return kitprom.NewGauge(opts, nil)
+}
+
+// Stop is a no-op
+func (p *prometheusProvider) Stop() {}

--- a/metrics/provider/providers.go
+++ b/metrics/provider/providers.go
@@ -193,10 +193,7 @@ type prometheusProvider struct {
 var _ Provider = prometheusProvider{}
 
 // NewPrometheusProvider returns a Prometheus provider that uses the provided
-// namespace and subsystem for all metrics. Help is not provided, which is very
-// much against Prometheus guidelines. Therefore, avoid using the Prometheus
-// provider unless it is absolutely necessary; prefer constructing Prometheus
-// metrics directly.
+// namespace and subsystem for all metrics.
 func NewPrometheusProvider(namespace, subsystem string) Provider {
 	return prometheusProvider{
 		namespace: namespace,

--- a/metrics/provider/providers_test.go
+++ b/metrics/provider/providers_test.go
@@ -1,0 +1,48 @@
+package provider
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+)
+
+func TestGraphite(t *testing.T) {
+	p, err := NewGraphiteProvider("network", "address", "prefix", time.Second, log.NewNopLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	testProvider(t, "Graphite", p)
+}
+
+func TestStatsd(t *testing.T) {
+	p, err := NewStatsdProvider("network", "address", "prefix", time.Second, log.NewNopLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	testProvider(t, "Statsd", p)
+}
+
+func TestExpvar(t *testing.T) {
+	testProvider(t, "Expvar", NewExpvarProvider("prefix"))
+}
+
+func TestPrometheus(t *testing.T) {
+	testProvider(t, "Prometheus", NewPrometheusProvider("namespace", "subsystem"))
+}
+
+func testProvider(t *testing.T, what string, p Provider) {
+	c := p.NewCounter("counter", "Counter help.")
+	c.Add(1)
+
+	h, err := p.NewHistogram("histogram", "Histogram help.", 1, 100, 3, 50, 95, 99)
+	if err != nil {
+		t.Errorf("%s: NewHistogram: %v", what, err)
+	}
+	h.Observe(99)
+
+	g := p.NewGauge("gauge", "Gauge help.")
+	g.Set(123)
+
+	p.Stop()
+}

--- a/metrics/provider/providers_test.go
+++ b/metrics/provider/providers_test.go
@@ -23,6 +23,14 @@ func TestStatsd(t *testing.T) {
 	testProvider(t, "Statsd", p)
 }
 
+func TestDogStatsd(t *testing.T) {
+	p, err := NewDogStatsdProvider("network", "address", "prefix", time.Second, log.NewNopLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	testProvider(t, "DogStatsd", p)
+}
+
 func TestExpvar(t *testing.T) {
 	testProvider(t, "Expvar", NewExpvarProvider("prefix"))
 }

--- a/metrics/statsd/emitter.go
+++ b/metrics/statsd/emitter.go
@@ -1,0 +1,154 @@
+package statsd
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/util/conn"
+)
+
+// Emitter is a struct to manage connections and orchestrate the emission of
+// metrics to a Statsd process.
+type Emitter struct {
+	prefix  string
+	keyVals chan keyVal
+	mgr     *conn.Manager
+	logger  log.Logger
+	quitc   chan chan struct{}
+}
+
+type keyVal struct {
+	key string
+	val string
+}
+
+func stringToKeyVal(key string, keyVals chan keyVal) chan string {
+	vals := make(chan string)
+	go func() {
+		for val := range vals {
+			keyVals <- keyVal{key: key, val: val}
+		}
+	}()
+	return vals
+}
+
+// NewEmitter will return an Emitter that will prefix all metrics names with the
+// given prefix. Once started, it will attempt to create a connection with the
+// given network and address via `net.Dial` and periodically post metrics to the
+// connection in the statsd protocol.
+func NewEmitter(network, address string, metricsPrefix string, flushInterval time.Duration, logger log.Logger) *Emitter {
+	return NewEmitterDial(net.Dial, network, address, metricsPrefix, flushInterval, logger)
+}
+
+// NewEmitterDial is the same as NewEmitter, but allows you to specify your own
+// Dialer function. This is primarily useful for tests.
+func NewEmitterDial(dialer conn.Dialer, network, address string, metricsPrefix string, flushInterval time.Duration, logger log.Logger) *Emitter {
+	e := &Emitter{
+		prefix:  metricsPrefix,
+		mgr:     conn.NewManager(dialer, network, address, time.After, logger),
+		logger:  logger,
+		keyVals: make(chan keyVal),
+		quitc:   make(chan chan struct{}),
+	}
+	var b bytes.Buffer
+	go e.loop(flushInterval, &b)
+	return e
+}
+
+// NewCounter returns a Counter that emits observations in the statsd protocol
+// via the Emitter's connection manager. Observations are buffered for the
+// report interval or until the buffer exceeds a max packet size, whichever
+// comes first. Fields are ignored.
+func (e *Emitter) NewCounter(key string) metrics.Counter {
+	return &statsdCounter{
+		key: e.prefix + key,
+		c:   stringToKeyVal(key, e.keyVals),
+	}
+}
+
+// NewHistogram returns a Histogram that emits observations in the statsd
+// protocol via the Emitter's conection manager. Observations are buffered for
+// the reporting interval or until the buffer exceeds a max packet size,
+// whichever comes first. Fields are ignored.
+//
+// NewHistogram is mapped to a statsd Timing, so observations should represent
+// milliseconds. If you observe in units of nanoseconds, you can make the
+// translation with a ScaledHistogram:
+//
+//    NewScaledHistogram(statsdHistogram, time.Millisecond)
+//
+// You can also enforce the constraint in a typesafe way with a millisecond
+// TimeHistogram:
+//
+//    NewTimeHistogram(statsdHistogram, time.Millisecond)
+//
+// TODO: support for sampling.
+func (e *Emitter) NewHistogram(key string) metrics.Histogram {
+	return &statsdHistogram{
+		key: e.prefix + key,
+		h:   stringToKeyVal(key, e.keyVals),
+	}
+}
+
+// NewGauge returns a Gauge that emits values in the statsd protocol via the
+// the Emitter's connection manager. Values are buffered for the report
+// interval or until the buffer exceeds a max packet size, whichever comes
+// first. Fields are ignored.
+//
+// TODO: support for sampling
+func (e *Emitter) NewGauge(key string) metrics.Gauge {
+	return &statsdGauge{
+		key: e.prefix + key,
+		g:   stringToKeyVal(key, e.keyVals),
+	}
+}
+
+func (e *Emitter) loop(d time.Duration, buf *bytes.Buffer) {
+	ticker := time.NewTicker(d)
+	defer ticker.Stop()
+	for {
+		select {
+		case kv := <-e.keyVals:
+			fmt.Fprintf(buf, "%s:%s\n", kv.key, kv.val)
+			if buf.Len() > maxBufferSize {
+				e.Flush(buf)
+			}
+
+		case <-ticker.C:
+			e.Flush(buf)
+
+		case q := <-e.quitc:
+			e.Flush(buf)
+			close(q)
+			return
+		}
+	}
+}
+
+// Stop will flush the current metrics and close the active connection. Calling
+// stop more than once is a programmer error.
+func (e *Emitter) Stop() {
+	q := make(chan struct{})
+	e.quitc <- q
+	<-q
+}
+
+// Flush will write the given buffer to a connection provided by the Emitter's
+// connection manager.
+func (e *Emitter) Flush(buf *bytes.Buffer) {
+	conn := e.mgr.Take()
+	if conn == nil {
+		e.logger.Log("during", "flush", "err", "connection unavailable")
+		return
+	}
+
+	_, err := conn.Write(buf.Bytes())
+	if err != nil {
+		e.logger.Log("during", "flush", "err", err)
+	}
+	e.mgr.Put(err)
+}

--- a/metrics/statsd/emitter.go
+++ b/metrics/statsd/emitter.go
@@ -64,7 +64,7 @@ func NewEmitterDial(dialer conn.Dialer, network, address string, metricsPrefix s
 // comes first. Fields are ignored.
 func (e *Emitter) NewCounter(key string) metrics.Counter {
 	key = e.prefix + key
-	return &statsdCounter{
+	return &counter{
 		key: key,
 		c:   stringToKeyVal(key, e.keyVals),
 	}
@@ -79,17 +79,17 @@ func (e *Emitter) NewCounter(key string) metrics.Counter {
 // milliseconds. If you observe in units of nanoseconds, you can make the
 // translation with a ScaledHistogram:
 //
-//    NewScaledHistogram(statsdHistogram, time.Millisecond)
+//    NewScaledHistogram(histogram, time.Millisecond)
 //
 // You can also enforce the constraint in a typesafe way with a millisecond
 // TimeHistogram:
 //
-//    NewTimeHistogram(statsdHistogram, time.Millisecond)
+//    NewTimeHistogram(histogram, time.Millisecond)
 //
 // TODO: support for sampling.
 func (e *Emitter) NewHistogram(key string) metrics.Histogram {
 	key = e.prefix + key
-	return &statsdHistogram{
+	return &histogram{
 		key: key,
 		h:   stringToKeyVal(key, e.keyVals),
 	}
@@ -103,7 +103,7 @@ func (e *Emitter) NewHistogram(key string) metrics.Histogram {
 // TODO: support for sampling
 func (e *Emitter) NewGauge(key string) metrics.Gauge {
 	key = e.prefix + key
-	return &statsdGauge{
+	return &gauge{
 		key: key,
 		g:   stringToKeyVal(key, e.keyVals),
 	}

--- a/metrics/teststat/graphite.go
+++ b/metrics/teststat/graphite.go
@@ -1,0 +1,61 @@
+package teststat
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// AssertGraphiteNormalHistogram ensures the expvar Histogram referenced by
+// metricName abides a normal distribution.
+func AssertGraphiteNormalHistogram(t *testing.T, prefix, metricName string, mean, stdev int64, quantiles []int, gPayload string) {
+	const tolerance int = 2
+
+	// check for hdr histo data
+	wants := map[string]int64{"count": 1234, "min": 15, "max": 83, "std-dev": stdev, "mean": mean}
+	for key, want := range wants {
+		re := regexp.MustCompile(fmt.Sprintf("%s.%s.%s (\\d*)", prefix, metricName, key))
+		if res := re.FindAllStringSubmatch(gPayload, 1); res != nil {
+			if len(res[0]) == 1 {
+				t.Errorf("bad regex found, please check the test scenario")
+				continue
+			}
+
+			have, err := strconv.ParseInt(res[0][1], 10, 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if int(math.Abs(float64(want-have))) > tolerance {
+				t.Errorf("key %s: want %d, have %d", key, want, have)
+			}
+		} else {
+			t.Error("did not find metrics log for", key, "in \n", gPayload)
+		}
+	}
+
+	// check for quantile gauges
+	for _, quantile := range quantiles {
+		want := normalValueAtQuantile(mean, stdev, quantile)
+
+		re := regexp.MustCompile(fmt.Sprintf("%s.%s_p%02d (\\d*\\.\\d*)", prefix, metricName, quantile))
+		if res := re.FindAllStringSubmatch(gPayload, 1); res != nil {
+			if len(res[0]) == 1 {
+				t.Errorf("bad regex found, please check the test scenario")
+				continue
+			}
+			have, err := strconv.ParseFloat(res[0][1], 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if int(math.Abs(float64(want)-have)) > tolerance {
+				t.Errorf("quantile %d: want %.2f, have %.2f", quantile, want, have)
+			}
+		} else {
+			t.Errorf("did not find metrics log for %d", quantile)
+		}
+
+	}
+}

--- a/metrics/teststat/graphite.go
+++ b/metrics/teststat/graphite.go
@@ -14,7 +14,7 @@ func AssertGraphiteNormalHistogram(t *testing.T, prefix, metricName string, mean
 	// check for hdr histo data
 	wants := map[string]int64{"count": 1234, "min": 15, "max": 83}
 	for key, want := range wants {
-		re := regexp.MustCompile(fmt.Sprintf("%s.%s.%s (\\d*)", prefix, metricName, key))
+		re := regexp.MustCompile(fmt.Sprintf("%s%s.%s (\\d*)", prefix, metricName, key))
 		res := re.FindAllStringSubmatch(gPayload, 1)
 		if res == nil {
 			t.Error("did not find metrics log for", key, "in \n", gPayload)
@@ -42,7 +42,7 @@ func AssertGraphiteNormalHistogram(t *testing.T, prefix, metricName string, mean
 	}
 	// check for quantile gauges
 	for key, want := range wants {
-		re := regexp.MustCompile(fmt.Sprintf("%s.%s%s (\\d*\\.\\d*)", prefix, metricName, key))
+		re := regexp.MustCompile(fmt.Sprintf("%s%s%s (\\d*\\.\\d*)", prefix, metricName, key))
 		res := re.FindAllStringSubmatch(gPayload, 1)
 		if res == nil {
 			t.Errorf("did not find metrics log for %s", key)

--- a/metrics/teststat/graphite.go
+++ b/metrics/teststat/graphite.go
@@ -11,51 +11,53 @@ import (
 // AssertGraphiteNormalHistogram ensures the expvar Histogram referenced by
 // metricName abides a normal distribution.
 func AssertGraphiteNormalHistogram(t *testing.T, prefix, metricName string, mean, stdev int64, quantiles []int, gPayload string) {
-	const tolerance int = 2
-
 	// check for hdr histo data
-	wants := map[string]int64{"count": 1234, "min": 15, "max": 83, "std-dev": stdev, "mean": mean}
+	wants := map[string]int64{"count": 1234, "min": 15, "max": 83}
 	for key, want := range wants {
 		re := regexp.MustCompile(fmt.Sprintf("%s.%s.%s (\\d*)", prefix, metricName, key))
-		if res := re.FindAllStringSubmatch(gPayload, 1); res != nil {
-			if len(res[0]) == 1 {
-				t.Errorf("bad regex found, please check the test scenario")
-				continue
-			}
-
-			have, err := strconv.ParseInt(res[0][1], 10, 64)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if int(math.Abs(float64(want-have))) > tolerance {
-				t.Errorf("key %s: want %d, have %d", key, want, have)
-			}
-		} else {
+		res := re.FindAllStringSubmatch(gPayload, 1)
+		if res == nil {
 			t.Error("did not find metrics log for", key, "in \n", gPayload)
+			continue
+		}
+
+		if len(res[0]) == 1 {
+			t.Fatalf("%q: bad regex, please check the test scenario", key)
+		}
+
+		have, err := strconv.ParseInt(res[0][1], 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if want != have {
+			t.Errorf("key %s: want %d, have %d", key, want, have)
 		}
 	}
 
-	// check for quantile gauges
+	const tolerance int = 2
+	wants = map[string]int64{".std-dev": stdev, ".mean": mean}
 	for _, quantile := range quantiles {
-		want := normalValueAtQuantile(mean, stdev, quantile)
-
-		re := regexp.MustCompile(fmt.Sprintf("%s.%s_p%02d (\\d*\\.\\d*)", prefix, metricName, quantile))
-		if res := re.FindAllStringSubmatch(gPayload, 1); res != nil {
-			if len(res[0]) == 1 {
-				t.Errorf("bad regex found, please check the test scenario")
-				continue
-			}
-			have, err := strconv.ParseFloat(res[0][1], 64)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if int(math.Abs(float64(want)-have)) > tolerance {
-				t.Errorf("quantile %d: want %.2f, have %.2f", quantile, want, have)
-			}
-		} else {
-			t.Errorf("did not find metrics log for %d", quantile)
+		wants[fmt.Sprintf("_p%02d", quantile)] = normalValueAtQuantile(mean, stdev, quantile)
+	}
+	// check for quantile gauges
+	for key, want := range wants {
+		re := regexp.MustCompile(fmt.Sprintf("%s.%s%s (\\d*\\.\\d*)", prefix, metricName, key))
+		res := re.FindAllStringSubmatch(gPayload, 1)
+		if res == nil {
+			t.Errorf("did not find metrics log for %s", key)
+			continue
 		}
 
+		if len(res[0]) == 1 {
+			t.Fatalf("%q: bad regex found, please check the test scenario", key)
+		}
+		have, err := strconv.ParseFloat(res[0][1], 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if int(math.Abs(float64(want)-have)) > tolerance {
+			t.Errorf("key %s: want %.2f, have %.2f", key, want, have)
+		}
 	}
 }

--- a/util/conn/manager.go
+++ b/util/conn/manager.go
@@ -10,7 +10,7 @@ import (
 // Dialer dials a network and address. net.Dial is a good default Dialer.
 type Dialer func(network, address string) (net.Conn, error)
 
-// time.After is a good default afterFunc.
+// AfterFunc imitates time.After.
 type AfterFunc func(time.Duration) <-chan time.Time
 
 // Manager manages a net.Conn. Clients should take the conn when they want to

--- a/util/conn/manager.go
+++ b/util/conn/manager.go
@@ -11,7 +11,7 @@ import (
 type Dialer func(network, address string) (net.Conn, error)
 
 // time.After is a good default afterFunc.
-type afterFunc func(time.Duration) <-chan time.Time
+type AfterFunc func(time.Duration) <-chan time.Time
 
 // Manager manages a net.Conn. Clients should take the conn when they want to
 // use it, and put back whatever error they receive from an e.g. Write. When a
@@ -21,14 +21,14 @@ type Manager struct {
 	dial    Dialer
 	network string
 	address string
-	after   afterFunc
+	after   AfterFunc
 	logger  log.Logger
 
 	takec chan net.Conn
 	putc  chan error
 }
 
-func NewManager(d Dialer, network, address string, after afterFunc, logger log.Logger) *Manager {
+func NewManager(d Dialer, network, address string, after AfterFunc, logger log.Logger) *Manager {
 	m := &Manager{
 		dial:    d,
 		network: network,


### PR DESCRIPTION
This PR is hoping to knock out both issues #251 and #262.

Included is the the new `Emitter` types for the `metrics/statsd` and `metrics/graphite` packages, both of which utilize the new `util/conn.Manager` connection manager.

The new `metrics/provider.Provider` is a thin layer over the new `Emitter` types along with very basic implementations for `expvar` and `prometheus`.

This PR currently lacks implementations for `dogstatsd` as I wanted to wait for feedback on the `statsd.Emitter` before continuing down the route and creating a `dogstatd.Emitter`.

If this PR is accepted, we can discard PR #259.