### PR TITLE
Use To rather than From in tracing examples.

### DIFF
--- a/examples/addsvc/client/grpc/client.go
+++ b/examples/addsvc/client/grpc/client.go
@@ -39,7 +39,7 @@ func New(conn *grpc.ClientConn, tracer stdopentracing.Tracer, logger log.Logger)
 			addsvc.EncodeGRPCSumRequest,
 			addsvc.DecodeGRPCSumResponse,
 			pb.SumReply{},
-			grpctransport.ClientBefore(opentracing.FromGRPCRequest(tracer, "Sum", logger)),
+			grpctransport.ClientBefore(opentracing.ToGRPCRequest(tracer, logger)),
 		).Endpoint()
 		sumEndpoint = opentracing.TraceClient(tracer, "Sum")(sumEndpoint)
 		sumEndpoint = limiter(sumEndpoint)
@@ -58,7 +58,7 @@ func New(conn *grpc.ClientConn, tracer stdopentracing.Tracer, logger log.Logger)
 			addsvc.EncodeGRPCConcatRequest,
 			addsvc.DecodeGRPCConcatResponse,
 			pb.ConcatReply{},
-			grpctransport.ClientBefore(opentracing.FromGRPCRequest(tracer, "Concat", logger)),
+			grpctransport.ClientBefore(opentracing.ToGRPCRequest(tracer, logger)),
 		).Endpoint()
 		concatEndpoint = opentracing.TraceClient(tracer, "Concat")(concatEndpoint)
 		concatEndpoint = limiter(concatEndpoint)

--- a/examples/addsvc/client/http/client.go
+++ b/examples/addsvc/client/http/client.go
@@ -46,7 +46,7 @@ func New(instance string, tracer stdopentracing.Tracer, logger log.Logger) (adds
 			copyURL(u, "/sum"),
 			addsvc.EncodeHTTPGenericRequest,
 			addsvc.DecodeHTTPSumResponse,
-			httptransport.ClientBefore(opentracing.FromHTTPRequest(tracer, "Sum", logger)),
+			httptransport.ClientBefore(opentracing.ToHTTPRequest(tracer, logger)),
 		).Endpoint()
 		sumEndpoint = opentracing.TraceClient(tracer, "Sum")(sumEndpoint)
 		sumEndpoint = limiter(sumEndpoint)
@@ -63,7 +63,7 @@ func New(instance string, tracer stdopentracing.Tracer, logger log.Logger) (adds
 			copyURL(u, "/concat"),
 			addsvc.EncodeHTTPGenericRequest,
 			addsvc.DecodeHTTPConcatResponse,
-			httptransport.ClientBefore(opentracing.FromHTTPRequest(tracer, "Concat", logger)),
+			httptransport.ClientBefore(opentracing.ToHTTPRequest(tracer, logger)),
 		).Endpoint()
 		concatEndpoint = opentracing.TraceClient(tracer, "Concat")(concatEndpoint)
 		concatEndpoint = limiter(concatEndpoint)


### PR DESCRIPTION
As discussed in #347, FromHTTPRequest was used on the client instead of ToHTTPRequest. It was also the case with GRPC. This updates the examples to use the correct RequestFuncs.