### PR TITLE
Use per request context as provided by net/http. (deprecates server wide context)

### DIFF
--- a/examples/addsvc/cmd/addsvc/main.go
+++ b/examples/addsvc/cmd/addsvc/main.go
@@ -207,7 +207,7 @@ func main() {
 	// HTTP transport.
 	go func() {
 		logger := log.NewContext(logger).With("transport", "HTTP")
-		h := addsvc.MakeHTTPHandler(ctx, endpoints, tracer, logger)
+		h := addsvc.MakeHTTPHandler(endpoints, tracer, logger)
 		logger.Log("addr", *httpAddr)
 		errc <- http.ListenAndServe(*httpAddr, h)
 	}()

--- a/examples/addsvc/transport_http.go
+++ b/examples/addsvc/transport_http.go
@@ -20,21 +20,19 @@ import (
 
 // MakeHTTPHandler returns a handler that makes a set of endpoints available
 // on predefined paths.
-func MakeHTTPHandler(ctx context.Context, endpoints Endpoints, tracer stdopentracing.Tracer, logger log.Logger) http.Handler {
+func MakeHTTPHandler(endpoints Endpoints, tracer stdopentracing.Tracer, logger log.Logger) http.Handler {
 	options := []httptransport.ServerOption{
 		httptransport.ServerErrorEncoder(errorEncoder),
 		httptransport.ServerErrorLogger(logger),
 	}
 	m := http.NewServeMux()
 	m.Handle("/sum", httptransport.NewServer(
-		ctx,
 		endpoints.SumEndpoint,
 		DecodeHTTPSumRequest,
 		EncodeHTTPGenericResponse,
 		append(options, httptransport.ServerBefore(opentracing.FromHTTPRequest(tracer, "Sum", logger)))...,
 	))
 	m.Handle("/concat", httptransport.NewServer(
-		ctx,
 		endpoints.ConcatEndpoint,
 		DecodeHTTPConcatRequest,
 		EncodeHTTPGenericResponse,

--- a/examples/apigateway/main.go
+++ b/examples/apigateway/main.go
@@ -104,7 +104,7 @@ func main() {
 		// HTTP handler, and just install it under a particular path prefix in
 		// our router.
 
-		r.PathPrefix("/addsvc").Handler(http.StripPrefix("/addsvc", addsvc.MakeHTTPHandler(ctx, endpoints, tracer, logger)))
+		r.PathPrefix("/addsvc").Handler(http.StripPrefix("/addsvc", addsvc.MakeHTTPHandler(endpoints, tracer, logger)))
 	}
 
 	// stringsvc routes.
@@ -140,8 +140,8 @@ func main() {
 		// have to do provide it with the encode and decode functions for our
 		// stringsvc methods.
 
-		r.Handle("/stringsvc/uppercase", httptransport.NewServer(ctx, uppercase, decodeUppercaseRequest, encodeJSONResponse))
-		r.Handle("/stringsvc/count", httptransport.NewServer(ctx, count, decodeCountRequest, encodeJSONResponse))
+		r.Handle("/stringsvc/uppercase", httptransport.NewServer(uppercase, decodeUppercaseRequest, encodeJSONResponse))
+		r.Handle("/stringsvc/count", httptransport.NewServer(count, decodeCountRequest, encodeJSONResponse))
 	}
 
 	// Interrupt handler.

--- a/examples/profilesvc/cmd/profilesvc/main.go
+++ b/examples/profilesvc/cmd/profilesvc/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"net/http"
@@ -26,11 +25,6 @@ func main() {
 		logger = log.NewContext(logger).With("caller", log.DefaultCaller)
 	}
 
-	var ctx context.Context
-	{
-		ctx = context.Background()
-	}
-
 	var s profilesvc.Service
 	{
 		s = profilesvc.NewInmemService()
@@ -39,7 +33,7 @@ func main() {
 
 	var h http.Handler
 	{
-		h = profilesvc.MakeHTTPHandler(ctx, s, log.NewContext(logger).With("component", "HTTP"))
+		h = profilesvc.MakeHTTPHandler(s, log.NewContext(logger).With("component", "HTTP"))
 	}
 
 	errs := make(chan error)

--- a/examples/profilesvc/transport.go
+++ b/examples/profilesvc/transport.go
@@ -25,7 +25,7 @@ var (
 
 // MakeHTTPHandler mounts all of the service endpoints into an http.Handler.
 // Useful in a profilesvc server.
-func MakeHTTPHandler(ctx context.Context, s Service, logger log.Logger) http.Handler {
+func MakeHTTPHandler(s Service, logger log.Logger) http.Handler {
 	r := mux.NewRouter()
 	e := MakeServerEndpoints(s)
 	options := []httptransport.ServerOption{
@@ -44,63 +44,54 @@ func MakeHTTPHandler(ctx context.Context, s Service, logger log.Logger) http.Han
 	// DELETE  /profiles/:id/addresses/:addressID  remove an address
 
 	r.Methods("POST").Path("/profiles/").Handler(httptransport.NewServer(
-		ctx,
 		e.PostProfileEndpoint,
 		decodePostProfileRequest,
 		encodeResponse,
 		options...,
 	))
 	r.Methods("GET").Path("/profiles/{id}").Handler(httptransport.NewServer(
-		ctx,
 		e.GetProfileEndpoint,
 		decodeGetProfileRequest,
 		encodeResponse,
 		options...,
 	))
 	r.Methods("PUT").Path("/profiles/{id}").Handler(httptransport.NewServer(
-		ctx,
 		e.PutProfileEndpoint,
 		decodePutProfileRequest,
 		encodeResponse,
 		options...,
 	))
 	r.Methods("PATCH").Path("/profiles/{id}").Handler(httptransport.NewServer(
-		ctx,
 		e.PatchProfileEndpoint,
 		decodePatchProfileRequest,
 		encodeResponse,
 		options...,
 	))
 	r.Methods("DELETE").Path("/profiles/{id}").Handler(httptransport.NewServer(
-		ctx,
 		e.DeleteProfileEndpoint,
 		decodeDeleteProfileRequest,
 		encodeResponse,
 		options...,
 	))
 	r.Methods("GET").Path("/profiles/{id}/addresses/").Handler(httptransport.NewServer(
-		ctx,
 		e.GetAddressesEndpoint,
 		decodeGetAddressesRequest,
 		encodeResponse,
 		options...,
 	))
 	r.Methods("GET").Path("/profiles/{id}/addresses/{addressID}").Handler(httptransport.NewServer(
-		ctx,
 		e.GetAddressEndpoint,
 		decodeGetAddressRequest,
 		encodeResponse,
 		options...,
 	))
 	r.Methods("POST").Path("/profiles/{id}/addresses/").Handler(httptransport.NewServer(
-		ctx,
 		e.PostAddressEndpoint,
 		decodePostAddressRequest,
 		encodeResponse,
 		options...,
 	))
 	r.Methods("DELETE").Path("/profiles/{id}/addresses/{addressID}").Handler(httptransport.NewServer(
-		ctx,
 		e.DeleteAddressEndpoint,
 		decodeDeleteAddressRequest,
 		encodeResponse,

--- a/examples/shipping/booking/transport.go
+++ b/examples/shipping/booking/transport.go
@@ -17,56 +17,49 @@ import (
 )
 
 // MakeHandler returns a handler for the booking service.
-func MakeHandler(ctx context.Context, bs Service, logger kitlog.Logger) http.Handler {
+func MakeHandler(bs Service, logger kitlog.Logger) http.Handler {
 	opts := []kithttp.ServerOption{
 		kithttp.ServerErrorLogger(logger),
 		kithttp.ServerErrorEncoder(encodeError),
 	}
 
 	bookCargoHandler := kithttp.NewServer(
-		ctx,
 		makeBookCargoEndpoint(bs),
 		decodeBookCargoRequest,
 		encodeResponse,
 		opts...,
 	)
 	loadCargoHandler := kithttp.NewServer(
-		ctx,
 		makeLoadCargoEndpoint(bs),
 		decodeLoadCargoRequest,
 		encodeResponse,
 		opts...,
 	)
 	requestRoutesHandler := kithttp.NewServer(
-		ctx,
 		makeRequestRoutesEndpoint(bs),
 		decodeRequestRoutesRequest,
 		encodeResponse,
 		opts...,
 	)
 	assignToRouteHandler := kithttp.NewServer(
-		ctx,
 		makeAssignToRouteEndpoint(bs),
 		decodeAssignToRouteRequest,
 		encodeResponse,
 		opts...,
 	)
 	changeDestinationHandler := kithttp.NewServer(
-		ctx,
 		makeChangeDestinationEndpoint(bs),
 		decodeChangeDestinationRequest,
 		encodeResponse,
 		opts...,
 	)
 	listCargosHandler := kithttp.NewServer(
-		ctx,
 		makeListCargosEndpoint(bs),
 		decodeListCargosRequest,
 		encodeResponse,
 		opts...,
 	)
 	listLocationsHandler := kithttp.NewServer(
-		ctx,
 		makeListLocationsEndpoint(bs),
 		decodeListLocationsRequest,
 		encodeResponse,

--- a/examples/shipping/handling/transport.go
+++ b/examples/shipping/handling/transport.go
@@ -17,7 +17,7 @@ import (
 )
 
 // MakeHandler returns a handler for the handling service.
-func MakeHandler(ctx context.Context, hs Service, logger kitlog.Logger) http.Handler {
+func MakeHandler(hs Service, logger kitlog.Logger) http.Handler {
 	r := mux.NewRouter()
 
 	opts := []kithttp.ServerOption{
@@ -26,7 +26,6 @@ func MakeHandler(ctx context.Context, hs Service, logger kitlog.Logger) http.Han
 	}
 
 	registerIncidentHandler := kithttp.NewServer(
-		ctx,
 		makeRegisterIncidentEndpoint(hs),
 		decodeRegisterIncidentRequest,
 		encodeResponse,

--- a/examples/shipping/main.go
+++ b/examples/shipping/main.go
@@ -137,9 +137,9 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	mux.Handle("/booking/v1/", booking.MakeHandler(ctx, bs, httpLogger))
-	mux.Handle("/tracking/v1/", tracking.MakeHandler(ctx, ts, httpLogger))
-	mux.Handle("/handling/v1/", handling.MakeHandler(ctx, hs, httpLogger))
+	mux.Handle("/booking/v1/", booking.MakeHandler(bs, httpLogger))
+	mux.Handle("/tracking/v1/", tracking.MakeHandler(ts, httpLogger))
+	mux.Handle("/handling/v1/", handling.MakeHandler(hs, httpLogger))
 
 	http.Handle("/", accessControl(mux))
 	http.Handle("/metrics", stdprometheus.Handler())

--- a/examples/shipping/tracking/transport.go
+++ b/examples/shipping/tracking/transport.go
@@ -15,7 +15,7 @@ import (
 )
 
 // MakeHandler returns a handler for the tracking service.
-func MakeHandler(ctx context.Context, ts Service, logger kitlog.Logger) http.Handler {
+func MakeHandler(ts Service, logger kitlog.Logger) http.Handler {
 	r := mux.NewRouter()
 
 	opts := []kithttp.ServerOption{
@@ -24,7 +24,6 @@ func MakeHandler(ctx context.Context, ts Service, logger kitlog.Logger) http.Han
 	}
 
 	trackCargoHandler := kithttp.NewServer(
-		ctx,
 		makeTrackCargoEndpoint(ts),
 		decodeTrackCargoRequest,
 		encodeResponse,

--- a/examples/stringsvc1/main.go
+++ b/examples/stringsvc1/main.go
@@ -32,18 +32,15 @@ func (stringService) Count(s string) int {
 }
 
 func main() {
-	ctx := context.Background()
 	svc := stringService{}
 
 	uppercaseHandler := httptransport.NewServer(
-		ctx,
 		makeUppercaseEndpoint(svc),
 		decodeUppercaseRequest,
 		encodeResponse,
 	)
 
 	countHandler := httptransport.NewServer(
-		ctx,
 		makeCountEndpoint(svc),
 		decodeCountRequest,
 		encodeResponse,

--- a/examples/stringsvc2/main.go
+++ b/examples/stringsvc2/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"net/http"
 	"os"
 
@@ -13,7 +12,6 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
 	logger := log.NewLogfmtLogger(os.Stderr)
 
 	fieldKeys := []string{"method", "error"}
@@ -42,14 +40,12 @@ func main() {
 	svc = instrumentingMiddleware{requestCount, requestLatency, countResult, svc}
 
 	uppercaseHandler := httptransport.NewServer(
-		ctx,
 		makeUppercaseEndpoint(svc),
 		decodeUppercaseRequest,
 		encodeResponse,
 	)
 
 	countHandler := httptransport.NewServer(
-		ctx,
 		makeCountEndpoint(svc),
 		decodeCountRequest,
 		encodeResponse,

--- a/examples/stringsvc3/proxying.go
+++ b/examples/stringsvc3/proxying.go
@@ -20,7 +20,7 @@ import (
 	httptransport "github.com/go-kit/kit/transport/http"
 )
 
-func proxyingMiddleware(instances string, ctx context.Context, logger log.Logger) ServiceMiddleware {
+func proxyingMiddleware(ctx context.Context, instances string, logger log.Logger) ServiceMiddleware {
 	// If instances is empty, don't proxy.
 	if instances == "" {
 		logger.Log("proxy_to", "none")

--- a/transport/http/example_test.go
+++ b/transport/http/example_test.go
@@ -9,7 +9,6 @@ import (
 
 func ExamplePopulateRequestContext() {
 	handler := NewServer(
-		context.Background(),
 		func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			fmt.Println("Method", ctx.Value(ContextKeyRequestMethod).(string))
 			fmt.Println("RequestPath", ctx.Value(ContextKeyRequestPath).(string))

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -11,7 +11,6 @@ import (
 
 // Server wraps an endpoint and implements http.Handler.
 type Server struct {
-	ctx          context.Context
 	e            endpoint.Endpoint
 	dec          DecodeRequestFunc
 	enc          EncodeResponseFunc
@@ -25,14 +24,12 @@ type Server struct {
 // NewServer constructs a new server, which implements http.Server and wraps
 // the provided endpoint.
 func NewServer(
-	ctx context.Context,
 	e endpoint.Endpoint,
 	dec DecodeRequestFunc,
 	enc EncodeResponseFunc,
 	options ...ServerOption,
 ) *Server {
 	s := &Server{
-		ctx:          ctx,
 		e:            e,
 		dec:          dec,
 		enc:          enc,
@@ -85,7 +82,7 @@ func ServerFinalizer(f ServerFinalizerFunc) ServerOption {
 
 // ServeHTTP implements http.Handler.
 func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx := s.ctx
+	ctx := r.Context()
 
 	if s.finalizer != nil {
 		iw := &interceptingWriter{w, http.StatusOK, 0}

--- a/transport/httprp/server.go
+++ b/transport/httprp/server.go
@@ -14,7 +14,6 @@ type RequestFunc func(context.Context, *http.Request) context.Context
 
 // Server is a proxying request handler.
 type Server struct {
-	ctx          context.Context
 	proxy        http.Handler
 	before       []RequestFunc
 	errorEncoder func(w http.ResponseWriter, err error)
@@ -25,12 +24,10 @@ type Server struct {
 // If the target's path is "/base" and the incoming request was for "/dir",
 // the target request will be for /base/dir.
 func NewServer(
-	ctx context.Context,
 	baseURL *url.URL,
 	options ...ServerOption,
 ) *Server {
 	s := &Server{
-		ctx:   ctx,
 		proxy: httputil.NewSingleHostReverseProxy(baseURL),
 	}
 	for _, option := range options {
@@ -50,7 +47,7 @@ func ServerBefore(before ...RequestFunc) ServerOption {
 
 // ServeHTTP implements http.Handler.
 func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx := s.ctx
+	ctx := r.Context()
 
 	for _, f := range s.before {
 		ctx = f(ctx, r)

--- a/transport/httprp/server_test.go
+++ b/transport/httprp/server_test.go
@@ -20,7 +20,6 @@ func TestServerHappyPathSingleServer(t *testing.T) {
 	originURL, _ := url.Parse(originServer.URL)
 
 	handler := httptransport.NewServer(
-		context.Background(),
 		originURL,
 	)
 	proxyServer := httptest.NewServer(handler)
@@ -55,7 +54,6 @@ func TestServerHappyPathSingleServerWithServerOptions(t *testing.T) {
 	originURL, _ := url.Parse(originServer.URL)
 
 	handler := httptransport.NewServer(
-		context.Background(),
 		originURL,
 		httptransport.ServerBefore(func(ctx context.Context, r *http.Request) context.Context {
 			r.Header.Add(headerKey, headerVal)
@@ -82,7 +80,6 @@ func TestServerOriginServerNotFoundResponse(t *testing.T) {
 	originURL, _ := url.Parse(originServer.URL)
 
 	handler := httptransport.NewServer(
-		context.Background(),
 		originURL,
 	)
 	proxyServer := httptest.NewServer(handler)
@@ -103,7 +100,6 @@ func TestServerOriginServerUnreachable(t *testing.T) {
 	originServer.Close()
 
 	handler := httptransport.NewServer(
-		context.Background(),
 		originURL,
 	)
 	proxyServer := httptest.NewServer(handler)
@@ -138,7 +134,6 @@ func TestMultipleServerBefore(t *testing.T) {
 	originURL, _ := url.Parse(originServer.URL)
 
 	handler := httptransport.NewServer(
-		context.Background(),
 		originURL,
 		httptransport.ServerBefore(func(ctx context.Context, r *http.Request) context.Context {
 			r.Header.Add(headerKey, headerVal)


### PR DESCRIPTION
Since go 1.7 we have per request context available. This eliminates the need for server wide scoped context. Since this is also our now lowest supported version we can move away from the old implementation.

This PR removes using the server wide context inside the ServeHTTP handler in favor of the one provided by *http.Request.

Examples and tests have been updated to reflect the change too.