### PR TITLE
log/alt_experimental_level: Introduce general projection and filtering

### DIFF
--- a/log/alt_experimental_level/benchmark_test.go
+++ b/log/alt_experimental_level/benchmark_test.go
@@ -1,0 +1,59 @@
+package level_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/alt_experimental_level"
+)
+
+func BenchmarkNopBaseline(b *testing.B) {
+	benchmarkRunner(b, log.NewNopLogger())
+}
+
+func BenchmarkNopDisallowedLevel(b *testing.B) {
+	benchmarkRunner(b,
+		level.AllowingInfoAndAbove(log.NewNopLogger()))
+}
+
+func BenchmarkNopAllowedLevel(b *testing.B) {
+	benchmarkRunner(b,
+		level.AllowingAll(log.NewNopLogger()))
+}
+
+func BenchmarkJSONBaseline(b *testing.B) {
+	benchmarkRunner(b, log.NewJSONLogger(ioutil.Discard))
+}
+
+func BenchmarkJSONDisallowedLevel(b *testing.B) {
+	benchmarkRunner(b,
+		level.AllowingInfoAndAbove(log.NewJSONLogger(ioutil.Discard)))
+}
+
+func BenchmarkJSONAllowedLevel(b *testing.B) {
+	benchmarkRunner(b,
+		level.AllowingAll(log.NewJSONLogger(ioutil.Discard)))
+}
+
+func BenchmarkLogfmtBaseline(b *testing.B) {
+	benchmarkRunner(b, log.NewLogfmtLogger(ioutil.Discard))
+}
+
+func BenchmarkLogfmtDisallowedLevel(b *testing.B) {
+	benchmarkRunner(b,
+		level.AllowingInfoAndAbove(log.NewLogfmtLogger(ioutil.Discard)))
+}
+
+func BenchmarkLogfmtAllowedLevel(b *testing.B) {
+	benchmarkRunner(b,
+		level.AllowingAll(log.NewLogfmtLogger(ioutil.Discard)))
+}
+
+func benchmarkRunner(b *testing.B, logger log.Logger) {
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		level.Debug(logger).Log("foo", "bar")
+	}
+}

