### PR TITLE
log/alt_experimental_level: concept demonstration

### DIFF
--- a/log/alt_experimental_level/benchmark_test.go
+++ b/log/alt_experimental_level/benchmark_test.go
@@ -1,0 +1,59 @@
+package level_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/alt_experimental_level"
+)
+
+func BenchmarkNopBaseline(b *testing.B) {
+	benchmarkRunner(b, log.NewNopLogger())
+}
+
+func BenchmarkNopDisallowedLevel(b *testing.B) {
+	level.AllowInfoAndAbove()
+	benchmarkRunner(b, log.NewNopLogger())
+}
+
+func BenchmarkNopAllowedLevel(b *testing.B) {
+	level.AllowAll()
+	benchmarkRunner(b, log.NewNopLogger())
+}
+
+func BenchmarkJSONBaseline(b *testing.B) {
+	benchmarkRunner(b, log.NewJSONLogger(ioutil.Discard))
+}
+
+func BenchmarkJSONDisallowedLevel(b *testing.B) {
+	level.AllowInfoAndAbove()
+	benchmarkRunner(b, log.NewJSONLogger(ioutil.Discard))
+}
+
+func BenchmarkJSONAllowedLevel(b *testing.B) {
+	level.AllowAll()
+	benchmarkRunner(b, log.NewJSONLogger(ioutil.Discard))
+}
+
+func BenchmarkLogfmtBaseline(b *testing.B) {
+	benchmarkRunner(b, log.NewLogfmtLogger(ioutil.Discard))
+}
+
+func BenchmarkLogfmtDisallowedLevel(b *testing.B) {
+	level.AllowInfoAndAbove()
+	benchmarkRunner(b, log.NewLogfmtLogger(ioutil.Discard))
+}
+
+func BenchmarkLogfmtAllowedLevel(b *testing.B) {
+	level.AllowAll()
+	benchmarkRunner(b, log.NewLogfmtLogger(ioutil.Discard))
+}
+
+func benchmarkRunner(b *testing.B, logger log.Logger) {
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		level.Debug(logger).Log("foo", "bar")
+	}
+}

--- a/log/alt_experimental_level/global.go
+++ b/log/alt_experimental_level/global.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	global Leveler = errorOnly{}
+	global = AllowingNone()
 	/*
 	   Alternately:
 	   global atomic.Value
@@ -30,23 +30,23 @@ func AllowAll() {
 }
 
 func AllowDebugAndAbove() {
-	resetGlobal(debugAndAbove{})
+	resetGlobal(AllowingDebugAndAbove())
 }
 
 func AllowInfoAndAbove() {
-	resetGlobal(infoAndAbove{})
+	resetGlobal(AllowingInfoAndAbove())
 }
 
 func AllowWarnAndAbove() {
-	resetGlobal(warnAndAbove{})
+	resetGlobal(AllowingWarnAndAbove())
 }
 
 func AllowErrorOnly() {
-	resetGlobal(errorOnly{})
+	resetGlobal(AllowingErrorOnly())
 }
 
 func AllowNone() {
-	resetGlobal(none{})
+	resetGlobal(AllowingNone())
 }
 
 func getGlobal() Leveler {

--- a/log/alt_experimental_level/global.go
+++ b/log/alt_experimental_level/global.go
@@ -1,0 +1,73 @@
+package level
+
+import (
+	"github.com/go-kit/kit/log"
+)
+
+var (
+	global Leveler = errorOnly{}
+	/*
+	   Alternately:
+	   global atomic.Value
+	*/
+)
+
+/* Alternately:
+func init() {
+	global.Store(errorOnly{})
+}
+*/
+
+func resetGlobal(proposed Leveler) {
+	global = proposed
+	/* Alternately:
+	global.Store(proposed)
+	*/
+}
+
+func AllowAll() {
+	AllowDebugAndAbove()
+}
+
+func AllowDebugAndAbove() {
+	resetGlobal(debugAndAbove{})
+}
+
+func AllowInfoAndAbove() {
+	resetGlobal(infoAndAbove{})
+}
+
+func AllowWarnAndAbove() {
+	resetGlobal(warnAndAbove{})
+}
+
+func AllowErrorOnly() {
+	resetGlobal(errorOnly{})
+}
+
+func AllowNone() {
+	resetGlobal(none{})
+}
+
+func getGlobal() Leveler {
+	return global
+	/* Alternately:
+	return global.Load().(Leveler)
+	*/
+}
+
+func Debug(logger log.Logger) log.Logger {
+	return getGlobal().Debug(logger)
+}
+
+func Info(logger log.Logger) log.Logger {
+	return getGlobal().Info(logger)
+}
+
+func Warn(logger log.Logger) log.Logger {
+	return getGlobal().Warn(logger)
+}
+
+func Error(logger log.Logger) log.Logger {
+	return getGlobal().Error(logger)
+}

