### PR TITLE
examples/addsvc: recompile protobufs

### DIFF
--- a/examples/addsvc/pb/addsvc.pb.go
+++ b/examples/addsvc/pb/addsvc.pb.go
@@ -32,7 +32,9 @@ var _ = math.Inf
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
-const _ = proto.ProtoPackageIsVersion1
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 // The sum request contains two parameters.
 type SumRequest struct {
@@ -91,7 +93,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion2
+const _ = grpc.SupportPackageIsVersion3
 
 // Client API for Add service
 
@@ -190,8 +192,11 @@ var _Add_serviceDesc = grpc.ServiceDesc{
 			Handler:    _Add_Concat_Handler,
 		},
 	},
-	Streams: []grpc.StreamDesc{},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: fileDescriptor0,
 }
+
+func init() { proto.RegisterFile("addsvc.proto", fileDescriptor0) }
 
 var fileDescriptor0 = []byte{
 	// 188 bytes of a gzipped FileDescriptorProto


### PR DESCRIPTION
Fixes a breaking change in gRPC upstream. (I hope.)