### PR TITLE
Add Zipkin HTTP Collector to addsvc example

### DIFF
--- a/examples/addsvc/cmd/addcli/main.go
+++ b/examples/addsvc/cmd/addcli/main.go
@@ -40,7 +40,8 @@ func main() {
 		thriftProtocol   = flag.String("thrift.protocol", "binary", "binary, compact, json, simplejson")
 		thriftBufferSize = flag.Int("thrift.buffer.size", 0, "0 for unbuffered")
 		thriftFramed     = flag.Bool("thrift.framed", false, "true to enable framing")
-		zipkinAddr       = flag.String("zipkin.addr", "", "Enable Zipkin tracing via a Kafka Collector host:port")
+		zipkinAddr       = flag.String("zipkin.addr", "", "Enable Zipkin tracing via a Zipkin HTTP Collector endpoint")
+		zipkinKafkaAddr  = flag.String("zipkin.kafka.addr", "", "Enable Zipkin tracing via a Kafka server host:port")
 		appdashAddr      = flag.String("appdash.addr", "", "Enable Appdash tracing via an Appdash server host:port")
 		lightstepToken   = flag.String("lightstep.token", "", "Enable LightStep tracing via a LightStep access token")
 		method           = flag.String("method", "sum", "sum, concat")
@@ -57,16 +58,34 @@ func main() {
 	var tracer stdopentracing.Tracer
 	{
 		if *zipkinAddr != "" {
+			// endpoint typically looks like: http://zipkinhost:9411/api/v1/spans
+			collector, err := zipkin.NewHTTPCollector(*zipkinAddr)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
+			defer collector.Close()
+
+			tracer, err = zipkin.NewTracer(
+				zipkin.NewRecorder(collector, false, "0.0.0.0:0", "addcli"),
+			)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
+		} else if *zipkinKafkaAddr != "" {
 			collector, err := zipkin.NewKafkaCollector(
-				strings.Split(*zipkinAddr, ","),
+				strings.Split(*zipkinKafkaAddr, ","),
 				zipkin.KafkaLogger(log.NewNopLogger()),
 			)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)
 			}
+			defer collector.Close()
+
 			tracer, err = zipkin.NewTracer(
-				zipkin.NewRecorder(collector, false, "localhost:8000", "addcli"),
+				zipkin.NewRecorder(collector, false, "0.0.0.0:0", "addcli"),
 			)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)


### PR DESCRIPTION
To make it easier for people to testdrive Zipkin an HTTP Collector set-up has been added to the `addsvc` example. 

This allows people to testdrive Zipkin with Go-kit using the official Zipkin docker image without the need of running Kafka and Zookeeper.