### PR TITLE
Add the ability to specify ServerBefore & ServerAfter multiple times in the ServerOption section

### DIFF
--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -59,13 +59,13 @@ type ServerOption func(*Server)
 // ServerBefore functions are executed on the HTTP request object before the
 // request is decoded.
 func ServerBefore(before ...RequestFunc) ServerOption {
-	return func(s *Server) { s.before = before }
+	return func(s *Server) { s.before = append(s.before, before...) }
 }
 
 // ServerAfter functions are executed on the HTTP response writer after the
 // endpoint is invoked, but before anything is written to the client.
 func ServerAfter(after ...ResponseFunc) ServerOption {
-	return func(s *Server) { s.after = after }
+	return func(s *Server) { s.after = append(s.after, after...) }
 }
 
 // ServerErrorLogger is used to log non-terminal errors. By default, no errors

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -51,13 +51,13 @@ type ServerOption func(*Server)
 // ServerBefore functions are executed on the HTTP request object before the
 // request is decoded.
 func ServerBefore(before ...RequestFunc) ServerOption {
-	return func(s *Server) { s.before = before }
+	return func(s *Server) { s.before = append(s.before, before...) }
 }
 
 // ServerAfter functions are executed on the HTTP response writer after the
 // endpoint is invoked, but before anything is written to the client.
 func ServerAfter(after ...ServerResponseFunc) ServerOption {
-	return func(s *Server) { s.after = after }
+	return func(s *Server) { s.after = append(s.after, after...) }
 }
 
 // ServerErrorEncoder is used to encode errors to the http.ResponseWriter

--- a/transport/httprp/server.go
+++ b/transport/httprp/server.go
@@ -45,7 +45,7 @@ type ServerOption func(*Server)
 // ServerBefore functions are executed on the HTTP request object before the
 // request is decoded.
 func ServerBefore(before ...RequestFunc) ServerOption {
-	return func(s *Server) { s.before = before }
+	return func(s *Server) { s.before = append(s.before, before...) }
 }
 
 // ServeHTTP implements http.Handler.


### PR DESCRIPTION
This makes it so you can set some global ServerBefore or After options without having to make sure you specify them individually on every handler