### PR TITLE
gRPC client fix: allow package names other than "pb"

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -35,9 +36,12 @@ func NewClient(
 	grpcReply interface{},
 	options ...ClientOption,
 ) *Client {
+	if strings.IndexByte(serviceName, '.') == -1 {
+		serviceName = "pb." + serviceName
+	}
 	c := &Client{
 		client: cc,
-		method: fmt.Sprintf("/pb.%s/%s", serviceName, method),
+		method: fmt.Sprintf("/%s/%s", serviceName, method),
 		enc:    enc,
 		dec:    dec,
 		// We are using reflect.Indirect here to allow both reply structs and


### PR DESCRIPTION
Previously the gRPC Client package automatically prefixed the "pb" package namespace to the gRPC service name. Since generated gRPC packages can have other names this caused problems.

This fix allows for setting service name with package prefix explicitly while remaining backward compatible to consumers omitting the package prefix.

This resolves issue #281 