### PR TITLE
tracing/opentracing: bugfixes and zipkin-go-opentracing example in addsvc

### DIFF
--- a/examples/addsvc/client/main.go
+++ b/examples/addsvc/client/main.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	zipkin "github.com/basvanbeek/zipkin-go-opentracing"
 	"github.com/lightstep/lightstep-tracer-go"
 	"github.com/opentracing/opentracing-go"
+	zipkin "github.com/openzipkin/zipkin-go-opentracing"
 	appdashot "github.com/sourcegraph/appdash/opentracing"
 	"golang.org/x/net/context"
 	"sourcegraph.com/sourcegraph/appdash"

--- a/examples/addsvc/client/main.go
+++ b/examples/addsvc/client/main.go
@@ -78,20 +78,21 @@ func main() {
 				zipkin.KafkaLogger(tracingLogger),
 			)
 			if err != nil {
-				tracingLogger.Log("err", "unable to create kafka collector")
+				tracingLogger.Log("err", "unable to create kafka collector", "fatal", err)
 				os.Exit(1)
 			}
 			tracer, err = zipkin.NewTracer(
 				zipkin.NewRecorder(collector, false, "localhost:8000", "addsvc-client"),
 			)
 			if err != nil {
-				tracingLogger.Log("err", "unable to create zipkin tracer")
+				tracingLogger.Log("err", "unable to create zipkin tracer", "fatal", err)
 				os.Exit(1)
 			}
 		case *appdashAddr == "" && *lightstepAccessToken == "" && *zipkinAddr == "":
 			tracer = opentracing.GlobalTracer() // no-op
 		default:
-			panic("specify a single -appdash.addr, -lightstep.access.token or -zipkin.kafka.addr")
+			tracingLogger.Log("fatal", "specify a single -appdash.addr, -lightstep.access.token or -zipkin.kafka.addr")
+			os.Exit(1)
 		}
 	}
 

--- a/examples/addsvc/main.go
+++ b/examples/addsvc/main.go
@@ -102,20 +102,21 @@ func main() {
 				zipkin.KafkaLogger(logger),
 			)
 			if err != nil {
-				logger.Log("err", "unable to create kafka collector")
+				logger.Log("err", "unable to create collector", "fatal", err)
 				os.Exit(1)
 			}
 			tracer, err = zipkin.NewTracer(
 				zipkin.NewRecorder(collector, false, "localhost:80", "addsvc"),
 			)
 			if err != nil {
-				logger.Log("err", "unable to create zipkin tracer")
+				logger.Log("err", "unable to create zipkin tracer", "fatal", err)
 				os.Exit(1)
 			}
 		case *appdashAddr == "" && *lightstepAccessToken == "" && *zipkinAddr == "":
 			tracer = opentracing.GlobalTracer() // no-op
 		default:
-			panic("specify a single -appdash.addr, -lightstep.access.token or -zipkin.kafka.addr")
+			logger.Log("fatal", "specify a single -appdash.addr, -lightstep.access.token or -zipkin.kafka.addr")
+			os.Exit(1)
 		}
 	}
 

