### PR TITLE
[WIP] Transports and contexts

### DIFF
--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -74,8 +74,7 @@ func ServerErrorLogger(logger log.Logger) ServerOption {
 
 // ServeGRPC implements the Handler interface.
 func (s Server) ServeGRPC(grpcCtx context.Context, req interface{}) (context.Context, interface{}, error) {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
+	ctx := s.ctx
 
 	// Retrieve gRPC metadata.
 	md, ok := metadata.FromContext(grpcCtx)

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -76,8 +76,7 @@ func ServerErrorLogger(logger log.Logger) ServerOption {
 
 // ServeHTTP implements http.Handler.
 func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
+	ctx := s.ctx
 
 	for _, f := range s.before {
 		ctx = f(ctx, r)

--- a/transport/httprp/server.go
+++ b/transport/httprp/server.go
@@ -51,8 +51,7 @@ func ServerBefore(before ...RequestFunc) ServerOption {
 
 // ServeHTTP implements http.Handler.
 func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
+	ctx := s.ctx
 
 	for _, f := range s.before {
 		ctx = f(ctx, r)


### PR DESCRIPTION
remove creation and call of server.Serve method's context.WithCancel.

In this initial commit I believe it would be in the interesting of flexibility to not force and immediate cancellation of the context that is spawned from the server.

This cancellation prevents the ability to fire an asynchronous request that inherits from the same context that was given for the Serve request.

However, I believe that may warrant further discussion, as in the golang 1.7 release there will be a context that will likely be inherited from in a future change to go-kit, that will cancel the underlying context when the client's connection is closed:
https://github.com/golang/go/blob/master/src/net/http/server.go#L1508-L1509

This is also the case with client-side connection as well in the new DialContext method
https://github.com/golang/go/blob/master/src/net/dial.go#L308-L309

In both of these cases the context lives for the life-time of the connection.  However, there is an important distinction.  On the client side, the context is inherited from the context that is passed in.  This means that when the context is canceled, it will only cancel down the context inheritence stack, which is only the context that they've created.  However, in the server side implementation, everything is inherited directly from the Connection handling / delivery with golang's net/http conn.serve method.

For Example the output of the following program
```go
package main

import (
	"context"
	"fmt"
	"sync"
)

func WaitTilDone(ctx context.Context, wg *sync.WaitGroup ) {
	select {
	case <- ctx.Done():
		fmt.Println( ctx.Err() )
	default:
		fmt.Println("Not Canceled")
	}

	wg.Done()
}

func main() {
	wg := new(sync.WaitGroup)
	ctx1 := context.Background()
	ctx2, cancel := context.WithCancel(ctx1)
	wg.Add(2)

	// cancel ctx2 immediately
	cancel()

	go WaitTilDone(ctx2, wg)
	go WaitTilDone(ctx1, wg)

	wg.Wait()
}
```
is the following:
```txt
Not Canceled
context canceled

```

Perhaps this means that overall context utilization may need to be reconsidered on the Server, as any inheritance from the net/http's conn.serve method's context will be canceled and invalidated on client connection close.


In the mean time, I'd also like to consider the removal of the context extension / cancellation in the client transport methods as well.  However, these hardly have much of a bearing, and I don't think they affect logic / asynchronous calls one way or another.

https://github.com/go-kit/kit/blob/master/transport/grpc/client.go#L77-L78
https://github.com/go-kit/kit/blob/master/transport/http/client.go#L80-L81

