### PR TITLE
Fixed overwrite global tags in Influx adapter

### DIFF
--- a/metrics/influx/influx.go
+++ b/metrics/influx/influx.go
@@ -168,10 +168,15 @@ func mergeTags(tags map[string]string, labelValues []string) map[string]string {
 	if len(labelValues)%2 != 0 {
 		panic("mergeTags received a labelValues with an odd number of strings")
 	}
-	for i := 0; i < len(labelValues); i += 2 {
-		tags[labelValues[i]] = labelValues[i+1]
+
+	ret := make(map[string]string, len(tags) + len(labelValues) / 2)
+	for k, v := range tags {
+		ret[k] = v
 	}
-	return tags
+	for i := 0; i < len(labelValues); i += 2 {
+		ret[labelValues[i]] = labelValues[i+1]
+	}
+	return ret
 }
 
 func sum(a []float64) float64 {

--- a/metrics/influx/influx.go
+++ b/metrics/influx/influx.go
@@ -168,8 +168,7 @@ func mergeTags(tags map[string]string, labelValues []string) map[string]string {
 	if len(labelValues)%2 != 0 {
 		panic("mergeTags received a labelValues with an odd number of strings")
 	}
-
-	ret := make(map[string]string, len(tags) + len(labelValues) / 2)
+	ret := make(map[string]string, len(tags)+len(labelValues)/2)
 	for k, v := range tags {
 		ret[k] = v
 	}


### PR DESCRIPTION
Hi.

I found that overwrites global tags in ```mergeTags``` in Influx adapter of metrics package. Example,

```go
func TestCounter_RewriteTags(t *testing.T) {
	in := New(map[string]string{}, influxdb.BatchPointsConfig{}, log.NewNopLogger())

	reFirst := regexp.MustCompile(`influx_counter_first,tag_for_counter_first=first count=([0-9\.]+) [0-9]+`)
	counterFirst := in.NewCounter("influx_counter_first").With("tag_for_counter_first", "first")
	counterFirst.Add(11)

	reSecond := regexp.MustCompile(`influx_counter_second,tag_for_counter_second=second count=([0-9\.]+) [0-9]+`)
	counterSecond := in.NewCounter("influx_counter_second").With("tag_for_counter_second", "second")
	counterSecond.Add(22)

	client := &bufWriter{}
	in.WriteTo(client)

	for _, row := range strings.Split(client.buf.String(), string('\n')) {
		if strings.HasPrefix(row, "influx_counter_first") && !reFirst.MatchString(row) {
			t.Fatal(`First counter not equal "`, reFirst.String() , `" want "`, row, `"`)
		} else if strings.HasPrefix(row, "influx_counter_second") && !reSecond.MatchString(row) {
			t.Fatal(`Second counter not equal "`, reSecond.String() , `" want "`, row, `"`)
		}
	}
}
```

Result
```
$ go test -run TestCounter_RewriteTags
--- FAIL: TestCounter_RewriteTags (0.00s)
        influx_test.go:51: Second counter not equal " influx_counter_second,tag_for_counter_second=second count=([0-9\.]+) [0-9]+ " want " influx_counter_second,tag_for_counter_first=first,tag_for_counter_second=second count=22 1481159549909954467 "
FAIL
exit status 1
FAIL    github.com/go-kit/kit/metrics/influx    0.010s
```

As you can see tags from the first counter appear in the second. I think that this is wrong. Map ```tags map[string]string``` is the root cause of the error, it is passed by pointer and each time frays from other counters/gauges/histograms.

Please see my PL.