### PR TITLE
Add StartTimer/ObserveDuration to histograms.

### DIFF
--- a/metrics/circonus/circonus.go
+++ b/metrics/circonus/circonus.go
@@ -83,3 +83,8 @@ func (h *Histogram) With(labelValues ...string) metrics.Histogram { return h }
 
 // Observe implements Histogram. No precision is lost.
 func (h *Histogram) Observe(value float64) { h.h.RecordValue(value) }
+
+// StartTimer implements Histogram.
+func (h *Histogram) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(h)
+}

--- a/metrics/discard/discard.go
+++ b/metrics/discard/discard.go
@@ -35,3 +35,8 @@ func (h histogram) With(labelValues ...string) metrics.Histogram { return h }
 
 // Observe implements histogram.
 func (h histogram) Observe(value float64) {}
+
+// StartTimer implements Histogram.
+func (h histogram) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(h)
+}

--- a/metrics/dogstatsd/dogstatsd.go
+++ b/metrics/dogstatsd/dogstatsd.go
@@ -283,6 +283,11 @@ func (t *Timing) Observe(value float64) {
 	t.obs(t.name, t.lvs, value)
 }
 
+// StartTimer implements metrics.Histogram.
+func (t *Timing) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(t)
+}
+
 // Histogram is a DogStatsD histrogram. Observations are forwarded to a
 // Dogstatsd object, and collected (but not aggregated) per timeseries.
 type Histogram struct {
@@ -303,4 +308,9 @@ func (h *Histogram) With(labelValues ...string) metrics.Histogram {
 // Observe implements metrics.Histogram.
 func (h *Histogram) Observe(value float64) {
 	h.obs(h.name, h.lvs, value)
+}
+
+// StartTimer implements metrics.Histogram.
+func (h *Histogram) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(h)
 }

--- a/metrics/expvar/expvar.go
+++ b/metrics/expvar/expvar.go
@@ -89,3 +89,8 @@ func (h *Histogram) Observe(value float64) {
 	h.p95.Set(h.h.Quantile(0.95))
 	h.p99.Set(h.h.Quantile(0.99))
 }
+
+// StartTimer implements Histogram.
+func (h *Histogram) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(h)
+}

--- a/metrics/generic/generic.go
+++ b/metrics/generic/generic.go
@@ -146,6 +146,11 @@ func (h *Histogram) Observe(value float64) {
 	h.h.Add(value)
 }
 
+// StartTimer implements Histogram.
+func (h *Histogram) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(h)
+}
+
 // Quantile returns the value of the quantile q, 0.0 < q < 1.0.
 func (h *Histogram) Quantile(q float64) float64 {
 	return h.h.Quantile(q)
@@ -203,6 +208,11 @@ func (h *SimpleHistogram) Observe(value float64) {
 	h.n++
 	h.avg -= h.avg / float64(h.n)
 	h.avg += value / float64(h.n)
+}
+
+// StartTimer implements Histogram.
+func (h *SimpleHistogram) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(h)
 }
 
 // ApproximateMovingAverage returns the approximate moving average of observations.

--- a/metrics/graphite/graphite.go
+++ b/metrics/graphite/graphite.go
@@ -198,3 +198,8 @@ func (h *Histogram) With(...string) metrics.Histogram { return h }
 
 // Observe implements histogram.
 func (h *Histogram) Observe(value float64) { h.h.Observe(value) }
+
+// StartTimer implements Histogram.
+func (h *Histogram) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(h)
+}

