### PR TITLE
conform to rename of OpenTracing tags for RPC endpoints

### DIFF
--- a/examples/addsvc/client/thrift/client.go
+++ b/examples/addsvc/client/thrift/client.go
@@ -42,10 +42,10 @@ func New(client *thriftadd.AddServiceClient) addsvc.Service {
 	{
 		concatEndpoint = addsvc.MakeThriftConcatEndpoint(client)
 		concatEndpoint = limiter(concatEndpoint)
-		sumEndpoint = circuitbreaker.Gobreaker(gobreaker.NewCircuitBreaker(gobreaker.Settings{
+		concatEndpoint = circuitbreaker.Gobreaker(gobreaker.NewCircuitBreaker(gobreaker.Settings{
 			Name:    "Concat",
 			Timeout: 30 * time.Second,
-		}))(sumEndpoint)
+		}))(concatEndpoint)
 	}
 
 	return addsvc.Endpoints{

--- a/tracing/opentracing/endpoint.go
+++ b/tracing/opentracing/endpoint.go
@@ -24,7 +24,7 @@ func TraceServer(tracer opentracing.Tracer, operationName string) endpoint.Middl
 				serverSpan.SetOperationName(operationName)
 			}
 			defer serverSpan.Finish()
-			otext.SpanKind.Set(serverSpan, otext.SpanKindRPCServer)
+			otext.SpanKindRPCServer.Set(serverSpan)
 			ctx = opentracing.ContextWithSpan(ctx, serverSpan)
 			return next(ctx, request)
 		}
@@ -46,7 +46,7 @@ func TraceClient(tracer opentracing.Tracer, operationName string) endpoint.Middl
 				clientSpan = tracer.StartSpan(operationName)
 			}
 			defer clientSpan.Finish()
-			otext.SpanKind.Set(clientSpan, otext.SpanKindRPCClient)
+			otext.SpanKindRPCClient.Set(clientSpan)
 			ctx = opentracing.ContextWithSpan(ctx, clientSpan)
 			return next(ctx, request)
 		}


### PR DESCRIPTION
A rename in the OpenTracing API for RPC endpoint tags made our tracing middleware fail to compile. This PR fixes it.

Also find a minor copy & paste error in the addsvc example and fixed it.