### PR TITLE
Retry callbacks passing errors.

### DIFF
--- a/sd/lb/retry.go
+++ b/sd/lb/retry.go
@@ -44,7 +44,9 @@ func maxRetries(max int) Callback {
 // whichever comes first.
 func RetryWithCallback(timeout time.Duration, b Balancer, cb Callback) endpoint.Endpoint {
 	if cb == nil {
-		panic("nil Callback")
+		cb = func(n int, err error) (bool, error) {
+			return true, nil
+		}
 	}
 	if b == nil {
 		panic("nil Balancer")

--- a/sd/lb/retry.go
+++ b/sd/lb/retry.go
@@ -14,8 +14,8 @@ import (
 // encountered. Should return whether the Retry function should continue trying,
 // and a custom error message if desired. The error message may be nil, but a
 // true/false is always expected. In all cases if the error message is supplied,
-// thecurrent error will be replaced.
-type Callback func(n int, err error) (cont bool, cbErr error)
+// the current error will be replaced.
+type Callback func(n int, received error) (keepTrying bool, cbErr error)
 
 // Retry wraps a service load balancer and returns an endpoint oriented load
 // balancer for the specified service method.

--- a/sd/lb/retry.go
+++ b/sd/lb/retry.go
@@ -10,11 +10,11 @@ import (
 	"github.com/go-kit/kit/endpoint"
 )
 
-// Callback function that indicates the current attempt count and the error encountered.
-//  Should return whether the Retry function should continue trying, and a custom
-//  error message if desired. The error message may be nil, but a true/false
-//  is always expected. In all cases if the error message is supplied, the
-//  current error will be replaced.
+// Callback is a function that indicates the current attempt count and the error
+// encountered. Should return whether the Retry function should continue trying,
+// and a custom error message if desired. The error message may be nil, but a
+// true/false is always expected. In all cases if the error message is supplied,
+// thecurrent error will be replaced.
 type Callback func(n int, err error) (cont bool, cbErr error)
 
 // Retry wraps a service load balancer and returns an endpoint oriented load

--- a/sd/lb/retry.go
+++ b/sd/lb/retry.go
@@ -1,21 +1,21 @@
 package lb
 
 import (
-    "fmt"
-    "strings"
-    "time"
+	"fmt"
+	"strings"
+	"time"
 
-    "golang.org/x/net/context"
+	"golang.org/x/net/context"
 
-    "github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/endpoint"
 )
 
 // Callback function that indicates the current attempt count and the error encountered.
-//  Should return whether the Retry function should continue trying, and a custom 
-//  error message if desired. The error message may be nil, but a true/false 
-//  is always expected. In all cases if the error message is supplied, the 
+//  Should return whether the Retry function should continue trying, and a custom
+//  error message if desired. The error message may be nil, but a true/false
+//  is always expected. In all cases if the error message is supplied, the
 //  current error will be replaced.
-type Callback func(int, string) (bool, *string)
+type Callback func(n int, err error) (cont bool, cbErr error)
 
 // Retry wraps a service load balancer and returns an endpoint oriented load
 // balancer for the specified service method.
@@ -23,61 +23,66 @@ type Callback func(int, string) (bool, *string)
 // balancer. Requests that return errors will be retried until they succeed,
 // up to max times, or until the timeout is elapsed, whichever comes first.
 func Retry(max int, timeout time.Duration, b Balancer) endpoint.Endpoint {
-    return RetryWithCallback(max, timeout, b, func(c int, s string) (bool, *string) { return true, nil })
+	return RetryWithCallback(max, timeout, b, func(c int, err error) (bool, error) { return true, nil })
 }
 
+// RetryWithCallback wraps a service load balancer and returns an endpoint oriented load
+// balancer for the specified service method.
+// Requests to the endpoint will be automatically load balanced via the load
+// balancer. Requests that return errors will be retried until they succeed,
+// up to max times, until the callback returns false, or until the timeout is elapsed,
+// whichever comes first.
 func RetryWithCallback(max int, timeout time.Duration, b Balancer, cb Callback) endpoint.Endpoint {
-    if cb == nil {
-        panic("nil Callback")
-    }
-    if b == nil {
-        panic("nil Balancer")
-    }
-    return func(ctx context.Context, request interface{}) (response interface{}, err error) {
-        var (
-            newctx, cancel = context.WithTimeout(ctx, timeout)
-            responses        = make(chan interface{}, 1)
-            errs                  = make(chan error, 1)
-            a                      = []string{}
-        )
-        defer cancel()
-        for i := 1; i <= max; i++ {
-            go func() {
-                e, err := b.Endpoint()
-                if err != nil {
-                    errs <- err
-                    return
-                }
-                response, err := e(newctx, request)
-                if err != nil {
-                    errs <- err
-                    return
-                }
-                responses <- response
-            }()
+	if cb == nil {
+		panic("nil Callback")
+	}
+	if b == nil {
+		panic("nil Balancer")
+	}
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		var (
+			newctx, cancel = context.WithTimeout(ctx, timeout)
+			responses      = make(chan interface{}, 1)
+			errs           = make(chan error, 1)
+			a              = []string{}
+		)
+		defer cancel()
+		for i := 1; i <= max; i++ {
+			go func() {
+				e, err := b.Endpoint()
+				if err != nil {
+					errs <- err
+					return
+				}
+				response, err := e(newctx, request)
+				if err != nil {
+					errs <- err
+					return
+				}
+				responses <- response
+			}()
 
-            select {
-            case <-newctx.Done():
-                return nil, newctx.Err()
-            case response := <-responses:
-                return response, nil
-            case err := <-errs:
-                cont, cbErr := cb(i, err.Error())
-                if !cont {
-                    if cbErr == nil {
-                        return nil, fmt.Errorf("retry attempts exceeded (%s)", strings.Join(a, "; "))   
-                    } else {
-                        return nil, fmt.Errorf(*cbErr) 
-                    }
-                }
-                currentErr := err.Error()
-                if cbErr != nil {
-                    currentErr = *cbErr
-                } 
-                a = append(a, currentErr)
-                continue
-            }
-        }
-        return nil, fmt.Errorf("retry attempts exceeded (%s)", strings.Join(a, "; "))
-    }
+			select {
+			case <-newctx.Done():
+				return nil, newctx.Err()
+			case response := <-responses:
+				return response, nil
+			case err := <-errs:
+				cont, cbErr := cb(i, err)
+				if !cont {
+					if cbErr == nil {
+						return nil, fmt.Errorf("retry attempts exceeded (%s)", strings.Join(a, "; "))
+					}
+					return nil, cbErr
+				}
+				currentErr := err.Error()
+				if cbErr != nil {
+					currentErr = cbErr.Error()
+				}
+				a = append(a, currentErr)
+				continue
+			}
+		}
+		return nil, fmt.Errorf("retry attempts exceeded (%s)", strings.Join(a, "; "))
+	}
 }

--- a/sd/lb/retry_test.go
+++ b/sd/lb/retry_test.go
@@ -42,7 +42,7 @@ func TestRetryMaxPartialFail(t *testing.T) {
 		ctx     = context.Background()
 	)
 	if _, err := loadbalancer.Retry(retries, time.Second, lb)(ctx, struct{}{}); err == nil {
-		t.Errorf("expected error, got none")
+		t.Errorf("expected error two, got none")
 	}
 }
 
@@ -98,7 +98,7 @@ func TestAbortEarlyCustomMessage_WCB(t *testing.T) {
 		}
 		endpoints = sd.FixedSubscriber{} // no endpoints
 		lb        = loadbalancer.NewRoundRobin(endpoints)
-		retry     = loadbalancer.RetryWithCallback(999, time.Second, lb, cb) // lots of retries
+		retry     = loadbalancer.RetryWithCallback(time.Second, lb, cb) // lots of retries
 		ctx       = context.Background()
 	)
 	_, err := retry(ctx, struct{}{})
@@ -107,27 +107,6 @@ func TestAbortEarlyCustomMessage_WCB(t *testing.T) {
 	}
 	if err.Error() != "Aborting early" {
 		t.Errorf("expected custom error message, got %v", err)
-	}
-}
-
-func TestAbortEarlyOnNTries_WCB(t *testing.T) {
-	var (
-		cb = func(count int, err error) (bool, error) {
-			if count >= 4 {
-				t.Errorf("expected retries to abort at 3 but continued to %v", count)
-			}
-			if count == 3 {
-				return false, nil
-			}
-			return true, nil
-		}
-		endpoints = sd.FixedSubscriber{} // no endpoints
-		lb        = loadbalancer.NewRoundRobin(endpoints)
-		retry     = loadbalancer.RetryWithCallback(999, time.Second, lb, cb) // lots of retries
-		ctx       = context.Background()
-	)
-	if _, err := retry(ctx, struct{}{}); err == nil {
-		t.Errorf("expected error, got none") // should fail
 	}
 }
 
