### PR TITLE
metrics/influx: fix the package implementation

### DIFF
--- a/metrics/influx/example_test.go
+++ b/metrics/influx/example_test.go
@@ -1,0 +1,104 @@
+package influx
+
+import (
+	"fmt"
+	"regexp"
+
+	influxdb "github.com/influxdata/influxdb/client/v2"
+
+	"github.com/go-kit/kit/log"
+)
+
+func ExampleCounter() {
+	in := New(map[string]string{"a": "b"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
+	counter := in.NewCounter("influx_counter")
+	counter.Add(10)
+	counter.With("error", "true").Add(1)
+	counter.With("error", "false").Add(2)
+	counter.Add(50)
+
+	client := &bufWriter{}
+	in.WriteTo(client)
+
+	expectedLines := []string{
+		`(influx_counter,a=b count=60) [0-9]{19}`,
+		`(influx_counter,a=b,error=true count=1) [0-9]{19}`,
+		`(influx_counter,a=b,error=false count=2) [0-9]{19}`,
+	}
+
+	if err := extractAndPrintMessage(expectedLines, client.buf.String()); err != nil {
+		fmt.Println(err.Error())
+	}
+
+	// Output:
+	// influx_counter,a=b count=60
+	// influx_counter,a=b,error=true count=1
+	// influx_counter,a=b,error=false count=2
+}
+
+func ExampleGauge() {
+	in := New(map[string]string{"a": "b"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
+	gauge := in.NewGauge("influx_gauge")
+	gauge.Set(10)
+	gauge.With("error", "true").Set(2)
+	gauge.With("error", "true").Set(1)
+	gauge.With("error", "false").Set(2)
+	gauge.Set(50)
+
+	client := &bufWriter{}
+	in.WriteTo(client)
+
+	expectedLines := []string{
+		`(influx_gauge,a=b value=50) [0-9]{19}`,
+		`(influx_gauge,a=b,error=true value=1) [0-9]{19}`,
+		`(influx_gauge,a=b,error=false value=2) [0-9]{19}`,
+	}
+
+	if err := extractAndPrintMessage(expectedLines, client.buf.String()); err != nil {
+		fmt.Println(err.Error())
+	}
+
+	// Output:
+	// influx_gauge,a=b value=50
+	// influx_gauge,a=b,error=true value=1
+	// influx_gauge,a=b,error=false value=2
+}
+
+func ExampleHistogram() {
+	in := New(map[string]string{"foo": "alpha"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
+	histogram := in.NewHistogram("influx_histogram")
+	histogram.Observe(float64(10))
+	histogram.With("error", "true").Observe(float64(1))
+	histogram.With("error", "false").Observe(float64(2))
+	histogram.Observe(float64(50))
+
+	client := &bufWriter{}
+	in.WriteTo(client)
+
+	expectedLines := []string{
+		`(influx_histogram,foo=alpha p50=10,p90=50,p95=50,p99=50) [0-9]{19}`,
+		`(influx_histogram,error=true,foo=alpha p50=1,p90=1,p95=1,p99=1) [0-9]{19}`,
+		`(influx_histogram,error=false,foo=alpha p50=2,p90=2,p95=2,p99=2) [0-9]{19}`,
+	}
+
+	if err := extractAndPrintMessage(expectedLines, client.buf.String()); err != nil {
+		fmt.Println(err.Error())
+	}
+
+	// Output:
+	// influx_histogram,foo=alpha p50=10,p90=50,p95=50,p99=50
+	// influx_histogram,error=true,foo=alpha p50=1,p90=1,p95=1,p99=1
+	// influx_histogram,error=false,foo=alpha p50=2,p90=2,p95=2,p99=2
+}
+
+func extractAndPrintMessage(expected []string, msg string) error {
+	for _, pattern := range expected {
+		re := regexp.MustCompile(pattern)
+		match := re.FindStringSubmatch(msg)
+		if len(match) != 2 {
+			return fmt.Errorf("Pattern not found! {%s} [%s]: %v\n", pattern, msg, match)
+		}
+		fmt.Println(match[1])
+	}
+	return nil
+}

--- a/metrics/influx/influx.go
+++ b/metrics/influx/influx.go
@@ -26,8 +26,8 @@ import (
 //
 // Influx tags are attached to the Influx object, can be given to each
 // metric at construction and can be updated anytime via With function. Influx fields
-// are mapped to Go kit label values directly by this collector. Actual metric values are provided as
-// fields with specific names depending on the metric.
+// are mapped to Go kit label values directly by this collector. Actual metric
+// values are provided as fields with specific names depending on the metric.
 //
 // All observations are collected in memory locally, and flushed on demand.
 type Influx struct {

--- a/metrics/influx/influx.go
+++ b/metrics/influx/influx.go
@@ -21,13 +21,12 @@ import (
 // one data point per flush, with a "count" field that reflects all adds since
 // the last flush. Gauges are modeled as a timeseries with one data point per
 // flush, with a "value" field that reflects the current state of the gauge.
-// Histograms are modeled as a timeseries with one data point per observation,
-// with a "value" field that reflects each observation; use e.g. the HISTOGRAM
-// aggregate function to compute histograms.
+// Histograms are modeled as a timeseries with one data point per combination of tags,
+// with a set of quantile fields that reflects the p50, p90, p95 & p99.
 //
-// Influx tags are immutable, attached to the Influx object, and given to each
-// metric at construction. Influx fields are mapped to Go kit label values, and
-// may be mutated via With functions. Actual metric values are provided as
+// Influx tags are attached to the Influx object, can be given to each
+// metric at construction and can be updated anytime via With function. Influx fields
+// are mapped to Go kit label values directly by this collector. Actual metric values are provided as
 // fields with specific names depending on the metric.
 //
 // All observations are collected in memory locally, and flushed on demand.

--- a/metrics/influx/influx_test.go
+++ b/metrics/influx/influx_test.go
@@ -11,7 +11,6 @@ import (
 	influxdb "github.com/influxdata/influxdb/client/v2"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics/generic"
 	"github.com/go-kit/kit/metrics/teststat"
 )
 
@@ -31,6 +30,28 @@ func TestCounter(t *testing.T) {
 	}
 }
 
+func TestCounter_multipleTags(t *testing.T) {
+	in := New(map[string]string{"a": "b"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
+	counter := in.NewCounter("influx_counter")
+	counter.Add(10)
+	counter.With("error", "true").Add(1)
+	counter.With("error", "false").Add(2)
+	counter.Add(50)
+
+	client := &bufWriter{}
+	in.WriteTo(client)
+
+	expectedLines := []string{
+		`influx_counter,a=b count=60 [0-9]+`,
+		`influx_counter,a=b,error=true count=1 [0-9]+`,
+		`influx_counter,a=b,error=false count=2 [0-9]+`,
+	}
+
+	if err := validateMessage(expectedLines, client.buf.String()); err != nil {
+		t.Error(err.Error())
+	}
+}
+
 func TestGauge(t *testing.T) {
 	in := New(map[string]string{"foo": "alpha"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
 	re := regexp.MustCompile(`influx_gauge,foo=alpha value=([0-9\.]+) [0-9]+`)
@@ -47,23 +68,70 @@ func TestGauge(t *testing.T) {
 	}
 }
 
+func TestGauge_multipleTags(t *testing.T) {
+	in := New(map[string]string{"a": "b"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
+	gauge := in.NewGauge("influx_gauge")
+	gauge.Set(10)
+	gauge.With("error", "true").Set(2)
+	gauge.With("error", "true").Set(1)
+	gauge.With("error", "false").Set(2)
+	gauge.Set(50)
+
+	client := &bufWriter{}
+	in.WriteTo(client)
+
+	expectedLines := []string{
+		`influx_gauge,a=b value=50 [0-9]+`,
+		`influx_gauge,a=b,error=true value=1 [0-9]+`,
+		`influx_gauge,a=b,error=false value=2 [0-9]+`,
+	}
+
+	if err := validateMessage(expectedLines, client.buf.String()); err != nil {
+		t.Error(err.Error())
+	}
+}
+
 func TestHistogram(t *testing.T) {
 	in := New(map[string]string{"foo": "alpha"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
-	re := regexp.MustCompile(`influx_histogram,foo=alpha bar="beta",value=([0-9\.]+) [0-9]+`)
+	re := regexp.MustCompile(`influx_histogram,bar=beta,foo=alpha p50=([0-9\.]+),p90=([0-9\.]+),p95=([0-9\.]+),p99=([0-9\.]+) [0-9]+`)
 	histogram := in.NewHistogram("influx_histogram").With("bar", "beta")
 	quantiles := func() (float64, float64, float64, float64) {
 		w := &bufWriter{}
 		in.WriteTo(w)
-		h := generic.NewHistogram("h", 50)
-		matches := re.FindAllStringSubmatch(w.buf.String(), -1)
-		for _, match := range matches {
-			f, _ := strconv.ParseFloat(match[1], 64)
-			h.Observe(f)
+		match := re.FindStringSubmatch(w.buf.String())
+		if len(match) != 5 {
+			t.Errorf("These are not the quantiles you're looking for: %v\n", match)
 		}
-		return h.Quantile(0.50), h.Quantile(0.90), h.Quantile(0.95), h.Quantile(0.99)
+		var result [4]float64
+		for i, q := range match[1:] {
+			result[i], _ = strconv.ParseFloat(q, 64)
+		}
+		return result[0], result[1], result[2], result[3]
 	}
 	if err := teststat.TestHistogram(histogram, quantiles, 0.01); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestHistogram_multipleTags(t *testing.T) {
+	in := New(map[string]string{"foo": "alpha"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
+	histogram := in.NewHistogram("influx_histogram")
+	histogram.Observe(float64(10))
+	histogram.With("error", "true").Observe(float64(1))
+	histogram.With("error", "false").Observe(float64(2))
+	histogram.Observe(float64(50))
+
+	client := &bufWriter{}
+	in.WriteTo(client)
+
+	expectedLines := []string{
+		`influx_histogram,foo=alpha p50=10,p90=50,p95=50,p99=50 [0-9]+`,
+		`influx_histogram,error=true,foo=alpha p50=1,p90=1,p95=1,p99=1 [0-9]+`,
+		`influx_histogram,error=false,foo=alpha p50=2,p90=2,p95=2,p99=2 [0-9]+`,
+	}
+
+	if err := validateMessage(expectedLines, client.buf.String()); err != nil {
+		t.Error(err.Error())
 	}
 }
 
@@ -88,6 +156,17 @@ type bufWriter struct {
 func (w *bufWriter) Write(bp influxdb.BatchPoints) error {
 	for _, p := range bp.Points() {
 		fmt.Fprintf(&w.buf, p.String()+"\n")
+	}
+	return nil
+}
+
+func validateMessage(expected []string, msg string) error {
+	for _, pattern := range expected {
+		re := regexp.MustCompile(pattern)
+		match := re.FindStringSubmatch(msg)
+		if len(match) != 1 {
+			return fmt.Errorf("Pattern not found! {%s} %s\n", pattern, msg)
+		}
 	}
 	return nil
 }

--- a/metrics/influx/influx_test.go
+++ b/metrics/influx/influx_test.go
@@ -30,33 +30,6 @@ func TestCounter(t *testing.T) {
 	}
 }
 
-func ExampleCounter() {
-	in := New(map[string]string{"a": "b"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
-	counter := in.NewCounter("influx_counter")
-	counter.Add(10)
-	counter.With("error", "true").Add(1)
-	counter.With("error", "false").Add(2)
-	counter.Add(50)
-
-	client := &bufWriter{}
-	in.WriteTo(client)
-
-	expectedLines := []string{
-		`(influx_counter,a=b count=60) [0-9]{19}`,
-		`(influx_counter,a=b,error=true count=1) [0-9]{19}`,
-		`(influx_counter,a=b,error=false count=2) [0-9]{19}`,
-	}
-
-	if err := extractAndPrintMessage(expectedLines, client.buf.String()); err != nil {
-		fmt.Println(err.Error())
-	}
-
-	// Output:
-	// influx_counter,a=b count=60
-	// influx_counter,a=b,error=true count=1
-	// influx_counter,a=b,error=false count=2
-}
-
 func TestGauge(t *testing.T) {
 	in := New(map[string]string{"foo": "alpha"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
 	re := regexp.MustCompile(`influx_gauge,foo=alpha value=([0-9\.]+) [0-9]+`)
@@ -71,34 +44,6 @@ func TestGauge(t *testing.T) {
 	if err := teststat.TestGauge(gauge, value); err != nil {
 		t.Fatal(err)
 	}
-}
-
-func ExampleGauge() {
-	in := New(map[string]string{"a": "b"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
-	gauge := in.NewGauge("influx_gauge")
-	gauge.Set(10)
-	gauge.With("error", "true").Set(2)
-	gauge.With("error", "true").Set(1)
-	gauge.With("error", "false").Set(2)
-	gauge.Set(50)
-
-	client := &bufWriter{}
-	in.WriteTo(client)
-
-	expectedLines := []string{
-		`(influx_gauge,a=b value=50) [0-9]{19}`,
-		`(influx_gauge,a=b,error=true value=1) [0-9]{19}`,
-		`(influx_gauge,a=b,error=false value=2) [0-9]{19}`,
-	}
-
-	if err := extractAndPrintMessage(expectedLines, client.buf.String()); err != nil {
-		fmt.Println(err.Error())
-	}
-
-	// Output:
-	// influx_gauge,a=b value=50
-	// influx_gauge,a=b,error=true value=1
-	// influx_gauge,a=b,error=false value=2
 }
 
 func TestHistogram(t *testing.T) {
@@ -123,33 +68,6 @@ func TestHistogram(t *testing.T) {
 	}
 }
 
-func ExampleHistogram() {
-	in := New(map[string]string{"foo": "alpha"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
-	histogram := in.NewHistogram("influx_histogram")
-	histogram.Observe(float64(10))
-	histogram.With("error", "true").Observe(float64(1))
-	histogram.With("error", "false").Observe(float64(2))
-	histogram.Observe(float64(50))
-
-	client := &bufWriter{}
-	in.WriteTo(client)
-
-	expectedLines := []string{
-		`(influx_histogram,foo=alpha p50=10,p90=50,p95=50,p99=50) [0-9]{19}`,
-		`(influx_histogram,error=true,foo=alpha p50=1,p90=1,p95=1,p99=1) [0-9]{19}`,
-		`(influx_histogram,error=false,foo=alpha p50=2,p90=2,p95=2,p99=2) [0-9]{19}`,
-	}
-
-	if err := extractAndPrintMessage(expectedLines, client.buf.String()); err != nil {
-		fmt.Println(err.Error())
-	}
-
-	// Output:
-	// influx_histogram,foo=alpha p50=10,p90=50,p95=50,p99=50
-	// influx_histogram,error=true,foo=alpha p50=1,p90=1,p95=1,p99=1
-	// influx_histogram,error=false,foo=alpha p50=2,p90=2,p95=2,p99=2
-}
-
 func TestHistogramLabels(t *testing.T) {
 	in := New(map[string]string{}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
 	h := in.NewHistogram("foo")
@@ -171,18 +89,6 @@ type bufWriter struct {
 func (w *bufWriter) Write(bp influxdb.BatchPoints) error {
 	for _, p := range bp.Points() {
 		fmt.Fprintf(&w.buf, p.String()+"\n")
-	}
-	return nil
-}
-
-func extractAndPrintMessage(expected []string, msg string) error {
-	for _, pattern := range expected {
-		re := regexp.MustCompile(pattern)
-		match := re.FindStringSubmatch(msg)
-		if len(match) != 2 {
-			return fmt.Errorf("Pattern not found! {%s} [%s]: %v\n", pattern, msg, match)
-		}
-		fmt.Println(match[1])
 	}
 	return nil
 }


### PR DESCRIPTION
As reviewing the #367 I've found all the implementations of the metrics used the labels as fields, so I generalized the hack for gauges and histograms too.

Also, the histogram implementation wasn't aggregating the results, so they couldn't be stored properly in the backend (same problem as in #367, because influx accepts just one combination of fields for a given combination of tags and timestamp).

Finally, I added 3 tests where you can see how the messages are being sent over the wire.