### PR TITLE
Add helper script for building all example binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 examples/addsvc/addsvc
 examples/addsvc/client/client
+examples/addsvc/cmd/addcli/addcli
+examples/addsvc/cmd/addsvc/addsvc
 examples/apigateway/apigateway
 examples/profilesvc/profilesvc
+examples/profilesvc/cmd/profilesvc/profilesvc
+examples/shipping/shipping
 examples/stringsvc1/stringsvc1
 examples/stringsvc2/stringsvc2
 examples/stringsvc3/stringsvc3

--- a/build-examples.bash
+++ b/build-examples.bash
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# This script builds all examples by looking for packages with "func main".
+
+set -e
+
+function go_files { grep -rl 'func main' examples ; }
+function filter { grep -v -e gen-go ; }
+function remove_relative_prefix { sed -e 's/^\.\///g' ; }
+
+function directories {
+	go_files | filter | remove_relative_prefix | while read f
+	do
+		dirname $f
+	done
+}
+
+function unique_directories { directories | sort | uniq ; }
+
+PATHS=${1:-$(unique_directories)}
+
+function build {
+	for path in $PATHS
+	do
+		echo building ./$path
+		(cd ./$path && go build .)
+	done
+}
+
+build
+

--- a/coverage.bash
+++ b/coverage.bash
@@ -7,7 +7,7 @@
 set -e
 
 function go_files { find . -name '*_test.go' ; }
-function filter { grep -v '/_' ; }
+function filter { grep -v -e '/_' -e vendor ; }
 function remove_relative_prefix { sed -e 's/^\.\///g' ; }
 
 function directories {


### PR DESCRIPTION
This is especially useful when refactoring APIs, to ensure all examples still compile.