--- a/log/alt_experimental_level/level.go
+++ b/log/alt_experimental_level/level.go
@@ -1,0 +1,99 @@
+package level
+
+import (
+	"github.com/go-kit/kit/log"
+)
+
+var (
+	levelKey = "level"
+
+	debugLevelValue = "debug"
+	infoLevelValue  = "info"
+	warnLevelValue  = "warn"
+	errorLevelValue = "error"
+
+	// Alternately, we could use a similarly inert logger that does nothing but
+	// return a given error value.
+	nop = log.NewNopLogger()
+)
+
+type Leveler interface {
+	Debug(logger log.Logger) log.Logger
+	Info(logger log.Logger) log.Logger
+	Warn(logger log.Logger) log.Logger
+	Error(logger log.Logger) log.Logger
+}
+
+type debugAndAbove struct{}
+
+func (debugAndAbove) Debug(logger log.Logger) log.Logger {
+	return log.NewContext(logger).With(levelKey, debugLevelValue)
+}
+
+func (debugAndAbove) Info(logger log.Logger) log.Logger {
+	return log.NewContext(logger).With(levelKey, infoLevelValue)
+}
+
+func (debugAndAbove) Warn(logger log.Logger) log.Logger {
+	return log.NewContext(logger).With(levelKey, warnLevelValue)
+}
+
+func (debugAndAbove) Error(logger log.Logger) log.Logger {
+	return log.NewContext(logger).With(levelKey, errorLevelValue)
+}
+
+type infoAndAbove struct {
+	debugAndAbove
+}
+
+func (infoAndAbove) Debug(logger log.Logger) log.Logger {
+	return nop
+}
+
+type warnAndAbove struct {
+	infoAndAbove
+}
+
+func (warnAndAbove) Info(logger log.Logger) log.Logger {
+	return nop
+}
+
+type errorOnly struct {
+	warnAndAbove
+}
+
+func (errorOnly) Warn(logger log.Logger) log.Logger {
+	return nop
+}
+
+type none struct {
+	errorOnly
+}
+
+func (none) Error(logger log.Logger) log.Logger {
+	return nop
+}
+
+func AllowingAll() Leveler {
+	return AllowingDebugAndAbove()
+}
+
+func AllowingDebugAndAbove() Leveler {
+	return debugAndAbove{}
+}
+
+func AllowingInfoAndAbove() Leveler {
+	return infoAndAbove{}
+}
+
+func AllowingWarnAndAbove() Leveler {
+	return warnAndAbove{}
+}
+
+func AllowingErrorOnly() Leveler {
+	return errorOnly{}
+}
+
+func AllowingNone() Leveler {
+	return none{}
+}

