### PR TITLE
fix(generic.go): add defer to ApproximateMovingAverage mutext

### DIFF
--- a/metrics/generic/generic.go
+++ b/metrics/generic/generic.go
@@ -208,7 +208,7 @@ func (h *SimpleHistogram) Observe(value float64) {
 // ApproximateMovingAverage returns the approximate moving average of observations.
 func (h *SimpleHistogram) ApproximateMovingAverage() float64 {
 	h.mtx.RLock()
-	h.mtx.RUnlock()
+	defer h.mtx.RUnlock()
 	return h.avg
 }
 


### PR DESCRIPTION
Currently there is a `h.mtx.RLock()` following by `h.mtx.RUnlock()`, the unlock should be a defer `defer h.mtx.RUnlock()`