### PR TITLE
Fix typo in graphite package

### DIFF
--- a/metrics/graphite/graphite.go
+++ b/metrics/graphite/graphite.go
@@ -38,7 +38,7 @@ type Graphite struct {
 	logger     log.Logger
 }
 
-// New returns a Statsd object that may be used to create metrics. Prefix is
+// New returns a Graphite object that may be used to create metrics. Prefix is
 // applied to all created metrics. Callers must ensure that regular calls to
 // WriteTo are performed, either manually or with one of the helper methods.
 func New(prefix string, logger log.Logger) *Graphite {

--- a/metrics/graphite/graphite_test.go
+++ b/metrics/graphite/graphite_test.go
@@ -36,7 +36,7 @@ func TestGauge(t *testing.T) {
 
 func TestHistogram(t *testing.T) {
 	// The histogram test is actually like 4 gauge tests.
-	prefix, name := "statsd.", "histogram_test"
+	prefix, name := "graphite.", "histogram_test"
 	label, value := "abc", "def" // ignored for Graphite
 	re50 := regexp.MustCompile(prefix + name + `.p50 ([0-9\.]+) [0-9]+`)
 	re90 := regexp.MustCompile(prefix + name + `.p90 ([0-9\.]+) [0-9]+`)


### PR DESCRIPTION
Rename `Statsd` to `Graphite` in the docstring for the `graphite.New` constructor.