### PR TITLE
[WIP] kitgen code generation

### DIFF
--- a/cmd/kitgen/main.go
+++ b/cmd/kitgen/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+)
+
+var (
+	// Logf will always output.
+	Logf = log.Printf
+
+	// Debugf will only output if -debug is passed.
+	Debugf = log.Printf
+)
+
+func main() {
+	// Set up the flags and usage text.
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage:\n")
+		fmt.Fprintf(os.Stderr, "  %s [flags] <Go source files>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "Flags:\n")
+		flag.PrintDefaults()
+	}
+	var (
+		debug = flag.Bool("debug", false, "Print debug information during parse")
+		name  = flag.String("name", "Service", "Interface name to extract")
+	)
+	flag.Parse()
+	if flag.NArg() <= 0 {
+		fmt.Fprintf(os.Stderr, "Error: %s requires at least 1 Go source file as an argument.\n\n", os.Args[0])
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// Set up our output.
+	log.SetFlags(0)
+	if !*debug {
+		Debugf = func(format string, args ...interface{}) {}
+	}
+
+	// Parse the files for the interface we will implement.
+	imports, iface, err := parseFiles(*name, flag.Args()...)
+	if err != nil {
+		Logf("Parse failed: %v", err)
+		os.Exit(1)
+	}
+	Logf(
+		"Found interface %s, with %d method(s), requiring %d import(s)",
+		iface.Name,
+		len(iface.Methods),
+		len(imports),
+	)
+	Logf("import (")
+	for _, importStr := range imports {
+		Logf("\t%s", importStr)
+	}
+	Logf(")")
+	Logf("")
+	Logf("%s", iface)
+
+	// TODO(pb): request and response structs
+	// TODO(pb): default interface implementation
+	// TODO(pb): endpoint constructors
+	// TODO(pb): default transport binding
+}

--- a/cmd/kitgen/parse.go
+++ b/cmd/kitgen/parse.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"go/ast"
+	"go/parser"
+	"go/token"
+)
+
+// Interface is the definition of our service.
+type Interface struct {
+	Name    string // Service (must be exported)
+	Methods []Method
+}
+
+func (i Interface) String() string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "type %s interface {\n", i.Name)
+	for _, method := range i.Methods {
+		fmt.Fprintf(&buf, "\t%s\n", method)
+	}
+	fmt.Fprintf(&buf, "}\n")
+	return buf.String()
+}
+
+// Method describes one method of the interface.
+type Method struct {
+	Name       string // Foo
+	Parameters []NamedType
+	Results    []NamedType
+}
+
+func (m Method) String() string {
+	var params []string
+	for _, param := range m.Parameters {
+		params = append(params, param.String())
+	}
+	paramStr := strings.Join(params, ", ")
+
+	var results []string
+	for _, result := range m.Results {
+		results = append(results, result.String())
+	}
+	var resultStr string
+	switch len(m.Results) {
+	case 0:
+		resultStr = ""
+	case 1:
+		resultStr = m.Results[0].Type
+	default:
+		resultStr = "(" + strings.Join(results, ", ") + ")"
+	}
+
+	return strings.TrimSpace(fmt.Sprintf("%s(%s) %s", m.Name, paramStr, resultStr))
+}
+
+// NamedType is a name and type tuple, e.g. `s string`.
+type NamedType struct {
+	Name string // "ctx"
+	Type string // "context.Context"
+}
+
+func (nt NamedType) String() string {
+	return fmt.Sprintf("%s %s", nt.Name, nt.Type)
+}
+
+func parseFiles(name string, filenames ...string) ([]string, Interface, error) {
+	for _, filename := range filenames {
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, filename, nil, parser.AllErrors)
+		if err != nil {
+			log.Printf("%s: %v", filename, err)
+			continue
+		}
+		imports, iface, ok := parseFile(name, f)
+		if ok {
+			Debugf("Successfully parsed %s from %s", name, filename)
+			return imports, iface, nil
+		}
+	}
+	return []string{}, Interface{}, errors.New("no suitable interface found")
+}
+
+func parseFile(name string, f *ast.File) ([]string, Interface, bool) {
+	Debugf("Parsing file %s", f.Name)
+	var imports []string
+	for i, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok {
+			Debugf("%s: skipping Decl %d", f.Name, i)
+			continue
+		}
+
+		for j, spec := range genDecl.Specs {
+			switch s := spec.(type) {
+			case *ast.ImportSpec:
+				importString := parseImportSpec(s)
+				Debugf("Appending import %s", importString)
+				imports = append(imports, importString)
+
+			case *ast.TypeSpec:
+				if iface, ok := parseTypeSpec(name, s); ok {
+					return imports, iface, true
+				}
+				Debugf("Failed to parse an Interface; continuing")
+
+			default:
+				Debugf("%s: Decl %d: skipping Spec %d", f.Name, i, j)
+			}
+		}
+	}
+	return []string{}, Interface{}, false
+}
+
+func parseImportSpec(s *ast.ImportSpec) string {
+	Debugf("Parsing ImportSpec %s", s.Name)
+
+	importAlias, importPath := "", s.Path.Value
+	if s.Name != nil {
+		importAlias = s.Name.Name
+	}
+	importString := strings.TrimSpace(fmt.Sprintf("%s %s", importAlias, importPath))
+	return importString
+}
+
+func parseTypeSpec(name string, s *ast.TypeSpec) (Interface, bool) {
+	Debugf("Parsing TypeSpec %s", s.Name)
+
+	t, ok := s.Type.(*ast.InterfaceType)
+	if !ok {
+		Debugf("Skipping a non-interface type")
+		return Interface{}, false
+	}
+	if s.Name.String() != name {
+		Debugf("Found interface %q, but looking for %q; skipping", s.Name, name)
+		return Interface{}, false
+	}
+	return parseInterfaceType(s.Name.Name, t), true
+}
+
+func parseInterfaceType(interfaceName string, t *ast.InterfaceType) Interface {
+	Debugf("Parsing InterfaceType %s", interfaceName)
+
+	var methods []Method
+	for i, field := range t.Methods.List {
+		funcType, ok := field.Type.(*ast.FuncType)
+		if !ok {
+			Debugf("Skipping non-function field %d", i)
+			continue
+		}
+
+		var methodName string
+		for _, ident := range field.Names {
+			if !ident.IsExported() {
+				continue
+			}
+			methodName = ident.Name
+			break
+		}
+		if methodName == "" {
+			Debugf("Field %d had no exported name; skipping", i)
+			continue
+		}
+
+		method := parseMethodField(methodName, field, funcType)
+		methods = append(methods, method)
+	}
+
+	return Interface{
+		Name:    interfaceName,
+		Methods: methods,
+	}
+}
+
+func parseMethodField(methodName string, field *ast.Field, funcType *ast.FuncType) Method {
+	Debugf("Parsing method %s", methodName)
+
+	params := parseFieldListAsNamedTypes(funcType.Params)
+	Debugf("Params: %#+v", params)
+
+	results := parseFieldListAsNamedTypes(funcType.Results)
+	Debugf("Results: %#+v", results)
+
+	return Method{
+		Name:       methodName,
+		Parameters: params,
+		Results:    results,
+	}
+}
+
+func parseFieldListAsNamedTypes(list *ast.FieldList) []NamedType {
+	Debugf("Parsing FieldList (%d) as NamedTypes", len(list.List))
+
+	var namedTypes []NamedType
+	for _, field := range list.List {
+		// Always 1 type
+		var typ string
+		switch t := field.Type.(type) {
+		case *ast.Ident:
+			Debugf("Type Ident, i.e. a built-in type")
+			typ = t.Name
+
+		case *ast.SelectorExpr:
+			Debugf("Type Selector, i.e. a third-party type")
+			selectorIdent, ok := t.X.(*ast.Ident)
+			if !ok {
+				Debugf("Selector X isn't an Ident; very odd, skipping")
+				continue
+			}
+			typ = fmt.Sprintf("%s.%s", selectorIdent.Name, t.Sel.Name)
+
+		default:
+			Debugf("Skipping unknown Field Type")
+			continue
+		}
+		Debugf("Type %s", typ)
+
+		// Potentially N names
+		var names []string
+		for _, ident := range field.Names {
+			names = append(names, ident.Name)
+		}
+		if len(names) == 0 {
+			// Anonymous named type, give it a default name
+			names = append(names, "somename") // TODO(pb): generator
+		}
+		for _, name := range names {
+			namedType := NamedType{
+				Name: name,
+				Type: typ,
+			}
+			Debugf("NamedType %+v", namedType)
+			namedTypes = append(namedTypes, namedType)
+		}
+	}
+	return namedTypes
+}