--- a/log/alt_experimental_level/level.go
+++ b/log/alt_experimental_level/level.go
@@ -5,13 +5,6 @@ import (
 )
 
 var (
-	levelKey = "level"
-
-	debugLevelValue = "debug"
-	infoLevelValue  = "info"
-	warnLevelValue  = "warn"
-	errorLevelValue = "error"
-
 	// Alternately, we could use a similarly inert logger that does nothing but
 	// return a given error value.
 	nop = log.NewNopLogger()
@@ -24,22 +17,26 @@ type Leveler interface {
 	Error(logger log.Logger) log.Logger
 }
 
+func withLevel(level string, logger log.Logger) log.Logger {
+	return log.NewContext(logger).With("level", level)
+}
+
 type debugAndAbove struct{}
 
 func (debugAndAbove) Debug(logger log.Logger) log.Logger {
-	return log.NewContext(logger).With(levelKey, debugLevelValue)
+	return withLevel("debug", logger)
 }
 
 func (debugAndAbove) Info(logger log.Logger) log.Logger {
-	return log.NewContext(logger).With(levelKey, infoLevelValue)
+	return withLevel("info", logger)
 }
 
 func (debugAndAbove) Warn(logger log.Logger) log.Logger {
-	return log.NewContext(logger).With(levelKey, warnLevelValue)
+	return withLevel("warn", logger)
 }
 
 func (debugAndAbove) Error(logger log.Logger) log.Logger {
-	return log.NewContext(logger).With(levelKey, errorLevelValue)
+	return withLevel("error", logger)
 }
 
 type infoAndAbove struct {

--- a/log/alt_experimental_level/level_test.go
+++ b/log/alt_experimental_level/level_test.go
@@ -1,0 +1,186 @@
+package level_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/alt_experimental_level"
+)
+
+func TestGlobalLevels(t *testing.T) {
+	for _, testcase := range []struct {
+		allowed string
+		allow   func()
+		want    string
+	}{
+		{
+			"all",
+			level.AllowAll,
+			strings.Join([]string{
+				`{"level":"debug","this is":"debug log"}`,
+				`{"level":"info","this is":"info log"}`,
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"debug+",
+			level.AllowDebugAndAbove,
+			strings.Join([]string{
+				`{"level":"debug","this is":"debug log"}`,
+				`{"level":"info","this is":"info log"}`,
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"info+",
+			level.AllowInfoAndAbove,
+			strings.Join([]string{
+				`{"level":"info","this is":"info log"}`,
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"warn+",
+			level.AllowWarnAndAbove,
+			strings.Join([]string{
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"error",
+			level.AllowErrorOnly,
+			strings.Join([]string{
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"none",
+			level.AllowNone,
+			``,
+		},
+	} {
+		var buf bytes.Buffer
+		logger := log.NewJSONLogger(&buf)
+
+		testcase.allow()
+
+		level.Debug(logger).Log("this is", "debug log")
+		level.Info(logger).Log("this is", "info log")
+		level.Warn(logger).Log("this is", "warn log")
+		level.Error(logger).Log("this is", "error log")
+
+		if want, have := testcase.want, strings.TrimSpace(buf.String()); want != have {
+			t.Errorf("given Allowed=%s: want\n%s\nhave\n%s", testcase.allowed, want, have)
+		}
+	}
+}
+
+func TestInstanceLevels(t *testing.T) {
+	for _, testcase := range []struct {
+		allowed string
+		leveler level.Leveler
+		want    string
+	}{
+		{
+			"all",
+			level.AllowingAll(),
+			strings.Join([]string{
+				`{"level":"debug","this is":"debug log"}`,
+				`{"level":"info","this is":"info log"}`,
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"debug+",
+			level.AllowingDebugAndAbove(),
+			strings.Join([]string{
+				`{"level":"debug","this is":"debug log"}`,
+				`{"level":"info","this is":"info log"}`,
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"info+",
+			level.AllowingInfoAndAbove(),
+			strings.Join([]string{
+				`{"level":"info","this is":"info log"}`,
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"warn+",
+			level.AllowingWarnAndAbove(),
+			strings.Join([]string{
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"error",
+			level.AllowingErrorOnly(),
+			strings.Join([]string{
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"none",
+			level.AllowingNone(),
+			``,
+		},
+	} {
+		var buf bytes.Buffer
+		logger := log.NewJSONLogger(&buf)
+
+		l := testcase.leveler
+
+		l.Debug(logger).Log("this is", "debug log")
+		l.Info(logger).Log("this is", "info log")
+		l.Warn(logger).Log("this is", "warn log")
+		l.Error(logger).Log("this is", "error log")
+
+		if want, have := testcase.want, strings.TrimSpace(buf.String()); want != have {
+			t.Errorf("given Allowed=%s: want\n%s\nhave\n%s", testcase.allowed, want, have)
+		}
+	}
+}
+func TestLevelContext(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Wrapping the level logger with a context allows users to use
+	// log.DefaultCaller as per normal.
+	var logger log.Logger
+	logger = log.NewLogfmtLogger(&buf)
+	level.AllowAll()
+	logger = level.Info(logger)
+	logger = log.NewContext(logger).With("caller", log.DefaultCaller)
+
+	logger.Log("foo", "bar")
+	if want, have := `level=info caller=level_test.go:166 foo=bar`, strings.TrimSpace(buf.String()); want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
+}
+
+func TestContextLevel(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Wrapping a context with the level logger allows users to use
+	// log.DefaultCaller as per normal.
+	var logger log.Logger
+	logger = log.NewLogfmtLogger(&buf)
+	logger = log.NewContext(logger).With("caller", log.DefaultCaller)
+
+	level.AllowAll()
+	level.Info(logger).Log("foo", "bar")
+	if want, have := `caller=level_test.go:182 level=info foo=bar`, strings.TrimSpace(buf.String()); want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
+}


### PR DESCRIPTION
As a foil to #357, demonstrate an alternate approach to the "level" package offered via the "github.com/go-kit/kit/log/experimental_package" import path, allowing use of either a global log event level filtering threshold or local filtering via instances of the `level.Leveler` interface.

Features not accommodated here for now:
- Returning an error from `log.Log` when squelching an event
- Returning an error from `log.Log` for events that lack a level  
  (This feature doesn't make much sense with this approach.)
- Squelching events that lack a level  
  (This feature doesn't make much sense with this approach.)
- Concurrent-safe adjustment of the global level threshold  
  (Note the "alternately" comments in file _global.go_ for one proposed solution.)
- Documentation  
  (We could adapt much of this from the sibling package.)

See the commit message for then _benchstat_ comparison.

This is a proof of concept. If others like this approach, we could refine whether to handle global configuration changes more safely (whether via `atomic.Value`, or guarding it with a `sync.RWMutex`), and whether to accommodate returning an error from `log.Log`, which wouldn't be too hard, whether via a singular sentinel `error` instance or with a caller-supplied `error` instance captured at configuration time.

Accommodating adjustment of the global level threshold safely imposes a performance tax on every subsequent event-recording call. I'd prefer to just document that callers should only change the threshold in an `init` function.
