### PR TITLE
opentracing/grpc fix: properly encode metadata key-value pairs

### DIFF
--- a/tracing/opentracing/grpc.go
+++ b/tracing/opentracing/grpc.go
@@ -1,6 +1,9 @@
 package opentracing
 
 import (
+	"encoding/base64"
+	"strings"
+
 	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
@@ -53,6 +56,10 @@ type metadataReaderWriter struct {
 }
 
 func (w metadataReaderWriter) Set(key, val string) {
+	key = strings.ToLower(key)
+	if strings.HasSuffix(key, "-bin") {
+		val = string(base64.StdEncoding.EncodeToString([]byte(val)))
+	}
 	(*w.MD)[key] = append((*w.MD)[key], val)
 }
 


### PR DESCRIPTION
Minor fix to properly encode gRPC metadata keys. 

Most OpenTracing drivers use lower cased propagation keys, so no problems show up. With Zipkin however we need to lower case the keys if using gRPC transport. Zipkin B3 keys are defined mixed case.