--- a/cmd/kitgen/testdata/foo.go
+++ b/cmd/kitgen/testdata/foo.go
@@ -1,0 +1,9 @@
+package foo
+
+import "golang.org/x/net/context"
+
+type Service interface {
+	Concat(ctx context.Context, a, b string) (string, error)
+	Count(ctx context.Context, s string) (count int)
+}
+


### PR DESCRIPTION
The idea is to `kitgen path/to/some.go`, have it parse out a `type Service interface`, and generate
- service.go: a no-op implementation: `type dummyService struct{}` + all methods
- endpoints.go: request and response structs, plus endpoint constructors, for each method
- transport.go: one or more default transport bindings

Ideally, also
- middlewares.go: with default logging and instrumenting middlewares
- client/client.go: a skeleton for a client package
- cmd/mysvc/main.go: a skeleton main.go

So far
- [x] Parsing path/to/some.go and extracting declarations
- [ ] Template and codegen for service.go
- [ ] Template and codegen for endpoints.go
- [ ] Template and codegen for transport.go (should have flags for different transports)
- [ ] Template and codegen for middlewares.go
- [ ] Template and codegen for client/client.go
- [ ] Template and codegen for cmd/mysvc/main.go (should figure out how to name the thing better)
- [ ] Properly tested :)
