### PR TITLE
change coverprofile in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ examples/profilesvc/profilesvc
 examples/stringsvc1/stringsvc1
 examples/stringsvc2/stringsvc2
 examples/stringsvc3/stringsvc3
-gover.coverprofile
+*.coverprofile
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o


### PR DESCRIPTION
change `gover.coverprofile` to `*.coverprofile` in the `.gitignore` in order to cover the
case of `cover.coverprofile` that can be generated from running the `coverage.bash` script.