### PR TITLE
Allow calling ServerBefore/After multiple times when creating ServerOptions

### DIFF
--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -59,13 +59,13 @@ type ServerOption func(*Server)
 // ServerBefore functions are executed on the HTTP request object before the
 // request is decoded.
 func ServerBefore(before ...RequestFunc) ServerOption {
-	return func(s *Server) { s.before = before }
+	return func(s *Server) { s.before = append(s.before, before...) }
 }
 
 // ServerAfter functions are executed on the HTTP response writer after the
 // endpoint is invoked, but before anything is written to the client.
 func ServerAfter(after ...ResponseFunc) ServerOption {
-	return func(s *Server) { s.after = after }
+	return func(s *Server) { s.after = append(s.after, after...) }
 }
 
 // ServerErrorLogger is used to log non-terminal errors. By default, no errors

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -51,13 +51,13 @@ type ServerOption func(*Server)
 // ServerBefore functions are executed on the HTTP request object before the
 // request is decoded.
 func ServerBefore(before ...RequestFunc) ServerOption {
-	return func(s *Server) { s.before = before }
+	return func(s *Server) { s.before = append(s.before, before...) }
 }
 
 // ServerAfter functions are executed on the HTTP response writer after the
 // endpoint is invoked, but before anything is written to the client.
 func ServerAfter(after ...ServerResponseFunc) ServerOption {
-	return func(s *Server) { s.after = after }
+	return func(s *Server) { s.after = append(s.after, after...) }
 }
 
 // ServerErrorEncoder is used to encode errors to the http.ResponseWriter

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -93,7 +93,141 @@ func TestServerHappyPath(t *testing.T) {
 	}
 }
 
+
+func TestMultipleServerBefore(t *testing.T) {
+	var (
+		headerKey    = "X-Henlo-Lizer"
+		headerVal    = "Helllo you stinky lizard"
+		statusCode   = http.StatusTeapot
+		responseBody = "go eat a fly ugly\n"
+		done         = make(chan struct{})
+	)
+	handler := httptransport.NewServer(
+		context.Background(),
+		endpoint.Nop,
+		func(context.Context, *http.Request) (interface{}, error) {
+			return struct{}{}, nil
+		},
+		func(_ context.Context, w http.ResponseWriter, _ interface{}) error {
+			w.Header().Set(headerKey, headerVal)
+			w.WriteHeader(statusCode)
+			w.Write([]byte(responseBody))
+			return nil
+		},
+		httptransport.ServerBefore(func(ctx context.Context, r *http.Request) context.Context {
+			ctx = context.WithValue(ctx, "one", 1)
+
+			return ctx
+		}),
+		httptransport.ServerBefore(func(ctx context.Context, r *http.Request) context.Context {
+			if _, ok := ctx.Value("one").(int); !ok {
+				t.Error("Value was not set properly when multiple ServerBefores are used")
+			}
+
+			close(done)
+			return ctx
+		}),
+	)
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	go http.Get(server.URL)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for finalizer")
+	}
+}
+
+func TestMultipleServerAfter(t *testing.T) {
+	var (
+		headerKey    = "X-Henlo-Lizer"
+		headerVal    = "Helllo you stinky lizard"
+		statusCode   = http.StatusTeapot
+		responseBody = "go eat a fly ugly\n"
+		done         = make(chan struct{})
+	)
+	handler := httptransport.NewServer(
+		context.Background(),
+		endpoint.Nop,
+		func(context.Context, *http.Request) (interface{}, error) {
+			return struct{}{}, nil
+		},
+		func(_ context.Context, w http.ResponseWriter, _ interface{}) error {
+			w.Header().Set(headerKey, headerVal)
+			w.WriteHeader(statusCode)
+			w.Write([]byte(responseBody))
+			return nil
+		},
+		httptransport.ServerAfter(func(ctx context.Context, w http.ResponseWriter) context.Context {
+			ctx = context.WithValue(ctx, "one", 1)
+
+			return ctx
+		}),
+		httptransport.ServerAfter(func(ctx context.Context, w http.ResponseWriter) context.Context {
+			if _, ok := ctx.Value("one").(int); !ok {
+				t.Error("Value was not set properly when multiple ServerAfters are used")
+			}
+
+			close(done)
+			return ctx
+		}),
+	)
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	go http.Get(server.URL)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for finalizer")
+	}
+}
+
 func TestServerFinalizer(t *testing.T) {
+	var (
+		headerKey    = "X-Henlo-Lizer"
+		headerVal    = "Helllo you stinky lizard"
+		statusCode   = http.StatusTeapot
+		responseBody = "go eat a fly ugly\n"
+		done         = make(chan struct{})
+	)
+	handler := httptransport.NewServer(
+		context.Background(),
+		endpoint.Nop,
+		func(context.Context, *http.Request) (interface{}, error) {
+			return struct{}{}, nil
+		},
+		func(_ context.Context, w http.ResponseWriter, _ interface{}) error {
+			w.Header().Set(headerKey, headerVal)
+			w.WriteHeader(statusCode)
+			w.Write([]byte(responseBody))
+			return nil
+		},
+		httptransport.ServerBefore(func(ctx context.Context, r *http.Request) context.Context {
+			ctx = context.WithValue(ctx, "one", 1)
+		}),
+		httptransport.ServerBefore(func(ctx context.Context, r *http.Request) context.Context {
+			if one, ok := ctx.Value("one").(int); !ok {
+				t.Error("Value was not set properly when multiple ServerBefores are used")
+			}
+		}),
+	)
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	go http.Get(server.URL)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for finalizer")
+	}
+}
+
+func TestServerBefore(t *testing.T) {
 	var (
 		headerKey    = "X-Henlo-Lizer"
 		headerVal    = "Helllo you stinky lizard"

--- a/transport/httprp/server.go
+++ b/transport/httprp/server.go
@@ -45,7 +45,7 @@ type ServerOption func(*Server)
 // ServerBefore functions are executed on the HTTP request object before the
 // request is decoded.
 func ServerBefore(before ...RequestFunc) ServerOption {
-	return func(s *Server) { s.before = before }
+	return func(s *Server) { s.before = append(s.before, before...) }
 }
 
 // ServeHTTP implements http.Handler.


### PR DESCRIPTION
This allows you to set some default options that multiple httptransport.NewServer's use, but still allows each handler to specify it's own as well

```
router = mux.NewRouter().StrictSlash(false)
options := []httptransport.ServerOption{
		httptransport.ServerErrorLogger(logger),
		httptransport.ServerErrorEncoder(httptransport.DefaultErrorEncoder),
		httptransport.ServerBefore(
			prepareRequestContext,
		),
	}
router = router.Methods("GET").Path("/path-A").Handler(httptransport.NewServer(
		ctx,
		endpointA,
		decodeRequest,
		encodeResponse,
		append(
			options,
			httptransport.ServerBefore(
				opentracing.FromHTTPRequest(tracer, "path-A", logger),
			),
		)...,
	))
router = router.Methods("GET").Path("/path-B").Handler(httptransport.NewServer(
		ctx,
		endpointB,
		decodeRequest,
		encodeResponse,
		append(
			options,
			httptransport.ServerBefore(
				opentracing.FromHTTPRequest(tracer, "path-B", logger),
			),
		)...,
	))
```
Without this change you would have to make sure that any global ServerBefore or ServerAfter methods we added to every handler