--- a/metrics/influx/influx.go
+++ b/metrics/influx/influx.go
@@ -247,3 +247,8 @@ func (h *Histogram) With(labelValues ...string) metrics.Histogram {
 func (h *Histogram) Observe(value float64) {
 	h.obs(h.name, h.lvs, value)
 }
+
+// StartTimer implements Histogram.
+func (h *Histogram) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(h)
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,5 +1,7 @@
 package metrics
 
+import "time"
+
 // Counter describes a metric that accumulates values monotonically.
 // An example of a counter is the number of received HTTP requests.
 type Counter interface {
@@ -21,4 +23,30 @@ type Gauge interface {
 type Histogram interface {
 	With(labelValues ...string) Histogram
 	Observe(value float64)
+  // Start a timer used to record a duration in seconds.
+  StartTimer() HistogramTimer
 }
+
+
+// HistogramTimer is used to implement StartTimer.
+type HistogramTimer struct {
+  h Histogram
+  start time.Time
+}
+
+// Start a timer for the given histogram.
+func NewHistogramTimer(h Histogram) HistogramTimer {
+  return HistogramTimer{h: h, start: time.Now()}
+}
+
+// Stop the timer and observe the duration in seconds.
+func (ht *HistogramTimer) ObserveDuration() {
+  duration := time.Since(ht.start).Seconds()
+  if duration < 0 {
+    // Time has gone backwards.
+    duration = 0
+  }
+  ht.h.Observe(duration)
+}
+
+

--- a/metrics/multi/multi.go
+++ b/metrics/multi/multi.go
@@ -69,6 +69,11 @@ func (h Histogram) Observe(value float64) {
 	}
 }
 
+// StartTimer implements Histogram.
+func (h Histogram) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(h)
+}
+
 // With implements histogram.
 func (h Histogram) With(labelValues ...string) metrics.Histogram {
 	next := make(Histogram, len(h))

--- a/metrics/multi/multi_test.go
+++ b/metrics/multi/multi_test.go
@@ -82,5 +82,6 @@ type mockHistogram struct {
 }
 
 func (h *mockHistogram) Observe(value float64)            { h.obs = append(h.obs, value) }
+func (h *mockHistogram) StartTimer() metrics.HistogramTimer { return metrics.NewHistogramTimer(h) }
 func (h *mockHistogram) With(...string) metrics.Histogram { return h }
 func (h *mockHistogram) String() string                   { return fmt.Sprintf("%v", h.obs) }

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -120,10 +120,16 @@ func (s *Summary) Observe(value float64) {
 	s.sv.With(makeLabels(s.lvs...)).Observe(value)
 }
 
+// StartTimer implements Histogram.
+func (s *Summary) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(s)
+}
+
 // Histogram implements Histogram via a Prometheus HistogramVec. The difference
 // between a Histogram and a Summary is that Histograms require predefined
 // quantile buckets, and can be statistically aggregated.
 type Histogram struct {
+  metrics.HistogramTimer
 	hv  *prometheus.HistogramVec
 	lvs lv.LabelValues
 }
@@ -154,6 +160,11 @@ func (h *Histogram) With(labelValues ...string) metrics.Histogram {
 // Observe implements Histogram.
 func (h *Histogram) Observe(value float64) {
 	h.hv.With(makeLabels(h.lvs...)).Observe(value)
+}
+
+// StartTimer implements Histogram.
+func (h *Histogram) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(h)
 }
 
 func makeLabels(labelValues ...string) prometheus.Labels {

--- a/metrics/statsd/statsd.go
+++ b/metrics/statsd/statsd.go
@@ -230,3 +230,8 @@ func (t *Timing) With(...string) metrics.Histogram {
 func (t *Timing) Observe(value float64) {
 	t.obs(t.name, lv.LabelValues{}, value)
 }
+
+// StartTimer implements Histogram.
+func (t *Timing) StartTimer() metrics.HistogramTimer {
+  return metrics.NewHistogramTimer(t)
+}


### PR DESCRIPTION
This makes it easy to record latencies,
and follows the Prometheus conventions.



This is a first pass, I think I need to change HistogramTImer to taking a function rather than a Histogram so that the value can be changed to ms for statsd. If this library grows to support the pushgateway equivalents we'll also need it on gauges. 