### PR TITLE
Update the Histogram example to reflect API changes

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -49,7 +49,7 @@ import (
 )
 
 func main() {
-	var dur metrics.Histogram = prometheus.NewSummary(stdprometheus.SummaryOpts{
+	var dur metrics.Histogram = prometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
 		Namespace: "myservice",
 		Subsystem: "api",
 		Name:     "request_duration_seconds",


### PR DESCRIPTION
`prometheus.NewSummary()` takes a ` *"github.com/prometheus/client_golang/prometheus".SummaryVec` as argument. `prometheus.NewSummaryFrom()` has the behaivour described in the example.

- Update the Histogram example so it uses `prometheus.NewSummaryFrom()` instead of `prometheus.NewSummary()`.