--- a/log/alt_experimental_level/benchmark_test.go
+++ b/log/alt_experimental_level/benchmark_test.go
@@ -1,6 +1,7 @@
 package level_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -9,48 +10,48 @@ import (
 )
 
 func BenchmarkNopBaseline(b *testing.B) {
-	benchmarkRunner(b, log.NewNopLogger())
+	singleRecordBenchmarkRunner(b, log.NewNopLogger())
 }
 
 func BenchmarkNopDisallowedLevel(b *testing.B) {
-	benchmarkRunner(b,
+	singleRecordBenchmarkRunner(b,
 		level.AllowingInfoAndAbove(log.NewNopLogger()))
 }
 
 func BenchmarkNopAllowedLevel(b *testing.B) {
-	benchmarkRunner(b,
+	singleRecordBenchmarkRunner(b,
 		level.AllowingAll(log.NewNopLogger()))
 }
 
 func BenchmarkJSONBaseline(b *testing.B) {
-	benchmarkRunner(b, log.NewJSONLogger(ioutil.Discard))
+	singleRecordBenchmarkRunner(b, log.NewJSONLogger(ioutil.Discard))
 }
 
 func BenchmarkJSONDisallowedLevel(b *testing.B) {
-	benchmarkRunner(b,
+	singleRecordBenchmarkRunner(b,
 		level.AllowingInfoAndAbove(log.NewJSONLogger(ioutil.Discard)))
 }
 
 func BenchmarkJSONAllowedLevel(b *testing.B) {
-	benchmarkRunner(b,
+	singleRecordBenchmarkRunner(b,
 		level.AllowingAll(log.NewJSONLogger(ioutil.Discard)))
 }
 
 func BenchmarkLogfmtBaseline(b *testing.B) {
-	benchmarkRunner(b, log.NewLogfmtLogger(ioutil.Discard))
+	singleRecordBenchmarkRunner(b, log.NewLogfmtLogger(ioutil.Discard))
 }
 
 func BenchmarkLogfmtDisallowedLevel(b *testing.B) {
-	benchmarkRunner(b,
+	singleRecordBenchmarkRunner(b,
 		level.AllowingInfoAndAbove(log.NewLogfmtLogger(ioutil.Discard)))
 }
 
 func BenchmarkLogfmtAllowedLevel(b *testing.B) {
-	benchmarkRunner(b,
+	singleRecordBenchmarkRunner(b,
 		level.AllowingAll(log.NewLogfmtLogger(ioutil.Discard)))
 }
 
-func benchmarkRunner(b *testing.B, logger log.Logger) {
+func singleRecordBenchmarkRunner(b *testing.B, logger log.Logger) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -58,18 +59,27 @@ func benchmarkRunner(b *testing.B, logger log.Logger) {
 	}
 }
 
-func BenchmarkManyDroppedRecords(b *testing.B) {
-	logger := level.AllowingInfoAndAbove(log.NewJSONLogger(ioutil.Discard))
-	b.ResetTimer()
-	b.ReportAllocs()
+func BenchmarkDroppedRecords(b *testing.B) {
+	logger := log.NewNopLogger()
+	logger = log.NewContext(logger).With("ts", log.DefaultTimestamp, "caller", log.DefaultCaller)
+	for _, dropped := range []uint{1, 3, 9, 99, 999} {
+		b.Run(fmt.Sprintf("%d-of-%d", dropped, dropped+1), func(b *testing.B) {
+			manyRecordBenchmarkRunner(b, logger, dropped)
+		})
+	}
+}
+
+func manyRecordBenchmarkRunner(b *testing.B, logger log.Logger, droppedRecords uint) {
+	logger = level.AllowingInfoAndAbove(logger)
 	debug := level.Debug(logger)
 	info := level.Info(logger)
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		debug.Log("foo", "1")
 		// Only this one will be retained.
-		info.Log("baz", "quux")
-		debug.Log("foo", "2")
-		debug.Log("foo", "3")
-		debug.Log("foo", "4")
+		info.Log("foo", "bar")
+		for ; droppedRecords != 0; droppedRecords-- {
+			debug.Log("baz", "quux")
+		}
 	}
 }

--- a/log/alt_experimental_level/benchmark_test.go
+++ b/log/alt_experimental_level/benchmark_test.go
@@ -57,3 +57,19 @@ func benchmarkRunner(b *testing.B, logger log.Logger) {
 		level.Debug(logger).Log("foo", "bar")
 	}
 }
+
+func BenchmarkManyDroppedRecords(b *testing.B) {
+	logger := level.AllowingInfoAndAbove(log.NewJSONLogger(ioutil.Discard))
+	b.ResetTimer()
+	b.ReportAllocs()
+	debug := level.Debug(logger)
+	info := level.Info(logger)
+	for i := 0; i < b.N; i++ {
+		debug.Log("foo", "1")
+		// Only this one will be retained.
+		info.Log("baz", "quux")
+		debug.Log("foo", "2")
+		debug.Log("foo", "3")
+		debug.Log("foo", "4")
+	}
+}

--- a/log/alt_experimental_level/benchmark_test.go
+++ b/log/alt_experimental_level/benchmark_test.go
@@ -78,7 +78,7 @@ func manyRecordBenchmarkRunner(b *testing.B, logger log.Logger, droppedRecords u
 	for i := 0; i < b.N; i++ {
 		// Only this one will be retained.
 		info.Log("foo", "bar")
-		for ; droppedRecords != 0; droppedRecords-- {
+		for dropped := droppedRecords; dropped != 0; dropped-- {
 			debug.Log("baz", "quux")
 		}
 	}

--- a/log/alt_experimental_level/level.go
+++ b/log/alt_experimental_level/level.go
@@ -1,0 +1,144 @@
+package level
+
+import "github.com/go-kit/kit/log"
+
+type leveler interface {
+	Debug(log.Logger) log.Logger
+	Info(log.Logger) log.Logger
+	Warn(log.Logger) log.Logger
+	Error(log.Logger) log.Logger
+}
+
+type level byte
+
+const (
+	levelDebug level = iota
+	levelInfo
+	levelWarn
+	levelError
+)
+
+type levelValue struct {
+	level
+	name string
+}
+
+func (v *levelValue) String() string {
+	return v.name
+}
+
+var (
+	valDebug = &levelValue{levelDebug, "debug"}
+	valInfo  = &levelValue{levelInfo, "info"}
+	valWarn  = &levelValue{levelWarn, "warn"}
+	valError = &levelValue{levelError, "error"}
+)
+
+func withLevel(v *levelValue, logger log.Logger) *log.Context {
+	return log.NewContext(logger).WithPrefix("level", v)
+}
+
+// Debug returns a logger ready to emit log records at the "debug"
+// level, intended for fine-level detailed tracing information. If the
+// supplied logger disallows records at that level, it instead returns
+// an inert logger that drops the record.
+func Debug(logger log.Logger) log.Logger {
+	return withLevel(valDebug, logger)
+}
+
+// Info returns a logger ready to emit log records at the "info"
+// level, intended for informational messages. If the supplied logger
+// disallows records at that level, it instead returns an inert logger
+// that drops the record.
+func Info(logger log.Logger) log.Logger {
+	return withLevel(valInfo, logger)
+}
+
+// Warn returns a logger ready to emit log records at the "warn"
+// level, intended for indicating potential problems. If the supplied
+// logger disallows records at that level, it instead returns an inert
+// logger that drops the record.
+func Warn(logger log.Logger) log.Logger {
+	return withLevel(valWarn, logger)
+}
+
+// Error returns a logger ready to emit log records at the "error"
+// level, intended for indicating serious failures. If the supplied
+// logger disallows records at that level, it instead returns an inert
+// logger that drops the record.
+func Error(logger log.Logger) log.Logger {
+	return withLevel(valError, logger)
+}
+
+func rejectLevelsLowerThan(minLevel level) log.Projection {
+	return func(keyvals []interface{}) ([]interface{}, bool) {
+		for i, end := 1, len(keyvals); i < end; i += 2 {
+			if l, ok := keyvals[i].(*levelValue); ok {
+				if l.level < minLevel {
+					return nil, false
+				}
+				break
+			}
+		}
+		return keyvals, true
+	}
+}
+
+var (
+	preserveInfoAndAbove = rejectLevelsLowerThan(levelInfo)
+	preserveWarnAndAbove = rejectLevelsLowerThan(levelWarn)
+	preserveErrorOnly    = rejectLevelsLowerThan(levelError)
+)
+
+// AllowingAll returns a logger allowed to emit log records at all
+// levels, unless the supplied logger is already restricted to some
+// narrower set of levels, in which case it retains that restriction.
+//
+// The behavior is equivalent to AllowingDebugAndAbove.
+func AllowingAll(logger log.Logger) log.Logger {
+	return AllowingDebugAndAbove(logger)
+}
+
+// AllowingDebugAndAbove returns a logger allowed to emit log records
+// at all levels, unless the supplied logger is already restricted to
+// some narrower set of levels, in which case it retains that
+// restriction.
+func AllowingDebugAndAbove(logger log.Logger) log.Logger {
+	return logger
+}
+
+// AllowingInfoAndAbove returns a logger allowed to emit log records
+// at levels "info" and above, dropping "debug"-level records, unless
+// the supplied logger is already restricted to some narrower set of
+// levels, in which case it retains that restriction.
+func AllowingInfoAndAbove(logger log.Logger) log.Logger {
+	return log.NewContext(logger).WithPreProjection(preserveInfoAndAbove)
+}
+
+// AllowingWarnAndAbove returns a logger allowed to emit log records
+// at levels "warn" and above, dropping "debug"- and "info"-level
+// records, unless the supplied logger is already restricted to some
+// narrower set of levels, in which case it retains that restriction.
+func AllowingWarnAndAbove(logger log.Logger) log.Logger {
+	return log.NewContext(logger).WithPreProjection(preserveWarnAndAbove)
+}
+
+// AllowingErrorOnly returns a logger allowed to emit log records only
+// at level "error", dropping "debug"-, "info"-, and "warn"-level
+// records, unless the supplied logger is already restricted to some
+// narrower set of levels, in which case it retains that restriction.
+func AllowingErrorOnly(logger log.Logger) log.Logger {
+	return log.NewContext(logger).WithPreProjection(preserveErrorOnly)
+}
+
+// AllowingNone returns a logger that drops log records at all levels.
+func AllowingNone(logger log.Logger) log.Logger {
+	return log.NewContext(logger).WithPreProjection(func(keyvals []interface{}) ([]interface{}, bool) {
+		for i, end := 1, len(keyvals); i < end; i += 2 {
+			if _, ok := keyvals[i].(*levelValue); ok {
+				return nil, false
+			}
+		}
+		return keyvals, true
+	})
+}

--- a/log/alt_experimental_level/level.go
+++ b/log/alt_experimental_level/level.go
@@ -112,7 +112,7 @@ func AllowingDebugAndAbove(logger log.Logger) log.Logger {
 // the supplied logger is already restricted to some narrower set of
 // levels, in which case it retains that restriction.
 func AllowingInfoAndAbove(logger log.Logger) log.Logger {
-	return log.NewContext(logger).WithPreProjection(preserveInfoAndAbove)
+	return log.NewContext(logger).WithPreProjection(preserveInfoAndAbove, false)
 }
 
 // AllowingWarnAndAbove returns a logger allowed to emit log records
@@ -120,7 +120,7 @@ func AllowingInfoAndAbove(logger log.Logger) log.Logger {
 // records, unless the supplied logger is already restricted to some
 // narrower set of levels, in which case it retains that restriction.
 func AllowingWarnAndAbove(logger log.Logger) log.Logger {
-	return log.NewContext(logger).WithPreProjection(preserveWarnAndAbove)
+	return log.NewContext(logger).WithPreProjection(preserveWarnAndAbove, false)
 }
 
 // AllowingErrorOnly returns a logger allowed to emit log records only
@@ -128,7 +128,7 @@ func AllowingWarnAndAbove(logger log.Logger) log.Logger {
 // records, unless the supplied logger is already restricted to some
 // narrower set of levels, in which case it retains that restriction.
 func AllowingErrorOnly(logger log.Logger) log.Logger {
-	return log.NewContext(logger).WithPreProjection(preserveErrorOnly)
+	return log.NewContext(logger).WithPreProjection(preserveErrorOnly, false)
 }
 
 // AllowingNone returns a logger that drops log records at all levels.
@@ -140,5 +140,5 @@ func AllowingNone(logger log.Logger) log.Logger {
 			}
 		}
 		return keyvals, true
-	})
+	}, false)
 }

--- a/log/alt_experimental_level/level.go
+++ b/log/alt_experimental_level/level.go
@@ -112,7 +112,7 @@ func AllowingDebugAndAbove(logger log.Logger) log.Logger {
 // the supplied logger is already restricted to some narrower set of
 // levels, in which case it retains that restriction.
 func AllowingInfoAndAbove(logger log.Logger) log.Logger {
-	return log.NewContext(logger).WithPreProjection(preserveInfoAndAbove, false)
+	return log.NewContext(logger).WithProjection(preserveInfoAndAbove)
 }
 
 // AllowingWarnAndAbove returns a logger allowed to emit log records
@@ -120,7 +120,7 @@ func AllowingInfoAndAbove(logger log.Logger) log.Logger {
 // records, unless the supplied logger is already restricted to some
 // narrower set of levels, in which case it retains that restriction.
 func AllowingWarnAndAbove(logger log.Logger) log.Logger {
-	return log.NewContext(logger).WithPreProjection(preserveWarnAndAbove, false)
+	return log.NewContext(logger).WithProjection(preserveWarnAndAbove)
 }
 
 // AllowingErrorOnly returns a logger allowed to emit log records only
@@ -128,17 +128,17 @@ func AllowingWarnAndAbove(logger log.Logger) log.Logger {
 // records, unless the supplied logger is already restricted to some
 // narrower set of levels, in which case it retains that restriction.
 func AllowingErrorOnly(logger log.Logger) log.Logger {
-	return log.NewContext(logger).WithPreProjection(preserveErrorOnly, false)
+	return log.NewContext(logger).WithProjection(preserveErrorOnly)
 }
 
 // AllowingNone returns a logger that drops log records at all levels.
 func AllowingNone(logger log.Logger) log.Logger {
-	return log.NewContext(logger).WithPreProjection(func(keyvals []interface{}) ([]interface{}, bool) {
+	return log.NewContext(logger).WithProjection(func(keyvals []interface{}) ([]interface{}, bool) {
 		for i, end := 1, len(keyvals); i < end; i += 2 {
 			if _, ok := keyvals[i].(*levelValue); ok {
 				return nil, false
 			}
 		}
 		return keyvals, true
-	}, false)
+	})
 }

--- a/log/alt_experimental_level/level_test.go
+++ b/log/alt_experimental_level/level_test.go
@@ -112,6 +112,20 @@ func TestContextLevel(t *testing.T) {
 	}
 }
 
+func TestLevelRestrictionOverLeveledContext(t *testing.T) {
+	var buf bytes.Buffer
+
+	var logger log.Logger
+	logger = log.NewLogfmtLogger(&buf)
+	logger = level.Debug(logger)
+	logger = level.AllowingInfoAndAbove(logger)
+	logger.Log("this is", "debug log")
+
+	if buf.Len() > 0 {
+		t.Errorf("want no output, have %q", buf.String())
+	}
+}
+
 func TestLevelLayerRestrictions(t *testing.T) {
 	factories := []struct {
 		name string

--- a/log/alt_experimental_level/level_test.go
+++ b/log/alt_experimental_level/level_test.go
@@ -1,0 +1,231 @@
+package level_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/alt_experimental_level"
+)
+
+func TestInstanceLevels(t *testing.T) {
+	for _, testcase := range []struct {
+		allowed string
+		allow   func(log.Logger) log.Logger
+		want    string
+	}{
+		{
+			"all",
+			level.AllowingAll,
+			strings.Join([]string{
+				`{"level":"debug","this is":"debug log"}`,
+				`{"level":"info","this is":"info log"}`,
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"debug+",
+			level.AllowingDebugAndAbove,
+			strings.Join([]string{
+				`{"level":"debug","this is":"debug log"}`,
+				`{"level":"info","this is":"info log"}`,
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"info+",
+			level.AllowingInfoAndAbove,
+			strings.Join([]string{
+				`{"level":"info","this is":"info log"}`,
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"warn+",
+			level.AllowingWarnAndAbove,
+			strings.Join([]string{
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"error",
+			level.AllowingErrorOnly,
+			strings.Join([]string{
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"none",
+			level.AllowingNone,
+			``,
+		},
+	} {
+		var buf bytes.Buffer
+		logger := testcase.allow(log.NewJSONLogger(&buf))
+
+		level.Debug(logger).Log("this is", "debug log")
+		level.Info(logger).Log("this is", "info log")
+		level.Warn(logger).Log("this is", "warn log")
+		level.Error(logger).Log("this is", "error log")
+
+		if want, have := testcase.want, strings.TrimSpace(buf.String()); want != have {
+			t.Errorf("given Allowed=%s: want\n%s\nhave\n%s", testcase.allowed, want, have)
+		}
+	}
+}
+
+func TestLevelContext(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Wrapping the level logger with a context allows users to use
+	// log.DefaultCaller as per normal.
+	var logger log.Logger
+	logger = log.NewLogfmtLogger(&buf)
+	logger = level.AllowingAll(logger)
+	logger = level.Info(logger)
+	logger = log.NewContext(logger).With("caller", log.DefaultCaller)
+
+	logger.Log("foo", "bar")
+	if want, have := `level=info caller=level_test.go:93 foo=bar`, strings.TrimSpace(buf.String()); want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
+}
+
+func TestContextLevel(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Wrapping the level logger with a context allows users to use
+	// log.DefaultCaller as per normal.
+	var logger log.Logger
+	logger = log.NewLogfmtLogger(&buf)
+	logger = log.NewContext(logger).With("caller", log.DefaultCaller)
+
+	logger = level.AllowingAll(logger)
+	level.Info(logger).Log("foo", "bar")
+	if want, have := `level=info caller=level_test.go:109 foo=bar`, strings.TrimSpace(buf.String()); want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
+}
+
+func TestLevelLayerRestrictions(t *testing.T) {
+	factories := []struct {
+		name string
+		f    func(log.Logger) log.Logger
+	}{
+		{"all", level.AllowingAll},
+		{"debug+", level.AllowingDebugAndAbove},
+		{"info+", level.AllowingInfoAndAbove},
+		{"warn+", level.AllowingWarnAndAbove},
+		{"error", level.AllowingErrorOnly},
+		{"none", level.AllowingNone},
+	}
+	emitters := []struct {
+		name string
+		f    func(log.Logger) log.Logger
+	}{
+		{"debug", level.Debug},
+		{"info", level.Info},
+		{"warn", level.Warn},
+		{"error", level.Error},
+	}
+	tests := [][][4]bool{
+		// all
+		{
+			{true, true, true, true},     // all
+			{true, true, true, true},     // debug+
+			{false, true, true, true},    // info+
+			{false, false, true, true},   // warn+
+			{false, false, false, true},  // error
+			{false, false, false, false}, // none
+		},
+		// debug+
+		{
+			{true, true, true, true},     // all
+			{true, true, true, true},     // debug+
+			{false, true, true, true},    // info+
+			{false, false, true, true},   // warn+
+			{false, false, false, true},  // error
+			{false, false, false, false}, // none
+		},
+		// info+
+		{
+			{false, true, true, true},    // all
+			{false, true, true, true},    // debug+
+			{false, true, true, true},    // info+
+			{false, false, true, true},   // warn+
+			{false, false, false, true},  // error
+			{false, false, false, false}, // none
+		},
+		// warn+
+		{
+			{false, false, true, true},   // all
+			{false, false, true, true},   // debug+
+			{false, false, true, true},   // info+
+			{false, false, true, true},   // warn+
+			{false, false, false, true},  // error
+			{false, false, false, false}, // none
+		},
+		// error
+		{
+			{false, false, false, true},  // all
+			{false, false, false, true},  // debug+
+			{false, false, false, true},  // info+
+			{false, false, false, true},  // warn+
+			{false, false, false, true},  // error
+			{false, false, false, false}, // none
+		},
+		// none
+		{
+			{false, false, false, false}, // all
+			{false, false, false, false}, // debug+
+			{false, false, false, false}, // info+
+			{false, false, false, false}, // warn+
+			{false, false, false, false}, // error
+			{false, false, false, false}, // none
+		},
+	}
+	var buf bytes.Buffer
+	logger := log.NewLogfmtLogger(&buf)
+	for i, test := range tests {
+		t.Run(factories[i].name, func(t *testing.T) {
+			initialLogger := factories[i].f(logger)
+			if initialLogger == nil {
+				t.Fatal("initial factory returned nil")
+			}
+			// Wrap with an intervening layer to confirm that
+			// subsequent level restricting factories can see through
+			// to the inner restriction.
+			initialLogger = log.NewContext(initialLogger)
+			for j, layer := range test {
+				t.Run(factories[j].name, func(t *testing.T) {
+					layeredLogger := factories[j].f(initialLogger)
+					if layeredLogger == nil {
+						t.Fatal("layering factory returned nil")
+					}
+					for k, expected := range layer {
+						t.Run(emitters[k].name, func(t *testing.T) {
+							defer buf.Reset()
+							leveled := emitters[k].f(layeredLogger)
+							if leveled == nil {
+								t.Fatalf("leveled emitter function returned nil")
+							}
+							leveled.Log("m", "x")
+							if buf.Len() > 0 {
+								if !expected {
+									t.Fatalf("want no output, have %q", buf.Bytes())
+								}
+							} else if expected {
+								t.Fatal("want output, have none")
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}

--- a/log/experimental_level/benchmark_test.go
+++ b/log/experimental_level/benchmark_test.go
@@ -1,6 +1,7 @@
 package level_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -9,48 +10,48 @@ import (
 )
 
 func BenchmarkNopBaseline(b *testing.B) {
-	benchmarkRunner(b, log.NewNopLogger())
+	singleRecordBenchmarkRunner(b, log.NewNopLogger())
 }
 
 func BenchmarkNopDisallowedLevel(b *testing.B) {
-	benchmarkRunner(b, level.New(log.NewNopLogger(),
+	singleRecordBenchmarkRunner(b, level.New(log.NewNopLogger(),
 		level.Allowed(level.AllowInfoAndAbove())))
 }
 
 func BenchmarkNopAllowedLevel(b *testing.B) {
-	benchmarkRunner(b, level.New(log.NewNopLogger(),
+	singleRecordBenchmarkRunner(b, level.New(log.NewNopLogger(),
 		level.Allowed(level.AllowAll())))
 }
 
 func BenchmarkJSONBaseline(b *testing.B) {
-	benchmarkRunner(b, log.NewJSONLogger(ioutil.Discard))
+	singleRecordBenchmarkRunner(b, log.NewJSONLogger(ioutil.Discard))
 }
 
 func BenchmarkJSONDisallowedLevel(b *testing.B) {
-	benchmarkRunner(b, level.New(log.NewJSONLogger(ioutil.Discard),
+	singleRecordBenchmarkRunner(b, level.New(log.NewJSONLogger(ioutil.Discard),
 		level.Allowed(level.AllowInfoAndAbove())))
 }
 
 func BenchmarkJSONAllowedLevel(b *testing.B) {
-	benchmarkRunner(b, level.New(log.NewJSONLogger(ioutil.Discard),
+	singleRecordBenchmarkRunner(b, level.New(log.NewJSONLogger(ioutil.Discard),
 		level.Allowed(level.AllowAll())))
 }
 
 func BenchmarkLogfmtBaseline(b *testing.B) {
-	benchmarkRunner(b, log.NewLogfmtLogger(ioutil.Discard))
+	singleRecordBenchmarkRunner(b, log.NewLogfmtLogger(ioutil.Discard))
 }
 
 func BenchmarkLogfmtDisallowedLevel(b *testing.B) {
-	benchmarkRunner(b, level.New(log.NewLogfmtLogger(ioutil.Discard),
+	singleRecordBenchmarkRunner(b, level.New(log.NewLogfmtLogger(ioutil.Discard),
 		level.Allowed(level.AllowInfoAndAbove())))
 }
 
 func BenchmarkLogfmtAllowedLevel(b *testing.B) {
-	benchmarkRunner(b, level.New(log.NewLogfmtLogger(ioutil.Discard),
+	singleRecordBenchmarkRunner(b, level.New(log.NewLogfmtLogger(ioutil.Discard),
 		level.Allowed(level.AllowAll())))
 }
 
-func benchmarkRunner(b *testing.B, logger log.Logger) {
+func singleRecordBenchmarkRunner(b *testing.B, logger log.Logger) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -58,20 +59,27 @@ func benchmarkRunner(b *testing.B, logger log.Logger) {
 	}
 }
 
-func BenchmarkManyDroppedRecords(b *testing.B) {
-	logger := level.New(log.NewJSONLogger(ioutil.Discard), level.Config{
-		Allowed: level.AllowInfoAndAbove(),
-	})
-	b.ResetTimer()
-	b.ReportAllocs()
+func BenchmarkDroppedRecords(b *testing.B) {
+	logger := log.NewNopLogger()
+	logger = log.NewContext(logger).With("ts", log.DefaultTimestamp, "caller", log.DefaultCaller)
+	for _, dropped := range []uint{1, 3, 9, 99, 999} {
+		b.Run(fmt.Sprintf("%d-of-%d", dropped, dropped+1), func(b *testing.B) {
+			manyRecordBenchmarkRunner(b, logger, dropped)
+		})
+	}
+}
+
+func manyRecordBenchmarkRunner(b *testing.B, logger log.Logger, droppedRecords uint) {
+	logger = level.New(logger, level.Allowed(level.AllowInfoAndAbove()))
 	debug := level.Debug(logger)
 	info := level.Info(logger)
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		debug.Log("foo", "1")
 		// Only this one will be retained.
-		info.Log("baz", "quux")
-		debug.Log("foo", "2")
-		debug.Log("foo", "3")
-		debug.Log("foo", "4")
+		info.Log("foo", "bar")
+		for ; droppedRecords != 0; droppedRecords-- {
+			debug.Log("baz", "quux")
+		}
 	}
 }

--- a/log/experimental_level/benchmark_test.go
+++ b/log/experimental_level/benchmark_test.go
@@ -57,3 +57,21 @@ func benchmarkRunner(b *testing.B, logger log.Logger) {
 		level.Debug(logger).Log("foo", "bar")
 	}
 }
+
+func BenchmarkManyDroppedRecords(b *testing.B) {
+	logger := level.New(log.NewJSONLogger(ioutil.Discard), level.Config{
+		Allowed: level.AllowInfoAndAbove(),
+	})
+	b.ResetTimer()
+	b.ReportAllocs()
+	debug := level.Debug(logger)
+	info := level.Info(logger)
+	for i := 0; i < b.N; i++ {
+		debug.Log("foo", "1")
+		// Only this one will be retained.
+		info.Log("baz", "quux")
+		debug.Log("foo", "2")
+		debug.Log("foo", "3")
+		debug.Log("foo", "4")
+	}
+}

--- a/log/experimental_level/benchmark_test.go
+++ b/log/experimental_level/benchmark_test.go
@@ -78,7 +78,7 @@ func manyRecordBenchmarkRunner(b *testing.B, logger log.Logger, droppedRecords u
 	for i := 0; i < b.N; i++ {
 		// Only this one will be retained.
 		info.Log("foo", "bar")
-		for ; droppedRecords != 0; droppedRecords-- {
+		for dropped := droppedRecords; dropped != 0; dropped-- {
 			debug.Log("baz", "quux")
 		}
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -213,17 +213,18 @@ func (l *Context) WithPreProjection(p Projection, deferred bool) *Context {
 	if p == nil || l == nil {
 		return l
 	}
-	if outer := l.projection; outer != nil {
-		if !deferred && outer.deferred {
+	if preceding := l.projection; preceding != nil {
+		if !deferred && preceding.deferred {
 			deferred = true
 		}
 		inner := p
+		outer := preceding.Projection
 		p = func(keyvals []interface{}) ([]interface{}, bool) {
 			kvs, preserve := inner(keyvals)
 			if !preserve {
 				return nil, false
 			}
-			return outer.Projection(kvs)
+			return outer(kvs)
 		}
 	}
 	return &Context{
@@ -248,13 +249,14 @@ func (l *Context) WithPostProjection(p Projection, deferred bool) *Context {
 	if p == nil || l == nil {
 		return l
 	}
-	if inner := l.projection; inner != nil {
-		if !deferred && inner.deferred {
+	if preceding := l.projection; preceding != nil {
+		if !deferred && preceding.deferred {
 			deferred = true
 		}
 		outer := p
+		inner := preceding.Projection
 		p = func(keyvals []interface{}) ([]interface{}, bool) {
-			kvs, preserve := inner.Projection(keyvals)
+			kvs, preserve := inner(keyvals)
 			if !preserve {
 				return nil, false
 			}


### PR DESCRIPTION
Following up from #444, demonstrate an alternate approach to the "level" package offered via the "github.com/go-kit/kit/log/experimental_package" import path (pending promotion via #449), allowing log event level filtering via functions that specify the filtering threshold.

This capability is implemented in terms of a new concept for `log.Context`: _projection functions_. There are two new exported methods on `log.Context` that mention a new exported type, though defining that type is a convenience and isn't strictly necessary:
- **`log.Projection`**  
  A convenience declaration of a _projection function_ that accepts a proposed set of key/value pairs and either drops the record (and any later records that would include those key/value pairs) or proposes a revised set of key/value pairs.
- **`log.Context.WithPreProjection`**  
  Composes a _projection function_ onto a `Context`, applying it early as the "innermost" such function.
- **`log.Context.WithPostProjection`**  
  Composes a _projection function_ onto a `Context`, applying it late as the "outermost" such function.

Including this function in `log.Context` increases the struct's size by four bytes, which accounts for the 16.67% increase in allocations per operation seen in the benchmarks. That is, each time we allocate a new `Context` in `log.NewContext`, we allocate 28 instead of 24 bytes.

There are a few operations that are slower than the alternate operation, such as the JSON and _logfmt_ conversion. I _think_ this is due to my level values being implementations of `fmt.Stringer` as opposed to `string` values; both those formatters visit such values second in line, and call on them with a deferred function to trap panics. As my interest here is more in cutting down on CPU and allocation cost in cases where most log messages are filtered out, I stuck with my `level.levelValue` type here, as it yielded faster benchmarks for discerning whether the value should be dropped by the filter.

With these _projection functions_ in place, it's possible to implement [log15's `ext.EscalateErrHandler`](https://godoc.org/github.com/inconshreveable/log15/ext#EscalateErrHandler), though only within the `level` package, because the `level.levelValue` type is not exported. We would have to make a copy of the supplied key/value slice and replace the level value in it if we discover a non-nil `error` elsewhere in the sequence, so it's not as efficient as `ext.EscalateErrHandler`, but that library's records include the level directly.

Invoking these projection functions involves trading trust for efficiency. I considered making a defensive copy of the key/value sequence supplied to each invocation of the function, which allows the function the opportunity to mutate the sequence in place. However, that induces allocation and copying even for cases where the projection function is just a pure filter; even sequences it would vote to drop would have been copied first. Instead, I decided to document that a well-behaved `log.Projection` does not mutate the supplied slice, expecting that the most common cases would involve only inspecting the proposed key/value pairs and either dropping them or preserving them as they are. I expect that this choice will be controversial.

Here are the benchmark comparisons:

| name  | old time/op | new time/op  | delta |
| --- | --- | --- | --- |
| NopBaseline-8           |  470ns ± 0% |  443ns ± 0% |  -5.74% |
| NopDisallowedLevel-8    |  513ns ± 0% |  187ns ± 0% | -63.55% |
| NopAllowedLevel-8       |  516ns ± 0% |  451ns ± 0% | -12.60% |
| JSONBaseline-8          | 2.44µs ± 0% | 2.40µs ± 0% |  -1.88% |
| JSONDisallowedLevel-8   |  515ns ± 0% |  184ns ± 0% | -64.27% |
| JSONAllowedLevel-8      | 2.48µs ± 0% | 2.34µs ± 0% |  -5.77% |
| LogfmtBaseline-8        | 1.05µs ± 0% | 1.13µs ± 0% |  +7.71% |
| LogfmtDisallowedLevel-8 |  514ns ± 0% |  181ns ± 0% | -64.79% |
| LogfmtAllowedLevel-8    | 1.13µs ± 0% | 1.13µs ± 0% |  -0.18% |

| name | old alloc/op | new alloc/op | delta |
| --- | --- | --- | --- |
| NopBaseline-8           | 288B ± 0% |  336B ± 0% | +16.67% |
| NopDisallowedLevel-8    | 288B ± 0% |  112B ± 0% | -61.11% |
| NopAllowedLevel-8       | 288B ± 0% |  336B ± 0% | +16.67% |
| JSONBaseline-8          | 968B ± 0% | 1032B ± 0% |  +6.61% |
| JSONDisallowedLevel-8   | 288B ± 0% |  112B ± 0% | -61.11% |
| JSONAllowedLevel-8      | 968B ± 0% | 1032B ± 0% |  +6.61% |
| LogfmtBaseline-8        | 288B ± 0% |  336B ± 0% | +16.67% |
| LogfmtDisallowedLevel-8 | 288B ± 0% |  112B ± 0% | -61.11% |
| LogfmtAllowedLevel-8    | 288B ± 0% |  336B ± 0% | +16.67% |

| name | old allocs/op | new allocs/op | delta |
| --- | --- | --- | --- |
| NopBaseline-8           | 9.00 ± 0% | 9.00 ± 0% |  +0.00% |
| NopDisallowedLevel-8    | 9.00 ± 0% | 5.00 ± 0% | -44.44% |
| NopAllowedLevel-8       | 9.00 ± 0% | 9.00 ± 0% |  +0.00% |
| JSONBaseline-8          | 22.0 ± 0% | 23.0 ± 0% |  +4.55% |
| JSONDisallowedLevel-8   | 9.00 ± 0% | 5.00 ± 0% | -44.44% |
| JSONAllowedLevel-8      | 22.0 ± 0% | 23.0 ± 0% |  +4.55% |
| LogfmtBaseline-8        | 9.00 ± 0% | 9.00 ± 0% |  +0.00% |
| LogfmtDisallowedLevel-8 | 9.00 ± 0% | 5.00 ± 0% | -44.44% |
| LogfmtAllowedLevel-8    | 9.00 ± 0% | 9.00 ± 0% |  +0.00% |

They are not as obviously rosy. I think that this approach's benefits would become more clear when we see filtering applied to a `log.Context` with lots of log messages dropped, such as the following:
```go
func BenchmarkManyDroppedRecords(b *testing.B) {
	logger := level.AllowingInfoAndAbove(log.NewJSONLogger(ioutil.Discard))
	b.ResetTimer()
	b.ReportAllocs()
	debug := level.Debug(logger)
	info := level.Info(logger)
	for i := 0; i < b.N; i++ {
		debug.Log("foo", "1")
		// Only this one will be retained.
		info.Log("baz", "quux")
		debug.Log("foo", "2")
		debug.Log("foo", "3")
		debug.Log("foo", "4")
	}
}
```
Run against the equivalent version from the _experimental_level_ directory:

| name  | old time/op | new time/op  | delta |
| --- | --- | --- | --- |
| ManyDroppedRecords-8 | 3.36µs ± 0% | 2.79µs ± 0% | -16.80% |

| name | old alloc/op | new alloc/op | delta |
| --- | --- | --- | --- |
| ManyDroppedRecords-8 | 1.32kB ± 0% | 1.08kB ± 0% | -18.18% |

| name | old allocs/op | new allocs/op | delta |
| --- | --- | --- | --- |
| ManyDroppedRecords-8 | 33.0 ± 0% | 30.0 ± 0% | -9.09% |

Lacking still are unit tests to cover the new `Context.WithPreProjection` and `Context.WithPostProjection` functions. As each has two parameters, the first of which can be nil, there are at least four interesting cases for each one, as well as exercising proper composition with an existing projection function in the `Context`. I didn't write those yet, as I am uncertain whether the maintainers are amenable to the ideas introduced here.

I welcome your thoughts, but if you're tired of considering these alternative proposals, I understand.