### PR TITLE
Reimplement log/experimental_levels

### DIFF
--- a/log/experimental_level/benchmark_test.go
+++ b/log/experimental_level/benchmark_test.go
@@ -44,10 +44,10 @@ func Benchmark(b *testing.B) {
 			return l
 		}},
 		{"DisallowedLevel", func(l log.Logger) log.Logger {
-			return level.New(l, level.Allowed(level.AllowInfoAndAbove()))
+			return level.NewFilter(l, level.AllowInfoAndAbove())
 		}},
 		{"AllowedLevel", func(l log.Logger) log.Logger {
-			return level.New(l, level.Allowed(level.AllowAll()))
+			return level.NewFilter(l, level.AllowAll())
 		}},
 	}
 

--- a/log/experimental_level/benchmark_test.go
+++ b/log/experimental_level/benchmark_test.go
@@ -44,7 +44,7 @@ func Benchmark(b *testing.B) {
 			return l
 		}},
 		{"DisallowedLevel", func(l log.Logger) log.Logger {
-			return level.NewFilter(l, level.AllowInfoAndAbove())
+			return level.NewFilter(l, level.AllowInfo())
 		}},
 		{"AllowedLevel", func(l log.Logger) log.Logger {
 			return level.NewFilter(l, level.AllowAll())

--- a/log/experimental_level/doc.go
+++ b/log/experimental_level/doc.go
@@ -2,11 +2,11 @@
 // definitely have breaking changes and may be deleted altogether. Be warned!
 //
 // To use the level package, create a logger as per normal in your func main,
-// and wrap it with level.New.
+// and wrap it with level.NewFilter.
 //
 //    var logger log.Logger
 //    logger = log.NewLogfmtLogger(os.Stderr)
-//    logger = level.New(logger, level.Allowed(level.AllowInfoAndAbove())) // <--
+//    logger = level.NewFilter(logger, level.AllowInfoAndAbove()) // <--
 //    logger = log.NewContext(logger).With("ts", log.DefaultTimestampUTC)
 //
 // Then, at the callsites, use one of the level.Debug, Info, Warn, or Error
@@ -19,9 +19,6 @@
 //    }
 //
 // The leveled logger allows precise control over what should happen if a log
-// event is emitted without a level key, or if a squelched level is used. Check
-// the Option functions for details. And, you can easily use non-default level
-// values: create new string constants for whatever you want to change, pass
-// them explicitly to the Allowed Option function, and write your own level.Foo-style
-// helper methods.
+// event is emitted without a level key, or if a squelched level is used.
+// Check the Option functions for details.
 package level

--- a/log/experimental_level/doc.go
+++ b/log/experimental_level/doc.go
@@ -18,7 +18,7 @@
 //        level.Error(logger).Log("value", value)
 //    }
 //
-// The leveled logger allows precise control over what should happen if a log
-// event is emitted without a level key, or if a squelched level is used.
-// Check the Option functions for details.
+// NewFilter allows precise control over what happens when a log event is
+// emitted without a level key, or if a squelched level is used. Check the
+// Option functions for details.
 package level

--- a/log/experimental_level/example_test.go
+++ b/log/experimental_level/example_test.go
@@ -1,0 +1,25 @@
+package level_test
+
+import (
+	"errors"
+	"os"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/experimental_level"
+)
+
+func Example_basic() {
+	// setup logger with level filter
+	logger := log.NewLogfmtLogger(os.Stdout)
+	logger = level.NewFilter(logger, level.AllowInfoAndAbove())
+	logger = log.NewContext(logger).With("caller", log.DefaultCaller)
+
+	// use level helpers to log at different levels
+	level.Error(logger).Log("err", errors.New("bad data"))
+	level.Info(logger).Log("event", "data saved")
+	level.Debug(logger).Log("next item", 17) // filtered
+
+	// Output:
+	// level=error caller=example_test.go:18 err="bad data"
+	// level=info caller=example_test.go:19 event="data saved"
+}

--- a/log/experimental_level/example_test.go
+++ b/log/experimental_level/example_test.go
@@ -11,7 +11,7 @@ import (
 func Example_basic() {
 	// setup logger with level filter
 	logger := log.NewLogfmtLogger(os.Stdout)
-	logger = level.NewFilter(logger, level.AllowInfoAndAbove())
+	logger = level.NewFilter(logger, level.AllowInfo())
 	logger = log.NewContext(logger).With("caller", log.DefaultCaller)
 
 	// use level helpers to log at different levels

--- a/log/experimental_level/level.go
+++ b/log/experimental_level/level.go
@@ -124,7 +124,8 @@ func ErrNoLevel(err error) Option {
 }
 
 // NewInjector wraps next and returns a logger that adds a Key/level pair to
-// the beginning of log events that don't already contain a level.
+// the beginning of log events that don't already contain a level. In effect,
+// this gives a default level to logs without a level.
 func NewInjector(next log.Logger, level Value) log.Logger {
 	return &injector{
 		next:  next,

--- a/log/experimental_level/level.go
+++ b/log/experimental_level/level.go
@@ -122,13 +122,12 @@ func ErrNoLevel(err error) Option {
 	return func(l *logger) { l.errNoLevel = err }
 }
 
-const levelKey = "level"
-
 var (
-	errorLevelValue = &levelValue{level: levelError, name: "error"}
-	warnLevelValue  = &levelValue{level: levelWarn, name: "warn"}
-	infoLevelValue  = &levelValue{level: levelInfo, name: "info"}
-	debugLevelValue = &levelValue{level: levelDebug, name: "debug"}
+	levelKey        interface{} = "level"
+	errorLevelValue             = &levelValue{level: levelError, name: "error"}
+	warnLevelValue              = &levelValue{level: levelWarn, name: "warn"}
+	infoLevelValue              = &levelValue{level: levelInfo, name: "info"}
+	debugLevelValue             = &levelValue{level: levelDebug, name: "debug"}
 )
 
 type level byte

--- a/log/experimental_level/level.go
+++ b/log/experimental_level/level.go
@@ -66,32 +66,32 @@ func (l *logger) Log(keyvals ...interface{}) error {
 // Option sets a parameter for the leveled logger.
 type Option func(*logger)
 
-// AllowAll is an alias for AllowDebugAndAbove.
+// AllowAll is an alias for AllowDebug.
 func AllowAll() Option {
-	return AllowDebugAndAbove()
+	return AllowDebug()
 }
 
-// AllowDebugAndAbove allows all of the four default log levels.
-func AllowDebugAndAbove() Option {
-	return allowed(levelDebug | levelInfo | levelWarn | levelError)
+// AllowDebug allows error, warn, info and debug level log events to pass.
+func AllowDebug() Option {
+	return allowed(levelError | levelWarn | levelInfo | levelDebug)
 }
 
-// AllowInfoAndAbove allows the default info, warn, and error log levels.
-func AllowInfoAndAbove() Option {
-	return allowed(levelInfo | levelWarn | levelError)
+// AllowInfo allows error, warn and info level log events to pass.
+func AllowInfo() Option {
+	return allowed(levelError | levelWarn | levelInfo)
 }
 
-// AllowWarnAndAbove allows the default warn and error log levels.
-func AllowWarnAndAbove() Option {
-	return allowed(levelWarn | levelError)
+// AllowWarn allows error and warn level log events to pass.
+func AllowWarn() Option {
+	return allowed(levelError | levelWarn)
 }
 
-// AllowErrorOnly allows only the default error log level.
-func AllowErrorOnly() Option {
+// AllowError allows only error level log events to pass.
+func AllowError() Option {
 	return allowed(levelError)
 }
 
-// AllowNone allows none of the default log levels.
+// AllowNone allows no leveled log events to pass.
 func AllowNone() Option {
 	return allowed(0)
 }
@@ -101,8 +101,9 @@ func allowed(allowed level) Option {
 }
 
 // ErrNotAllowed sets the error to return from Log when it squelches a log
-// event below the configured filtering level. By default, ErrNotAllowed is
-// nil; in this case, the log event is squelched with no error.
+// event disallowed by the configured Allow[Level] option. By default,
+// ErrNotAllowed is nil; in this case the log event is squelched with no
+// error.
 func ErrNotAllowed(err error) Option {
 	return func(l *logger) { l.errNotAllowed = err }
 }
@@ -116,8 +117,8 @@ func SquelchNoLevel(squelch bool) Option {
 }
 
 // ErrNoLevel sets the error to return from Log when it squelches a log event
-// with no level. By default, ErrNoLevel is nil; in this case, the log event
-// is squelched with no error.
+// with no level. By default, ErrNoLevel is nil; in this case the log event is
+// squelched with no error.
 func ErrNoLevel(err error) Option {
 	return func(l *logger) { l.errNoLevel = err }
 }

--- a/log/experimental_level/level_test.go
+++ b/log/experimental_level/level_test.go
@@ -26,7 +26,7 @@ func TestVariousLevels(t *testing.T) {
 			}, "\n"),
 		},
 		{
-			level.AllowDebugAndAbove(),
+			level.AllowDebug(),
 			strings.Join([]string{
 				`{"level":"debug","this is":"debug log"}`,
 				`{"level":"info","this is":"info log"}`,
@@ -35,7 +35,7 @@ func TestVariousLevels(t *testing.T) {
 			}, "\n"),
 		},
 		{
-			level.AllowInfoAndAbove(),
+			level.AllowInfo(),
 			strings.Join([]string{
 				`{"level":"info","this is":"info log"}`,
 				`{"level":"warn","this is":"warn log"}`,
@@ -43,14 +43,14 @@ func TestVariousLevels(t *testing.T) {
 			}, "\n"),
 		},
 		{
-			level.AllowWarnAndAbove(),
+			level.AllowWarn(),
 			strings.Join([]string{
 				`{"level":"warn","this is":"warn log"}`,
 				`{"level":"error","this is":"error log"}`,
 			}, "\n"),
 		},
 		{
-			level.AllowErrorOnly(),
+			level.AllowError(),
 			strings.Join([]string{
 				`{"level":"error","this is":"error log"}`,
 			}, "\n"),
@@ -77,7 +77,7 @@ func TestVariousLevels(t *testing.T) {
 func TestErrNotAllowed(t *testing.T) {
 	myError := errors.New("squelched!")
 	opts := []level.Option{
-		level.AllowWarnAndAbove(),
+		level.AllowWarn(),
 		level.ErrNotAllowed(myError),
 	}
 	logger := level.NewFilter(log.NewNopLogger(), opts...)

--- a/log/experimental_level/level_test.go
+++ b/log/experimental_level/level_test.go
@@ -215,9 +215,21 @@ func TestInjector(t *testing.T) {
 	if got, want := len(output), 4; got != want {
 		t.Errorf("missing level not injected: got len==%d, want len==%d", got, want)
 	}
+	if got, want := output[0], level.Key(); got != want {
+		t.Errorf("wrong level key: got %#v, want %#v", got, want)
+	}
+	if got, want := output[1], level.InfoValue(); got != want {
+		t.Errorf("wrong level value: got %#v, want %#v", got, want)
+	}
 
 	level.Error(logger).Log("foo", "bar")
 	if got, want := len(output), 4; got != want {
 		t.Errorf("leveled record modified: got len==%d, want len==%d", got, want)
+	}
+	if got, want := output[0], level.Key(); got != want {
+		t.Errorf("wrong level key: got %#v, want %#v", got, want)
+	}
+	if got, want := output[1], level.ErrorValue(); got != want {
+		t.Errorf("wrong level value: got %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
The main focus here is to get away from identifying level keyvals with string matching and use type matching with a bit set for level filtering in the manner demonstrated by @seh in #453.

I am very happy that all of the configuration options could be preserved. I have taken the liberty to simplify the `Options` API a bit to make it friendlier. The `Allowed` option was removed in favor of converting all of its helper functions (e.g. `AllowInfoAndAbove`) into functional Options that can be used directly. I also changed `level.New` to `level.NewFilter` because it better expresses its purpose.

The documentation is updated and corrected.

Before updating the implementation I rewrote the benchmarks to be more comprehensive with the use of the new (Go 1.7) sub-benchmark feature. The before and after results of the benchmarks follow.

Updated benchmarks after 6a12b3162160a71abf7458cdfccdc8aa0cca0ba0.
```
name                                              old time/op    new time/op    delta
/NoContext/Baseline/Nop-8                            434ns ±13%     371ns ± 7%  -14.55%  (p=0.032 n=5+5)
/NoContext/Baseline/Logfmt-8                         796ns ± 1%     828ns ± 1%   +3.99%  (p=0.008 n=5+5)
/NoContext/Baseline/JSON-8                          2.06µs ± 3%    2.06µs ± 2%     ~     (p=0.690 n=5+5)
/NoContext/DisallowedLevel/Nop-8                     422ns ± 6%     368ns ±19%     ~     (p=0.095 n=5+5)
/NoContext/DisallowedLevel/Logfmt-8                  435ns ± 9%     377ns ±12%     ~     (p=0.056 n=5+5)
/NoContext/DisallowedLevel/JSON-8                    422ns ±11%     355ns ± 4%  -15.89%  (p=0.008 n=5+5)
/NoContext/AllowedLevel/Nop-8                        447ns ± 8%     343ns ± 9%  -23.20%  (p=0.008 n=5+5)
/NoContext/AllowedLevel/Logfmt-8                     824ns ± 1%     833ns ± 2%     ~     (p=0.111 n=5+5)
/NoContext/AllowedLevel/JSON-8                      2.07µs ± 3%    2.05µs ± 1%     ~     (p=0.690 n=5+5)
/TimeContext/Baseline/Nop-8                          780ns ± 4%     702ns ± 1%   -9.95%  (p=0.008 n=5+5)
/TimeContext/Baseline/Logfmt-8                      1.46µs ± 2%    1.47µs ± 1%     ~     (p=0.222 n=5+5)
/TimeContext/Baseline/JSON-8                        3.00µs ± 1%    2.99µs ± 4%     ~     (p=0.690 n=5+5)
/TimeContext/DisallowedLevel/Nop-8                   799ns ± 3%     711ns ± 2%  -11.06%  (p=0.008 n=5+5)
/TimeContext/DisallowedLevel/Logfmt-8                796ns ± 3%     698ns ± 0%  -12.23%  (p=0.000 n=5+4)
/TimeContext/DisallowedLevel/JSON-8                  792ns ± 1%     714ns ± 3%   -9.85%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/Nop-8                      806ns ± 5%     717ns ± 1%  -10.97%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/Logfmt-8                  1.47µs ± 1%    1.48µs ± 2%     ~     (p=0.056 n=5+5)
/TimeContext/AllowedLevel/JSON-8                    2.99µs ± 3%    2.94µs ± 0%     ~     (p=0.206 n=5+5)
/CallerContext/Baseline/Nop-8                       1.03µs ± 3%    0.97µs ± 1%   -6.45%  (p=0.008 n=5+5)
/CallerContext/Baseline/Logfmt-8                    2.31µs ± 1%    2.33µs ± 1%     ~     (p=0.246 n=5+5)
/CallerContext/Baseline/JSON-8                      3.86µs ± 1%    3.88µs ± 1%     ~     (p=0.286 n=5+5)
/CallerContext/DisallowedLevel/Nop-8                1.04µs ± 0%    0.99µs ± 3%   -4.61%  (p=0.008 n=5+5)
/CallerContext/DisallowedLevel/Logfmt-8             1.08µs ± 6%    0.97µs ± 2%  -10.10%  (p=0.016 n=5+4)
/CallerContext/DisallowedLevel/JSON-8               1.04µs ± 0%    1.14µs ±29%     ~     (p=1.000 n=4+5)
/CallerContext/AllowedLevel/Nop-8                   1.04µs ± 0%    1.06µs ± 4%     ~     (p=0.698 n=4+5)
/CallerContext/AllowedLevel/Logfmt-8                2.38µs ± 4%    2.79µs ±13%  +17.09%  (p=0.008 n=5+5)
/CallerContext/AllowedLevel/JSON-8                  4.03µs ± 3%    4.44µs ± 5%  +10.29%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/Nop-8              1.57µs ±10%    1.57µs ± 8%     ~     (p=1.000 n=5+5)
/TimeCallerReqIDContext/Baseline/Logfmt-8           3.41µs ± 3%    3.56µs ± 1%   +4.56%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/JSON-8             5.60µs ± 2%    5.76µs ± 4%     ~     (p=0.056 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/Nop-8       1.50µs ± 1%    1.46µs ± 2%   -2.69%  (p=0.032 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/Logfmt-8    1.52µs ± 2%    1.46µs ± 1%   -3.86%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/JSON-8      1.50µs ± 1%    1.46µs ± 2%   -2.67%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/Nop-8          1.51µs ± 1%    1.46µs ± 1%   -3.11%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/Logfmt-8       3.45µs ± 3%    3.49µs ± 1%     ~     (p=0.151 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/JSON-8         5.55µs ± 2%    5.80µs ± 2%   +4.42%  (p=0.008 n=5+5)

name                                              old alloc/op   new alloc/op   delta
/NoContext/Baseline/Nop-8                             288B ± 0%      256B ± 0%  -11.11%  (p=0.008 n=5+5)
/NoContext/Baseline/Logfmt-8                          288B ± 0%      256B ± 0%  -11.11%  (p=0.008 n=5+5)
/NoContext/Baseline/JSON-8                          1.06kB ± 0%    1.05kB ± 0%   -1.50%  (p=0.008 n=5+5)
/NoContext/DisallowedLevel/Nop-8                      288B ± 0%      256B ± 0%  -11.11%  (p=0.008 n=5+5)
/NoContext/DisallowedLevel/Logfmt-8                   288B ± 0%      256B ± 0%  -11.11%  (p=0.008 n=5+5)
/NoContext/DisallowedLevel/JSON-8                     288B ± 0%      256B ± 0%  -11.11%  (p=0.008 n=5+5)
/NoContext/AllowedLevel/Nop-8                         288B ± 0%      256B ± 0%  -11.11%  (p=0.008 n=5+5)
/NoContext/AllowedLevel/Logfmt-8                      288B ± 0%      256B ± 0%  -11.11%  (p=0.008 n=5+5)
/NoContext/AllowedLevel/JSON-8                      1.06kB ± 0%    1.05kB ± 0%   -1.50%  (p=0.008 n=5+5)
/TimeContext/Baseline/Nop-8                           384B ± 0%      352B ± 0%   -8.33%  (p=0.008 n=5+5)
/TimeContext/Baseline/Logfmt-8                        384B ± 0%      352B ± 0%   -8.33%  (p=0.008 n=5+5)
/TimeContext/Baseline/JSON-8                        1.28kB ± 0%    1.26kB ± 0%   -1.25%  (p=0.008 n=5+5)
/TimeContext/DisallowedLevel/Nop-8                    384B ± 0%      352B ± 0%   -8.33%  (p=0.008 n=5+5)
/TimeContext/DisallowedLevel/Logfmt-8                 384B ± 0%      352B ± 0%   -8.33%  (p=0.008 n=5+5)
/TimeContext/DisallowedLevel/JSON-8                   384B ± 0%      352B ± 0%   -8.33%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/Nop-8                       384B ± 0%      352B ± 0%   -8.33%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/Logfmt-8                    384B ± 0%      352B ± 0%   -8.33%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/JSON-8                    1.28kB ± 0%    1.26kB ± 0%   -1.25%  (p=0.008 n=5+5)
/CallerContext/Baseline/Nop-8                         352B ± 0%      320B ± 0%   -9.09%  (p=0.008 n=5+5)
/CallerContext/Baseline/Logfmt-8                      520B ± 0%      488B ± 0%   -6.15%  (p=0.008 n=5+5)
/CallerContext/Baseline/JSON-8                      1.42kB ± 0%    1.40kB ± 0%   -1.13%  (p=0.008 n=5+5)
/CallerContext/DisallowedLevel/Nop-8                  352B ± 0%      320B ± 0%   -9.09%  (p=0.008 n=5+5)
/CallerContext/DisallowedLevel/Logfmt-8               352B ± 0%      320B ± 0%   -9.09%  (p=0.008 n=5+5)
/CallerContext/DisallowedLevel/JSON-8                 352B ± 0%      320B ± 0%   -9.09%  (p=0.008 n=5+5)
/CallerContext/AllowedLevel/Nop-8                     352B ± 0%      320B ± 0%   -9.09%  (p=0.008 n=5+5)
/CallerContext/AllowedLevel/Logfmt-8                  520B ± 0%      488B ± 0%   -6.15%  (p=0.008 n=5+5)
/CallerContext/AllowedLevel/JSON-8                  1.42kB ± 0%    1.40kB ± 0%   -1.13%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/Nop-8                592B ± 0%      560B ± 0%   -5.41%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/Logfmt-8             768B ± 0%      736B ± 0%   -4.17%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/JSON-8             1.86kB ± 0%    1.85kB ± 0%   -0.86%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/Nop-8         592B ± 0%      560B ± 0%   -5.41%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/Logfmt-8      592B ± 0%      560B ± 0%   -5.41%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/JSON-8        592B ± 0%      560B ± 0%   -5.41%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/Nop-8            592B ± 0%      560B ± 0%   -5.41%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/Logfmt-8         768B ± 0%      736B ± 0%   -4.17%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/JSON-8         1.86kB ± 0%    1.85kB ± 0%   -0.86%  (p=0.008 n=5+5)

name                                              old allocs/op  new allocs/op  delta
/NoContext/Baseline/Nop-8                             9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.008 n=5+5)
/NoContext/Baseline/Logfmt-8                          9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.008 n=5+5)
/NoContext/Baseline/JSON-8                            24.0 ± 0%      23.0 ± 0%   -4.17%  (p=0.008 n=5+5)
/NoContext/DisallowedLevel/Nop-8                      9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.008 n=5+5)
/NoContext/DisallowedLevel/Logfmt-8                   9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.008 n=5+5)
/NoContext/DisallowedLevel/JSON-8                     9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.008 n=5+5)
/NoContext/AllowedLevel/Nop-8                         9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.008 n=5+5)
/NoContext/AllowedLevel/Logfmt-8                      9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.008 n=5+5)
/NoContext/AllowedLevel/JSON-8                        24.0 ± 0%      23.0 ± 0%   -4.17%  (p=0.008 n=5+5)
/TimeContext/Baseline/Nop-8                           10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
/TimeContext/Baseline/Logfmt-8                        10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
/TimeContext/Baseline/JSON-8                          28.0 ± 0%      27.0 ± 0%   -3.57%  (p=0.008 n=5+5)
/TimeContext/DisallowedLevel/Nop-8                    10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
/TimeContext/DisallowedLevel/Logfmt-8                 10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
/TimeContext/DisallowedLevel/JSON-8                   10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/Nop-8                       10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/Logfmt-8                    10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/JSON-8                      28.0 ± 0%      27.0 ± 0%   -3.57%  (p=0.008 n=5+5)
/CallerContext/Baseline/Nop-8                         9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.008 n=5+5)
/CallerContext/Baseline/Logfmt-8                      13.0 ± 0%      11.0 ± 0%  -15.38%  (p=0.008 n=5+5)
/CallerContext/Baseline/JSON-8                        31.0 ± 0%      30.0 ± 0%   -3.23%  (p=0.008 n=5+5)
/CallerContext/DisallowedLevel/Nop-8                  9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.008 n=5+5)
/CallerContext/DisallowedLevel/Logfmt-8               9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.008 n=5+5)
/CallerContext/DisallowedLevel/JSON-8                 9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.008 n=5+5)
/CallerContext/AllowedLevel/Nop-8                     9.00 ± 0%      7.00 ± 0%  -22.22%  (p=0.008 n=5+5)
/CallerContext/AllowedLevel/Logfmt-8                  13.0 ± 0%      11.0 ± 0%  -15.38%  (p=0.008 n=5+5)
/CallerContext/AllowedLevel/JSON-8                    31.0 ± 0%      30.0 ± 0%   -3.23%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/Nop-8                11.0 ± 0%       9.0 ± 0%  -18.18%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/Logfmt-8             16.0 ± 0%      14.0 ± 0%  -12.50%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/JSON-8               39.0 ± 0%      38.0 ± 0%   -2.56%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/Nop-8         11.0 ± 0%       9.0 ± 0%  -18.18%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/Logfmt-8      11.0 ± 0%       9.0 ± 0%  -18.18%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/JSON-8        11.0 ± 0%       9.0 ± 0%  -18.18%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/Nop-8            11.0 ± 0%       9.0 ± 0%  -18.18%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/Logfmt-8         16.0 ± 0%      14.0 ± 0%  -12.50%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/JSON-8           39.0 ± 0%      38.0 ± 0%   -2.56%  (p=0.008 n=5+5)
```