### PR TITLE
log/experimental_level: level key should be prefixed

### DIFF
--- a/log/experimental_level/level.go
+++ b/log/experimental_level/level.go
@@ -49,22 +49,22 @@ func AllowNone() []string {
 
 // Error returns a logger with the level key set to ErrorLevelValue.
 func Error(logger log.Logger) log.Logger {
-	return log.NewContext(logger).With(levelKey, errorLevelValue)
+	return log.NewContext(logger).WithPrefix(levelKey, errorLevelValue)
 }
 
 // Warn returns a logger with the level key set to WarnLevelValue.
 func Warn(logger log.Logger) log.Logger {
-	return log.NewContext(logger).With(levelKey, warnLevelValue)
+	return log.NewContext(logger).WithPrefix(levelKey, warnLevelValue)
 }
 
 // Info returns a logger with the level key set to InfoLevelValue.
 func Info(logger log.Logger) log.Logger {
-	return log.NewContext(logger).With(levelKey, infoLevelValue)
+	return log.NewContext(logger).WithPrefix(levelKey, infoLevelValue)
 }
 
 // Debug returns a logger with the level key set to DebugLevelValue.
 func Debug(logger log.Logger) log.Logger {
-	return log.NewContext(logger).With(levelKey, debugLevelValue)
+	return log.NewContext(logger).WithPrefix(levelKey, debugLevelValue)
 }
 
 // Config parameterizes the leveled logger.

--- a/log/experimental_level/level_test.go
+++ b/log/experimental_level/level_test.go
@@ -132,7 +132,7 @@ func TestLevelContext(t *testing.T) {
 	logger = log.NewContext(logger).With("caller", log.DefaultCaller)
 
 	level.Info(logger).Log("foo", "bar")
-	if want, have := `caller=level_test.go:134 level=info foo=bar`, strings.TrimSpace(buf.String()); want != have {
+	if want, have := `level=info caller=level_test.go:134 foo=bar`, strings.TrimSpace(buf.String()); want != have {
 		t.Errorf("want %q, have %q", want, have)
 	}
 }


### PR DESCRIPTION
This is just a usability upgrade, IMO.