### PR TITLE
Correct typ-o in addsvc for concatEndpoint

### DIFF
--- a/examples/addsvc/client/http/client.go
+++ b/examples/addsvc/client/http/client.go
@@ -67,10 +67,10 @@ func New(instance string, tracer stdopentracing.Tracer, logger log.Logger) (adds
 		).Endpoint()
 		concatEndpoint = opentracing.TraceClient(tracer, "Concat")(concatEndpoint)
 		concatEndpoint = limiter(concatEndpoint)
-		sumEndpoint = circuitbreaker.Gobreaker(gobreaker.NewCircuitBreaker(gobreaker.Settings{
+		concatEndpoint = circuitbreaker.Gobreaker(gobreaker.NewCircuitBreaker(gobreaker.Settings{
 			Name:    "Concat",
 			Timeout: 30 * time.Second,
-		}))(sumEndpoint)
+		}))(concatEndpoint)
 	}
 
 	return addsvc.Endpoints{


### PR DESCRIPTION
There is a small typ-o in the addsvc example http client. The concatEndpoint block shows two lines with 'sumEndpoint'.