### PR TITLE
do not log "SpanContext not found in Extract carrier" 

### DIFF
--- a/tracing/opentracing/http.go
+++ b/tracing/opentracing/http.go
@@ -16,8 +16,6 @@ import (
 // ToHTTPRequest returns an http RequestFunc that injects an OpenTracing Span
 // found in `ctx` into the http headers. If no such Span can be found, the
 // RequestFunc is a noop.
-//
-// The logger is used to report errors and may be nil.
 func ToHTTPRequest(tracer opentracing.Tracer, logger log.Logger) kithttp.RequestFunc {
 	return func(ctx context.Context, req *http.Request) context.Context {
 		// Try to find a Span in the Context.
@@ -52,8 +50,6 @@ func ToHTTPRequest(tracer opentracing.Tracer, logger log.Logger) kithttp.Request
 // `operationName` accordingly. If no trace could be found in `req`, the Span
 // will be a trace root. The Span is incorporated in the returned Context and
 // can be retrieved with opentracing.SpanFromContext(ctx).
-//
-// The logger is used to report errors and may be nil.
 func FromHTTPRequest(tracer opentracing.Tracer, operationName string, logger log.Logger) kithttp.RequestFunc {
 	return func(ctx context.Context, req *http.Request) context.Context {
 		// Try to join to a trace propagated in `req`.
@@ -62,7 +58,7 @@ func FromHTTPRequest(tracer opentracing.Tracer, operationName string, logger log
 			opentracing.TextMap,
 			opentracing.HTTPHeaderTextMapCarrier(req.Header),
 		)
-		if err != nil {
+		if err != nil && err != opentracing.ErrSpanContextNotFound {
 			logger.Log("err", err)
 		}
 		span = tracer.StartSpan(operationName, ext.RPCServerOption(wireContext))


### PR DESCRIPTION
If a server endpoint includes OpenTracing middleware and the client calling the endpoint is not instrumented, OpenTracing will emit a "SpanContext not found" error.  We should not log these as errors as it is common behavior.

Also removed the incorrect comments on logger being allowed to be nil.