### PR TITLE
transport/http: provide more response details

### DIFF
--- a/transport/http/request_response_funcs.go
+++ b/transport/http/request_response_funcs.go
@@ -116,4 +116,13 @@ const (
 	// ContextKeyRequestXRequestID is populated in the context by
 	// PopulateRequestContext. Its value is r.Header.Get("X-Request-Id").
 	ContextKeyRequestXRequestID
+
+	// ContextKeyResponseHeaders is populated in the context whenever a
+	// ServerFinalizerFunc is specified. Its value is of type http.Header, and
+	// is captured only once the entire response has been written.
+	ContextKeyResponseHeaders
+
+	// ContextKeyResponseSize is populated in the context whenever a
+	// ServerFinalizerFunc is specified. Its value is of type int64.
+	ContextKeyResponseSize
 )


### PR DESCRIPTION
ServerFinalizerFunc gets access to response headers and size. Closes #460.

@xla Will this give you what you want? Check the test for usage.