### PR TITLE
Use variadic function to pass parameters instead of Config struct

### DIFF
--- a/log/experimental_level/benchmark_test.go
+++ b/log/experimental_level/benchmark_test.go
@@ -13,15 +13,13 @@ func BenchmarkNopBaseline(b *testing.B) {
 }
 
 func BenchmarkNopDisallowedLevel(b *testing.B) {
-	benchmarkRunner(b, level.New(log.NewNopLogger(), level.Config{
-		Allowed: level.AllowInfoAndAbove(),
-	}))
+	benchmarkRunner(b, level.New(log.NewNopLogger(),
+		level.Allowed(level.AllowInfoAndAbove())))
 }
 
 func BenchmarkNopAllowedLevel(b *testing.B) {
-	benchmarkRunner(b, level.New(log.NewNopLogger(), level.Config{
-		Allowed: level.AllowAll(),
-	}))
+	benchmarkRunner(b, level.New(log.NewNopLogger(),
+		level.Allowed(level.AllowAll())))
 }
 
 func BenchmarkJSONBaseline(b *testing.B) {
@@ -29,15 +27,13 @@ func BenchmarkJSONBaseline(b *testing.B) {
 }
 
 func BenchmarkJSONDisallowedLevel(b *testing.B) {
-	benchmarkRunner(b, level.New(log.NewJSONLogger(ioutil.Discard), level.Config{
-		Allowed: level.AllowInfoAndAbove(),
-	}))
+	benchmarkRunner(b, level.New(log.NewJSONLogger(ioutil.Discard),
+		level.Allowed(level.AllowInfoAndAbove())))
 }
 
 func BenchmarkJSONAllowedLevel(b *testing.B) {
-	benchmarkRunner(b, level.New(log.NewJSONLogger(ioutil.Discard), level.Config{
-		Allowed: level.AllowAll(),
-	}))
+	benchmarkRunner(b, level.New(log.NewJSONLogger(ioutil.Discard),
+		level.Allowed(level.AllowAll())))
 }
 
 func BenchmarkLogfmtBaseline(b *testing.B) {
@@ -45,15 +41,13 @@ func BenchmarkLogfmtBaseline(b *testing.B) {
 }
 
 func BenchmarkLogfmtDisallowedLevel(b *testing.B) {
-	benchmarkRunner(b, level.New(log.NewLogfmtLogger(ioutil.Discard), level.Config{
-		Allowed: level.AllowInfoAndAbove(),
-	}))
+	benchmarkRunner(b, level.New(log.NewLogfmtLogger(ioutil.Discard),
+		level.Allowed(level.AllowInfoAndAbove())))
 }
 
 func BenchmarkLogfmtAllowedLevel(b *testing.B) {
-	benchmarkRunner(b, level.New(log.NewLogfmtLogger(ioutil.Discard), level.Config{
-		Allowed: level.AllowAll(),
-	}))
+	benchmarkRunner(b, level.New(log.NewLogfmtLogger(ioutil.Discard),
+		level.Allowed(level.AllowAll())))
 }
 
 func benchmarkRunner(b *testing.B, logger log.Logger) {

--- a/log/experimental_level/doc.go
+++ b/log/experimental_level/doc.go
@@ -6,7 +6,7 @@
 //
 //    var logger log.Logger
 //    logger = log.NewLogfmtLogger(os.Stderr)
-//    logger = level.New(logger, level.Config{Allowed: level.AllowInfoAndAbove}) // <--
+//    logger = level.New(logger, level.Allowed(level.AllowInfoAndAbove())) // <--
 //    logger = log.NewContext(logger).With("ts", log.DefaultTimestampUTC)
 //
 // Then, at the callsites, use one of the level.Debug, Info, Warn, or Error
@@ -20,8 +20,8 @@
 //
 // The leveled logger allows precise control over what should happen if a log
 // event is emitted without a level key, or if a squelched level is used. Check
-// the Config struct for details. And, you can easily use non-default level
+// the Option functions for details. And, you can easily use non-default level
 // values: create new string constants for whatever you want to change, pass
-// them explicitly to the Config struct, and write your own level.Foo-style
+// them explicitly to the Allowed Option function, and write your own level.Foo-style
 // helper methods.
 package level

--- a/log/experimental_level/level.go
+++ b/log/experimental_level/level.go
@@ -69,6 +69,8 @@ func Debug(logger log.Logger) log.Logger {
 
 // New wraps the logger and implements level checking. See the commentary on the
 // Option functions for a detailed description of how to configure levels.
+// If no options are provided, all leveled log events created with level.Debug,
+// Info, Warn or Error helper methods will be squelched.
 func New(next log.Logger, options ...Option) log.Logger {
 	l := logger{
 		next: next,

--- a/log/experimental_level/level.go
+++ b/log/experimental_level/level.go
@@ -18,31 +18,31 @@ func AllowAll() []string {
 }
 
 // AllowDebugAndAbove allows all of the four default log levels.
-// Its return value may be provided as the Allowed parameter in the Config.
+// Its return value may be provided with the Allowed Option.
 func AllowDebugAndAbove() []string {
 	return []string{errorLevelValue, warnLevelValue, infoLevelValue, debugLevelValue}
 }
 
 // AllowInfoAndAbove allows the default info, warn, and error log levels.
-// Its return value may be provided as the Allowed parameter in the Config.
+// Its return value may be provided with the Allowed Option.
 func AllowInfoAndAbove() []string {
 	return []string{errorLevelValue, warnLevelValue, infoLevelValue}
 }
 
 // AllowWarnAndAbove allows the default warn and error log levels.
-// Its return value may be provided as the Allowed parameter in the Config.
+// Its return value may be provided with the Allowed Option.
 func AllowWarnAndAbove() []string {
 	return []string{errorLevelValue, warnLevelValue}
 }
 
 // AllowErrorOnly allows only the default error log level.
-// Its return value may be provided as the Allowed parameter in the Config.
+// Its return value may be provided with the Allowed Option.
 func AllowErrorOnly() []string {
 	return []string{errorLevelValue}
 }
 
 // AllowNone allows none of the default log levels.
-// Its return value may be provided as the Allowed parameter in the Config.
+// Its return value may be provided with the Allowed Option.
 func AllowNone() []string {
 	return []string{}
 }
@@ -67,41 +67,49 @@ func Debug(logger log.Logger) log.Logger {
 	return log.NewContext(logger).WithPrefix(levelKey, debugLevelValue)
 }
 
-// Config parameterizes the leveled logger.
-type Config struct {
-	// Allowed enumerates the accepted log levels. If a log event is encountered
-	// with a level key set to a value that isn't explicitly allowed, the event
-	// will be squelched, and ErrNotAllowed returned.
-	Allowed []string
-
-	// ErrNotAllowed is returned to the caller when Log is invoked with a level
-	// key that hasn't been explicitly allowed. By default, ErrNotAllowed is
-	// nil; in this case, the log event is squelched with no error.
-	ErrNotAllowed error
-
-	// SquelchNoLevel will squelch log events with no level key, so that they
-	// don't proceed through to the wrapped logger. If SquelchNoLevel is set to
-	// true and a log event is squelched in this way, ErrNoLevel is returned to
-	// the caller.
-	SquelchNoLevel bool
-
-	// ErrNoLevel is returned to the caller when SquelchNoLevel is true, and Log
-	// is invoked without a level key. By default, ErrNoLevel is nil; in this
-	// case, the log event is squelched with no error.
-	ErrNoLevel error
-}
-
 // New wraps the logger and implements level checking. See the commentary on the
-// Config object for a detailed description of how to configure levels.
-func New(next log.Logger, config Config) log.Logger {
-	return &logger{
-		next:           next,
-		allowed:        makeSet(config.Allowed),
-		errNotAllowed:  config.ErrNotAllowed,
-		squelchNoLevel: config.SquelchNoLevel,
-		errNoLevel:     config.ErrNoLevel,
+// Option functions for a detailed description of how to configure levels.
+func New(next log.Logger, options ...Option) log.Logger {
+	l := logger{
+		next: next,
 	}
+	for _, option := range options {
+		option(&l)
+	}
+	return &l
 }
+
+// Allowed enumerates the accepted log levels. If a log event is encountered
+// with a level key set to a value that isn't explicitly allowed, the event
+// will be squelched, and ErrNotAllowed returned.
+func Allowed(allowed []string) Option {
+	return func(l *logger) { l.allowed = makeSet(allowed) }
+}
+
+// ErrNoLevel is returned to the caller when SquelchNoLevel is true, and Log
+// is invoked without a level key. By default, ErrNoLevel is nil; in this
+// case, the log event is squelched with no error.
+func ErrNotAllowed(err error) Option {
+	return func(l *logger) { l.errNotAllowed = err }
+}
+
+// SquelchNoLevel will squelch log events with no level key, so that they
+// don't proceed through to the wrapped logger. If SquelchNoLevel is set to
+// true and a log event is squelched in this way, ErrNoLevel is returned to
+// the caller.
+func SquelchNoLevel(squelch bool) Option {
+	return func(l *logger) { l.squelchNoLevel = squelch }
+}
+
+// ErrNoLevel is returned to the caller when SquelchNoLevel is true, and Log
+// is invoked without a level key. By default, ErrNoLevel is nil; in this
+// case, the log event is squelched with no error.
+func ErrNoLevel(err error) Option {
+	return func(l *logger) { l.errNoLevel = err }
+}
+
+// Option sets a parameter for the leveled logger.
+type Option func(*logger)
 
 type logger struct {
 	next           log.Logger


### PR DESCRIPTION
Using function to pass optional params makes the API more consistent
with the rest of go-kit packages.

For #427 

Following up on discussion in https://github.com/go-kit/kit/issues/427#issuecomment-275938942
> > Why not use functional options for level.New instead of Config?

> There's no practical difference, but I can in hindsight see the value of using functional options for consistency with the rest of package log. I'd accept a PR :)

I thought it was important to get this change in before #449 and ultimately 1.0.0 to avoid making breaking changes in a stable API. 