### PR TITLE
kit/log/levels: Add enabled level

### DIFF
--- a/log/levels/enabled/enabled.go
+++ b/log/levels/enabled/enabled.go
@@ -1,0 +1,89 @@
+package enabled
+
+import "github.com/go-kit/kit/log/levels"
+
+// LevelEnabledLogger provides a wrapper around a logger with a feature
+// for checking a level is enabled.  It has five
+// levels: debug, info, warning (warn), error, and critical (crit).
+//
+// It is users' responsibility not to call the Log method of a logger.
+type LevelEnabledLogger struct {
+	levels.Levels
+	debugEnabled bool
+	infoEnabled  bool
+	warnEnabled  bool
+	errorEnabled bool
+	critEnabled  bool
+}
+
+// New creates a new level enabled logger, wrapping the passed logger.
+func New(logger levels.Levels, option Option) LevelEnabledLogger {
+	l := LevelEnabledLogger{
+		Levels: logger,
+	}
+	option(&l)
+	return l
+}
+
+// DebugEnabled returns the debug level is enabled
+func (l LevelEnabledLogger) DebugEnabled() bool { return l.debugEnabled }
+
+// InfoEnabled returns the info level is enabled
+func (l LevelEnabledLogger) InfoEnabled() bool { return l.infoEnabled }
+
+// WarnEnabled returns the warn level is enabled
+func (l LevelEnabledLogger) WarnEnabled() bool { return l.warnEnabled }
+
+// ErrorEnabled returns the error level is enabled
+func (l LevelEnabledLogger) ErrorEnabled() bool { return l.errorEnabled }
+
+// CritEnabled returns the crit level is enabled
+func (l LevelEnabledLogger) CritEnabled() bool { return l.critEnabled }
+
+// Option sets a parameter for level enabled loggers.
+type Option func(*LevelEnabledLogger)
+
+// Debug enables all levels for the level enabled logger.
+func Debug() Option {
+	return func(l *LevelEnabledLogger) {
+		l.debugEnabled = true
+		l.infoEnabled = true
+		l.warnEnabled = true
+		l.errorEnabled = true
+		l.critEnabled = true
+	}
+}
+
+// Info enables info and above levels for the level enabled logger.
+func Info() Option {
+	return func(l *LevelEnabledLogger) {
+		l.infoEnabled = true
+		l.warnEnabled = true
+		l.errorEnabled = true
+		l.critEnabled = true
+	}
+}
+
+// Warn enables warn and above levels for the level enabled logger.
+func Warn() Option {
+	return func(l *LevelEnabledLogger) {
+		l.warnEnabled = true
+		l.errorEnabled = true
+		l.critEnabled = true
+	}
+}
+
+// Error enables error and above levels for the level enabled logger.
+func Error() Option {
+	return func(l *LevelEnabledLogger) {
+		l.errorEnabled = true
+		l.critEnabled = true
+	}
+}
+
+// Crit enables crit level for the level enabled logger.
+func Crit() Option {
+	return func(l *LevelEnabledLogger) {
+		l.critEnabled = true
+	}
+}

--- a/log/levels/enabled/enabled_test.go
+++ b/log/levels/enabled/enabled_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestInfoLevel(t *testing.T) {
 	buf := bytes.Buffer{}
-	logger := enabled.New(levels.New(log.NewLogfmtLogger(&buf)), enabled.Info())
+	logger := enabled.NewInfo(levels.New(log.NewLogfmtLogger(&buf)))
 
 	if logger.DebugEnabled() {
 		logger.Debug().Log("msg", "résumé") // of course you'd want to do this
@@ -47,7 +47,14 @@ func TestInfoLevel(t *testing.T) {
 }
 
 func ExampleEnabled() {
-	logger := enabled.New(levels.New(log.NewLogfmtLogger(os.Stdout)), enabled.Warn())
+	logger, err := enabled.New(levels.New(log.NewLogfmtLogger(os.Stdout)), "warn")
+	if err != nil {
+		// This happens only when the level is invalid.
+		// In this example, this never happens as the valid level "warn" is used.
+		// In a real usage like reading a level from a command line option or a
+		// config file, you should check this error.
+		panic(err)
+	}
 	if logger.DebugEnabled() {
 		logger.Debug().Log("msg", "hello")
 	}

--- a/log/levels/enabled/enabled_test.go
+++ b/log/levels/enabled/enabled_test.go
@@ -1,0 +1,60 @@
+package enabled_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/levels"
+	"github.com/go-kit/kit/log/levels/enabled"
+)
+
+func TestInfoLevel(t *testing.T) {
+	buf := bytes.Buffer{}
+	logger := enabled.New(levels.New(log.NewLogfmtLogger(&buf)), enabled.Info())
+
+	if logger.DebugEnabled() {
+		logger.Debug().Log("msg", "résumé") // of course you'd want to do this
+	}
+	if want, have := "", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	buf.Reset()
+	if logger.InfoEnabled() {
+		logger.Info().Log("msg", "Åhus")
+	}
+	if want, have := "level=info msg=Åhus\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	buf.Reset()
+	if logger.ErrorEnabled() {
+		logger.Error().Log("msg", "© violation")
+	}
+	if want, have := "level=error msg=\"© violation\"\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	buf.Reset()
+	if logger.CritEnabled() {
+		logger.Crit().Log("msg", "	")
+	}
+	if want, have := "level=crit msg=\"\\t\"\n", buf.String(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+}
+
+func ExampleEnabled() {
+	logger := enabled.New(levels.New(log.NewLogfmtLogger(os.Stdout)), enabled.Warn())
+	if logger.DebugEnabled() {
+		logger.Debug().Log("msg", "hello")
+	}
+	if logger.WarnEnabled() {
+		logger.With("context", "foo").Warn().Log("err", "error")
+	}
+
+	// Output:
+	// level=warn context=foo err=error
+}


### PR DESCRIPTION
I read #252 and #269 and I think I prefer simpler approach for users to check a log level is enabled. So here it is.

The example code:

```
	logger, err := enabled.New(levels.New(log.NewLogfmtLogger(os.Stdout)), "warn")
	if err != nil {
		// This happens only when the level is invalid.
		// In this example, this never happens as the valid level "warn" is used.
		// In a real usage like reading a level from a command line option or a
		// config file, you should check this error.
		panic(err)
	}
	if logger.DebugEnabled() {
		logger.Debug().Log("msg", "hello")
	}
	if logger.WarnEnabled() {
		logger.With("context", "foo").Warn().Log("err", "error")
	}
```

The con is that it takes two more lines for `if logger.XxxEnabled() {` and `}`.
The pro is that it avoids the execution cost of the block for `if` when the level is disabled. I think this is important.
