### PR TITLE
Install docker-compose 1.10 manually

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,8 @@ machine:
 
 dependencies:
   pre:
-    - sudo pip install docker-compose
+    - sudo curl -L "https://github.com/docker/compose/releases/download/1.10.0/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose
+    - sudo chmod +x /usr/local/bin/docker-compose
     - docker-compose -f docker-compose-integration.yml up -d --force-recreate
 
 test:


### PR DESCRIPTION
Randomly, the docker-compose installed by pip was downgraded to a
version that couldn't parse version-2-style docker-compose files.
This attempts to get version 1.10 manually.