@@ -145,7 +124,7 @@ func TestErrorPassedUnchangedToCallback_WCB(t *testing.T) {
 		}
 		endpoints = sd.FixedSubscriber{endpoint} // no endpoints
 		lb        = loadbalancer.NewRoundRobin(endpoints)
-		retry     = loadbalancer.RetryWithCallback(999, time.Second, lb, cb) // lots of retries
+		retry     = loadbalancer.RetryWithCallback(time.Second, lb, cb) // lots of retries
 		ctx       = context.Background()
 	)
 	_, _ = retry(ctx, struct{}{})

--- a/sd/lb/retry_test.go
+++ b/sd/lb/retry_test.go
@@ -129,3 +129,17 @@ func TestErrorPassedUnchangedToCallback_WCB(t *testing.T) {
 	)
 	_, _ = retry(ctx, struct{}{})
 }
+
+func TestHandleNilCallback(t *testing.T) {
+	var (
+		subscriber = sd.FixedSubscriber{
+			func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil /* OK */ },
+		}
+		lb  = loadbalancer.NewRoundRobin(subscriber)
+		ctx = context.Background()
+	)
+	retry := loadbalancer.RetryWithCallback(time.Second, lb, nil)
+	if _, err := retry(ctx, struct{}{}); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
Hopefully this should resolve #341.

I wasn't sure what the protocol should be for this, but I noticed things had gone a bit quiet on the other PR for this issue. I've pulled @morganhein's changes and made a few tweaks in line with @peterbourgon's feedback.

Callbacks now accept an `error`, and an additional test is added to demonstrate that errors are passed unchanged from the endpoint.

Please let me know if anything needs tweaked, or if I should submit this change differently.