### PR TITLE
metrics: Move the Provider interface to metrics

### DIFF
--- a/metrics/provider.go
+++ b/metrics/provider.go
@@ -1,0 +1,15 @@
+package metrics
+
+// Provider abstracts over constructors and lifecycle management functions for
+// each supported metrics backend. It should only be used by those who need to
+// swap out implementations dynamically.
+//
+// This is primarily useful for intermediating frameworks, and is likely
+// unnecessary for most Go kit services. See the provider package-level doc
+// comment for more typical usage instructions.
+type Provider interface {
+	NewCounter(name string) Counter
+	NewGauge(name string) Gauge
+	NewHistogram(name string, buckets int) Histogram
+	Stop()
+}

--- a/metrics/provider/discard.go
+++ b/metrics/provider/discard.go
@@ -9,7 +9,7 @@ type discardProvider struct{}
 
 // NewDiscardProvider returns a provider that produces no-op metrics via the
 // discarding backend.
-func NewDiscardProvider() Provider { return discardProvider{} }
+func NewDiscardProvider() metrics.Provider { return discardProvider{} }
 
 // NewCounter implements Provider.
 func (discardProvider) NewCounter(string) metrics.Counter { return discard.NewCounter() }

--- a/metrics/provider/doc.go
+++ b/metrics/provider/doc.go
@@ -15,28 +15,9 @@
 //        s := statsd.New(...)
 //        t := time.NewTicker(5*time.Second)
 //        go s.SendLoop(t.C, "tcp", "statsd.local:8125")
-//        latency = s.NewHistogram(...)
 //        requests = s.NewCounter(...)
 //    default:
 //        log.Fatal("unsupported metrics backend %q", *metricsBackend)
 //    }
 //
 package provider
-
-import (
-	"github.com/go-kit/kit/metrics"
-)
-
-// Provider abstracts over constructors and lifecycle management functions for
-// each supported metrics backend. It should only be used by those who need to
-// swap out implementations dynamically.
-//
-// This is primarily useful for intermediating frameworks, and is likely
-// unnecessary for most Go kit services. See the package-level doc comment for
-// more typical usage instructions.
-type Provider interface {
-	NewCounter(name string) metrics.Counter
-	NewGauge(name string) metrics.Gauge
-	NewHistogram(name string, buckets int) metrics.Histogram
-	Stop()
-}

--- a/metrics/provider/dogstatsd.go
+++ b/metrics/provider/dogstatsd.go
@@ -13,7 +13,7 @@ type dogstatsdProvider struct {
 // NewDogstatsdProvider wraps the given Dogstatsd object and stop func and
 // returns a Provider that produces Dogstatsd metrics. A typical stop function
 // would be ticker.Stop from the ticker passed to the SendLoop helper method.
-func NewDogstatsdProvider(d *dogstatsd.Dogstatsd, stop func()) Provider {
+func NewDogstatsdProvider(d *dogstatsd.Dogstatsd, stop func()) metrics.Provider {
 	return &dogstatsdProvider{
 		d:    d,
 		stop: stop,

--- a/metrics/provider/expvar.go
+++ b/metrics/provider/expvar.go
@@ -8,7 +8,7 @@ import (
 type expvarProvider struct{}
 
 // NewExpvarProvider returns a Provider that produces expvar metrics.
-func NewExpvarProvider() Provider {
+func NewExpvarProvider() metrics.Provider {
 	return expvarProvider{}
 }
 

--- a/metrics/provider/graphite.go
+++ b/metrics/provider/graphite.go
@@ -13,7 +13,7 @@ type graphiteProvider struct {
 // NewGraphiteProvider wraps the given Graphite object and stop func and returns
 // a Provider that produces Graphite metrics. A typical stop function would be
 // ticker.Stop from the ticker passed to the SendLoop helper method.
-func NewGraphiteProvider(g *graphite.Graphite, stop func()) Provider {
+func NewGraphiteProvider(g *graphite.Graphite, stop func()) metrics.Provider {
 	return &graphiteProvider{
 		g:    g,
 		stop: stop,

--- a/metrics/provider/influx.go
+++ b/metrics/provider/influx.go
@@ -12,7 +12,7 @@ type influxProvider struct {
 
 // NewInfluxProvider takes the given Influx object and stop func, and returns
 // a Provider that produces Influx metrics.
-func NewInfluxProvider(in *influx.Influx, stop func()) Provider {
+func NewInfluxProvider(in *influx.Influx, stop func()) metrics.Provider {
 	return &influxProvider{
 		in:   in,
 		stop: stop,

--- a/metrics/provider/prometheus.go
+++ b/metrics/provider/prometheus.go
@@ -14,7 +14,7 @@ type prometheusProvider struct {
 
 // NewPrometheusProvider returns a Provider that produces Prometheus metrics.
 // Namespace and subsystem are applied to all produced metrics.
-func NewPrometheusProvider(namespace, subsystem string) Provider {
+func NewPrometheusProvider(namespace, subsystem string) metrics.Provider {
 	return &prometheusProvider{
 		namespace: namespace,
 		subsystem: subsystem,

--- a/metrics/provider/statsd.go
+++ b/metrics/provider/statsd.go
@@ -13,7 +13,7 @@ type statsdProvider struct {
 // NewStatsdProvider wraps the given Statsd object and stop func and returns a
 // Provider that produces Statsd metrics. A typical stop function would be
 // ticker.Stop from the ticker passed to the SendLoop helper method.
-func NewStatsdProvider(s *statsd.Statsd, stop func()) Provider {
+func NewStatsdProvider(s *statsd.Statsd, stop func()) metrics.Provider {
 	return &statsdProvider{
 		s:    s,
 		stop: stop,


### PR DESCRIPTION
Reasons:

1. The Provider interface is all about returning things from metrics. It makes
more sense to me to have it located there.

2. provider.Provider is a form of stutter. It's more accepted then other forms
though (cf. hash.Hash), but I personally dislike it. For instance, what is a
provider.Provider providing? metrics.Provider says a lot more IMO.

3. Importing the provider package incurrs a lot of additional dependencies, most
of which aren't needed. Our work around to this is to redefine a Provider
interface locally. These are usually defined in a local `metrics` package
requiring either the local or go-kit metrics package to be renamed during import
which is :-(. These local metrics packages proliferate over time across projects.