--- a/examples/addsvc/main.go
+++ b/examples/addsvc/main.go
@@ -15,9 +15,9 @@ import (
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	zipkin "github.com/basvanbeek/zipkin-go-opentracing"
 	"github.com/lightstep/lightstep-tracer-go"
 	"github.com/opentracing/opentracing-go"
+	zipkin "github.com/openzipkin/zipkin-go-opentracing"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	appdashot "github.com/sourcegraph/appdash/opentracing"
 	"golang.org/x/net/context"

--- a/examples/addsvc/main.go
+++ b/examples/addsvc/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
+	zipkin "github.com/basvanbeek/zipkin-go-opentracing"
 	"github.com/lightstep/lightstep-tracer-go"
 	"github.com/opentracing/opentracing-go"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
@@ -32,7 +33,6 @@ import (
 	"github.com/go-kit/kit/metrics/expvar"
 	"github.com/go-kit/kit/metrics/prometheus"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
-	"github.com/go-kit/kit/tracing/zipkin"
 	httptransport "github.com/go-kit/kit/transport/http"
 )
 
@@ -51,6 +51,7 @@ func main() {
 		thriftFramed     = fs.Bool("thrift.framed", false, "true to enable framing")
 
 		// Supported OpenTracing backends
+		zipkinAddr           = fs.String("zipkin.kafka.addr", "", "Enable Zipkin tracing via a Kafka server host:port")
 		appdashAddr          = fs.String("appdash.addr", "", "Enable Appdash tracing via an Appdash server host:port")
 		lightstepAccessToken = fs.String("lightstep.token", "", "Enable LightStep tracing via a LightStep access token")
 	)
@@ -88,17 +89,33 @@ func main() {
 	var tracer opentracing.Tracer
 	{
 		switch {
-		case *appdashAddr != "" && *lightstepAccessToken == "":
+		case *appdashAddr != "" && *lightstepAccessToken == "" && *zipkinAddr == "":
 			tracer = appdashot.NewTracer(appdash.NewRemoteCollector(*appdashAddr))
-		case *appdashAddr == "" && *lightstepAccessToken != "":
+		case *appdashAddr == "" && *lightstepAccessToken != "" && *zipkinAddr == "":
 			tracer = lightstep.NewTracer(lightstep.Options{
 				AccessToken: *lightstepAccessToken,
 			})
 			defer lightstep.FlushLightStepTracer(tracer)
-		case *appdashAddr == "" && *lightstepAccessToken == "":
+		case *appdashAddr == "" && *lightstepAccessToken == "" && *zipkinAddr != "":
+			collector, err := zipkin.NewKafkaCollector(
+				strings.Split(*zipkinAddr, ","),
+				zipkin.KafkaLogger(logger),
+			)
+			if err != nil {
+				logger.Log("err", "unable to create kafka collector")
+				os.Exit(1)
+			}
+			tracer, err = zipkin.NewTracer(
+				zipkin.NewRecorder(collector, false, "localhost:80", "addsvc"),
+			)
+			if err != nil {
+				logger.Log("err", "unable to create zipkin tracer")
+				os.Exit(1)
+			}
+		case *appdashAddr == "" && *lightstepAccessToken == "" && *zipkinAddr == "":
 			tracer = opentracing.GlobalTracer() // no-op
 		default:
-			panic("specify either -appdash.addr or -lightstep.access.token, not both")
+			panic("specify a single -appdash.addr, -lightstep.access.token or -zipkin.kafka.addr")
 		}
 	}
 
@@ -237,24 +254,3 @@ func interrupt() error {
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 	return fmt.Errorf("%s", <-c)
 }
-
-type loggingCollector struct{ log.Logger }
-
-func (c loggingCollector) Collect(s *zipkin.Span) error {
-	annotations := s.Encode().GetAnnotations()
-	values := make([]string, len(annotations))
-	for i, a := range annotations {
-		values[i] = a.Value
-	}
-	c.Logger.Log(
-		"trace_id", s.TraceID(),
-		"span_id", s.SpanID(),
-		"parent_span_id", s.ParentSpanID(),
-		"annotations", strings.Join(values, " "),
-	)
-	return nil
-}
-
-func (c loggingCollector) ShouldSample(*zipkin.Span) bool { return true }
-
-func (c loggingCollector) Close() error { return nil }

--- a/tracing/opentracing/grpc.go
+++ b/tracing/opentracing/grpc.go
@@ -39,11 +39,11 @@ func ToGRPCRequest(tracer opentracing.Tracer, logger log.Logger) func(ctx contex
 func FromGRPCRequest(tracer opentracing.Tracer, operationName string, logger log.Logger) func(ctx context.Context, md *metadata.MD) context.Context {
 	return func(ctx context.Context, md *metadata.MD) context.Context {
 		span, err := tracer.Join(operationName, opentracing.TextMap, metadataReaderWriter{md})
-		if err != nil && logger != nil {
-			logger.Log("msg", "Join failed", "err", err)
-		}
-		if span == nil {
+		if err != nil {
 			span = tracer.StartSpan(operationName)
+			if logger != nil {
+				logger.Log("msg", "Join failed", "err", err)
+			}
 		}
 		return opentracing.ContextWithSpan(ctx, span)
 	}

--- a/tracing/opentracing/grpc.go
+++ b/tracing/opentracing/grpc.go
@@ -20,9 +20,8 @@ func ToGRPCRequest(tracer opentracing.Tracer, logger log.Logger) func(ctx contex
 	return func(ctx context.Context, md *metadata.MD) context.Context {
 		if span := opentracing.SpanFromContext(ctx); span != nil {
 			// There's nothing we can do with an error here.
-			err := tracer.Inject(span, opentracing.TextMap, metadataReaderWriter{md})
-			if err != nil && logger != nil {
-				logger.Log("msg", "Inject failed", "err", err)
+			if err := tracer.Inject(span, opentracing.TextMap, metadataReaderWriter{md}); err != nil {
+				logger.Log("err", err)
 			}
 		}
 		return ctx
@@ -41,8 +40,8 @@ func FromGRPCRequest(tracer opentracing.Tracer, operationName string, logger log
 		span, err := tracer.Join(operationName, opentracing.TextMap, metadataReaderWriter{md})
 		if err != nil {
 			span = tracer.StartSpan(operationName)
-			if logger != nil {
-				logger.Log("msg", "Join failed", "err", err)
+			if err != opentracing.ErrTraceNotFound {
+				logger.Log("err", err)
 			}
 		}
 		return opentracing.ContextWithSpan(ctx, span)

--- a/tracing/opentracing/http.go
+++ b/tracing/opentracing/http.go
@@ -27,7 +27,7 @@ func ToHTTPRequest(tracer opentracing.Tracer, logger log.Logger) kithttp.Request
 			host, portString, err := net.SplitHostPort(req.URL.Host)
 			if err == nil {
 				ext.PeerHostname.Set(span, host)
-				if port, _ := strconv.Atoi(portString); err != nil {
+				if port, err := strconv.Atoi(portString); err != nil {
 					ext.PeerPort.Set(span, uint16(port))
 				}
 			} else {


### PR DESCRIPTION
The opentracing.FromHTTPRequest and opentracing.FromGRPCRequest incorrectly assumed span would be nil on a Join error. This made the next step crash in a server side implementation.

Added Zipkin to the examples to highlight the availability of it through OpenTracing.