### PR TITLE
Add *WithClaims methods to jwt middleware for more advanced usage.

### DIFF
--- a/auth/jwt/middleware.go
+++ b/auth/jwt/middleware.go
@@ -45,7 +45,7 @@ var (
 )
 
 // NewSigner creates a new JWT token generating middleware, specifying key ID,
-// signing string, signing method and the jwt.Claims you would like it to contain.
+// signing string, signing method and the claims you would like it to contain.
 // Tokens are signed with a Key ID header (kid) which is useful for determining
 // the key to use for parsing. Particularly useful for clients.
 func NewSigner(kid string, key []byte, method jwt.SigningMethod, claims jwt.Claims) endpoint.Middleware {
@@ -67,8 +67,8 @@ func NewSigner(kid string, key []byte, method jwt.SigningMethod, claims jwt.Clai
 }
 
 // NewParser creates a new JWT token parsing middleware, specifying a
-// jwt.Keyfunc interface, the signing method as well as the claims to parse into.
-// NewParserWithClaims adds the resulting claims to endpoint context or returns error on invalid token.
+// jwt.Keyfunc interface, the signing method and the claims type to be used. NewParser
+// adds the resulting  claims to endpoint context or returns error on invalid token.
 // Particularly useful for servers.
 func NewParser(keyFunc jwt.Keyfunc, method jwt.SigningMethod, claims jwt.Claims) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {

--- a/auth/jwt/middleware.go
+++ b/auth/jwt/middleware.go
@@ -47,14 +47,14 @@ var (
 // Claims is a map of arbitrary claim data.
 type Claims map[string]interface{}
 
-// NewSigner creates a new JWT token generating middleware, specifying key ID,
-// signing string, signing method and the claims you would like it to contain.
+// NewSignerWithClaims creates a new JWT token generating middleware, specifying key ID,
+// signing string, signing method and the jwt.Claims you would like it to contain.
 // Tokens are signed with a Key ID header (kid) which is useful for determining
 // the key to use for parsing. Particularly useful for clients.
-func NewSigner(kid string, key []byte, method jwt.SigningMethod, claims Claims) endpoint.Middleware {
+func NewSignerWithClaims(kid string, key []byte, method jwt.SigningMethod, claims jwt.Claims) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
-			token := jwt.NewWithClaims(method, jwt.MapClaims(claims))
+			token := jwt.NewWithClaims(method, claims)
 			token.Header["kid"] = kid
 
 			// Sign and get the complete encoded token as a string using the secret
@@ -69,11 +69,18 @@ func NewSigner(kid string, key []byte, method jwt.SigningMethod, claims Claims) 
 	}
 }
 
-// NewParser creates a new JWT token parsing middleware, specifying a
-// jwt.Keyfunc interface and the signing method. NewParser adds the resulting
-// claims to endpoint context or returns error on invalid token. Particularly
-// useful for servers.
-func NewParser(keyFunc jwt.Keyfunc, method jwt.SigningMethod) endpoint.Middleware {
+// NewSigner creates a new JWT token generating middleware, specifying key ID,
+// signing string, signing method and the claims you would like it to contain.
+// It passes these values onto NewSignerWithClaims to handle the signing process.
+func NewSigner(kid string, key []byte, method jwt.SigningMethod, claims Claims) endpoint.Middleware {
+	return NewSignerWithClaims(kid, key, method, jwt.MapClaims(claims))
+}
+
+// NewParserWithClaims creates a new JWT token parsing middleware, specifying a
+// jwt.Keyfunc interface, the signing method as well as the claims to parse into.
+// NewParserWithClaims adds the resulting claims to endpoint context or returns error on invalid token.
+// Particularly useful for servers.
+func NewParserWithClaims(keyFunc jwt.Keyfunc, method jwt.SigningMethod, claims jwt.Claims) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			// tokenString is stored in the context from the transport handlers.
@@ -88,7 +95,7 @@ func NewParser(keyFunc jwt.Keyfunc, method jwt.SigningMethod) endpoint.Middlewar
 			// of the token to identify which key to use, but the parsed token
 			// (head and claims) is provided to the callback, providing
 			// flexibility.
-			token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+			token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 				// Don't forget to validate the alg is what you expect:
 				if token.Method != method {
 					return nil, ErrUnexpectedSigningMethod
@@ -119,11 +126,20 @@ func NewParser(keyFunc jwt.Keyfunc, method jwt.SigningMethod) endpoint.Middlewar
 				return nil, ErrTokenInvalid
 			}
 
-			if claims, ok := token.Claims.(jwt.MapClaims); ok {
-				ctx = context.WithValue(ctx, JWTClaimsContextKey, Claims(claims))
+			if tokenClaims, ok := token.Claims.(jwt.MapClaims); ok {
+				ctx = context.WithValue(ctx, JWTClaimsContextKey, Claims(tokenClaims))
+			} else {
+				ctx = context.WithValue(ctx, JWTClaimsContextKey, token.Claims)
 			}
 
 			return next(ctx, request)
 		}
 	}
+}
+
+// NewParser creates a new JWT token parsing middleware, specifying a
+// jwt.KeyFunc interface and the signing method. It will utilize NewParserWithClaims
+// and fall back to implementing the jwt.MapClaims type.
+func NewParser(keyFunc jwt.Keyfunc, method jwt.SigningMethod) endpoint.Middleware {
+	return NewParserWithClaims(keyFunc, method, jwt.MapClaims{})
 }


### PR DESCRIPTION
I started migrating our existing JWT layer to go-kit's version however I was not able to complete the process. We implement a custom jwt.Claims object and need to be able to add middleware layers that use this.

This PR adds some new exported middlewares that allow for advanced claim types.