### PR TITLE
Correct http tags in tracing spans

### DIFF
--- a/tracing/opentracing/grpc_test.go
+++ b/tracing/opentracing/grpc_test.go
@@ -30,7 +30,7 @@ func TestTraceGRPCRequestRoundtrip(t *testing.T) {
 	// The Span should not have changed.
 	afterSpan := opentracing.SpanFromContext(afterCtx)
 	if beforeSpan != afterSpan {
-		t.Errorf("Should not swap in a new span")
+		t.Error("Should not swap in a new span")
 	}
 
 	// No spans should have finished yet.

--- a/tracing/opentracing/http.go
+++ b/tracing/opentracing/http.go
@@ -21,7 +21,8 @@ func ToHTTPRequest(tracer opentracing.Tracer, logger log.Logger) kithttp.Request
 		// Try to find a Span in the Context.
 		if span := opentracing.SpanFromContext(ctx); span != nil {
 			// Add standard OpenTracing tags.
-			ext.HTTPMethod.Set(span, req.URL.RequestURI())
+			ext.HTTPMethod.Set(span, req.Method)
+			ext.HTTPUrl.Set(span, req.URL.String())
 			host, portString, err := net.SplitHostPort(req.URL.Host)
 			if err == nil {
 				ext.PeerHostname.Set(span, host)
@@ -61,7 +62,10 @@ func FromHTTPRequest(tracer opentracing.Tracer, operationName string, logger log
 		if err != nil && err != opentracing.ErrSpanContextNotFound {
 			logger.Log("err", err)
 		}
+
 		span = tracer.StartSpan(operationName, ext.RPCServerOption(wireContext))
+		ext.HTTPMethod.Set(span, req.Method)
+		ext.HTTPUrl.Set(span, req.URL.String())
 		return opentracing.ContextWithSpan(ctx, span)
 	}
 }


### PR DESCRIPTION
Set correct value of HTTP URL tag that is added to client span in ToHTTPRequest() function.
Add new opentracing tags in tracing request functions.