### PR TITLE
Fix overriding of metadata set by the user.

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -91,8 +91,8 @@ func (c Client) Endpoint() endpoint.Endpoint {
 			return nil, err
 		}
 
-		md,ok := metadata.FromContext(ctx)
-		if !ok{
+		md, ok := metadata.FromContext(ctx)
+		if !ok {
 			md = metadata.MD{}
 		}
 		for _, f := range c.before {

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -91,7 +91,10 @@ func (c Client) Endpoint() endpoint.Endpoint {
 			return nil, err
 		}
 
-		md,_ := metadata.FromContext(ctx)
+		md,ok := metadata.FromContext(ctx)
+		if !ok{
+			md = metadata.MD{}
+		}
 		for _, f := range c.before {
 			ctx = f(ctx, &md)
 		}

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -91,11 +91,11 @@ func (c Client) Endpoint() endpoint.Endpoint {
 			return nil, err
 		}
 
-		md := &metadata.MD{}
+		md,_ := metadata.FromContext(ctx)
 		for _, f := range c.before {
-			ctx = f(ctx, md)
+			ctx = f(ctx, &md)
 		}
-		ctx = metadata.NewContext(ctx, *md)
+		ctx = metadata.NewContext(ctx, md)
 
 		var header, trailer metadata.MD
 		grpcReply := reflect.New(c.grpcReply).Interface()


### PR DESCRIPTION
The metadata set by the user is being overridden by: 
https://github.com/go-kit/kit/blob/master/transport/grpc/client.go#L94-L98
I think we should be allowed to set the metadata without using `before` functions just like the official doc describes it : https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md
This fixes this issue and allows users to set the metadata.
 