### PR TITLE
log: Add TimestampFormat and Timeformat.

### DIFF
--- a/log/value.go
+++ b/log/value.go
@@ -32,11 +32,50 @@ func containsValuer(keyvals []interface{}) bool {
 	return false
 }
 
-// Timestamp returns a Valuer that invokes the underlying function when bound,
-// returning a time.Time. Users will probably want to use DefaultTimestamp or
-// DefaultTimestampUTC.
+// Timestamp returns a timestamp Valuer. It invokes the t function to get the
+// time; unless you are doing something tricky, pass time.Now.
+//
+// Most users will want to use DefaultTimestamp or DefaultTimestampUTC, which
+// are TimestampFormats that use the RFC3339Nano format.
 func Timestamp(t func() time.Time) Valuer {
 	return func() interface{} { return t() }
+}
+
+// TimestampFormat returns a timestamp Valuer with a custom time format. It
+// invokes the t function to get the time to format; unless you are doing
+// something tricky, pass time.Now. The layout string is passed to
+// Time.Format.
+//
+// Most users will want to use DefaultTimestamp or DefaultTimestampUTC, which
+// are TimestampFormats that use the RFC3339Nano format.
+func TimestampFormat(t func() time.Time, layout string) Valuer {
+	return func() interface{} {
+		return timeFormat{
+			time:   t(),
+			layout: layout,
+		}
+	}
+}
+
+// A timeFormat represents an instant in time and a layout used when
+// marshaling to a text format.
+type timeFormat struct {
+	time   time.Time
+	layout string
+}
+
+func (tf timeFormat) String() string {
+	return tf.time.Format(tf.layout)
+}
+
+// MarshalText implements encoding.TextMarshaller.
+func (tf timeFormat) MarshalText() (text []byte, err error) {
+	// The following code adapted from the standard library time.Time.Format
+	// method. Using the same undocumented magic constant to extend the size
+	// of the buffer as seen there.
+	b := make([]byte, 0, len(tf.layout)+10)
+	b = tf.time.AppendFormat(b, tf.layout)
+	return b, nil
 }
 
 // Caller returns a Valuer that returns a file and line from a specified depth
@@ -48,15 +87,14 @@ func Caller(depth int) Valuer {
 var (
 	// DefaultTimestamp is a Valuer that returns the current wallclock time,
 	// respecting time zones, when bound.
-	DefaultTimestamp = Valuer(func() interface{} {
-		return time.Now().Format(time.RFC3339Nano)
-	})
+	DefaultTimestamp = TimestampFormat(time.Now, time.RFC3339Nano)
 
 	// DefaultTimestampUTC is a Valuer that returns the current time in UTC
 	// when bound.
-	DefaultTimestampUTC = Valuer(func() interface{} {
-		return time.Now().UTC().Format(time.RFC3339Nano)
-	})
+	DefaultTimestampUTC = TimestampFormat(
+		func() time.Time { return time.Now().UTC() },
+		time.RFC3339Nano,
+	)
 
 	// DefaultCaller is a Valuer that returns the file and line where the Log
 	// method was invoked. It can only be used with log.With.


### PR DESCRIPTION
- TimeFormat provides a value that defers formating timestamps until
  serialization, which improves performance when a log event is not
  serialized.
- TimestampFormat is a convenience function to produce time Valuers
  with arbitrary time formats.
- DefaultTimestamp and DefaultTimestampUTC are now created using
  TimestampFormat.

Benchmarks from log/level showing the benefits:
```
name                                              old time/op    new time/op    delta
/TimeContext/Baseline/Nop-8                          679ns ± 0%     358ns ± 0%  -47.25%  (p=0.008 n=5+5)
/TimeContext/Baseline/Logfmt-8                      1.41µs ± 0%    1.49µs ± 0%   +5.67%  (p=0.008 n=5+5)
/TimeContext/Baseline/JSON-8                        2.87µs ± 0%    2.87µs ± 0%     ~     (p=0.611 n=5+5)
/TimeContext/DisallowedLevel/Nop-8                   680ns ± 0%     360ns ± 0%  -47.13%  (p=0.008 n=5+5)
/TimeContext/DisallowedLevel/Logfmt-8                680ns ± 0%     359ns ± 0%  -47.18%  (p=0.008 n=5+5)
/TimeContext/DisallowedLevel/JSON-8                  680ns ± 0%     360ns ± 0%  -47.04%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/Nop-8                      688ns ± 0%     364ns ± 0%  -47.15%  (p=0.016 n=4+5)
/TimeContext/AllowedLevel/Logfmt-8                  1.42µs ± 0%    1.50µs ± 0%   +5.38%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/JSON-8                    2.88µs ± 0%    2.88µs ± 0%   +0.32%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/Nop-8              1.41µs ± 0%    1.07µs ± 1%  -24.43%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/Logfmt-8           3.26µs ± 0%    3.37µs ± 0%   +3.55%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/JSON-8             5.32µs ± 0%    5.34µs ± 0%   +0.53%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/Nop-8       1.41µs ± 0%    1.06µs ± 0%  -24.49%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/Logfmt-8    1.41µs ± 0%    1.06µs ± 0%  -24.53%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/JSON-8      1.41µs ± 0%    1.07µs ± 1%  -24.37%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/Nop-8          1.42µs ± 0%    1.07µs ± 0%  -24.54%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/Logfmt-8       3.26µs ± 1%    3.38µs ± 0%   +3.81%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/JSON-8         5.35µs ± 0%    5.34µs ± 0%     ~     (p=0.238 n=5+5)

name                                              old alloc/op   new alloc/op   delta
/TimeContext/Baseline/Nop-8                           352B ± 0%      352B ± 0%     ~     (all equal)
/TimeContext/Baseline/Logfmt-8                        352B ± 0%      400B ± 0%  +13.64%  (p=0.008 n=5+5)
/TimeContext/Baseline/JSON-8                        1.26kB ± 0%    1.31kB ± 0%   +3.80%  (p=0.008 n=5+5)
/TimeContext/DisallowedLevel/Nop-8                    352B ± 0%      352B ± 0%     ~     (all equal)
/TimeContext/DisallowedLevel/Logfmt-8                 352B ± 0%      352B ± 0%     ~     (all equal)
/TimeContext/DisallowedLevel/JSON-8                   352B ± 0%      352B ± 0%     ~     (all equal)
/TimeContext/AllowedLevel/Nop-8                       352B ± 0%      352B ± 0%     ~     (all equal)
/TimeContext/AllowedLevel/Logfmt-8                    352B ± 0%      400B ± 0%  +13.64%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/JSON-8                    1.26kB ± 0%    1.31kB ± 0%   +3.80%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/Nop-8                560B ± 0%      560B ± 0%     ~     (all equal)
/TimeCallerReqIDContext/Baseline/Logfmt-8             736B ± 0%      784B ± 0%   +6.52%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/JSON-8             1.85kB ± 0%    1.90kB ± 0%   +2.60%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/Nop-8         560B ± 0%      560B ± 0%     ~     (all equal)
/TimeCallerReqIDContext/DisallowedLevel/Logfmt-8      560B ± 0%      560B ± 0%     ~     (all equal)
/TimeCallerReqIDContext/DisallowedLevel/JSON-8        560B ± 0%      560B ± 0%     ~     (all equal)
/TimeCallerReqIDContext/AllowedLevel/Nop-8            560B ± 0%      560B ± 0%     ~     (all equal)
/TimeCallerReqIDContext/AllowedLevel/Logfmt-8         736B ± 0%      784B ± 0%   +6.52%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/JSON-8         1.85kB ± 0%    1.90kB ± 0%   +2.60%  (p=0.008 n=5+5)

name                                              old allocs/op  new allocs/op  delta
/TimeContext/Baseline/Nop-8                           8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.008 n=5+5)
/TimeContext/Baseline/Logfmt-8                        8.00 ± 0%      8.00 ± 0%     ~     (all equal)
/TimeContext/Baseline/JSON-8                          27.0 ± 0%      27.0 ± 0%     ~     (all equal)
/TimeContext/DisallowedLevel/Nop-8                    8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.008 n=5+5)
/TimeContext/DisallowedLevel/Logfmt-8                 8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.008 n=5+5)
/TimeContext/DisallowedLevel/JSON-8                   8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/Nop-8                       8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.008 n=5+5)
/TimeContext/AllowedLevel/Logfmt-8                    8.00 ± 0%      8.00 ± 0%     ~     (all equal)
/TimeContext/AllowedLevel/JSON-8                      27.0 ± 0%      27.0 ± 0%     ~     (all equal)
/TimeCallerReqIDContext/Baseline/Nop-8                9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/Baseline/Logfmt-8             14.0 ± 0%      14.0 ± 0%     ~     (all equal)
/TimeCallerReqIDContext/Baseline/JSON-8               38.0 ± 0%      38.0 ± 0%     ~     (all equal)
/TimeCallerReqIDContext/DisallowedLevel/Nop-8         9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/Logfmt-8      9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/DisallowedLevel/JSON-8        9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/Nop-8            9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.008 n=5+5)
/TimeCallerReqIDContext/AllowedLevel/Logfmt-8         14.0 ± 0%      14.0 ± 0%     ~     (all equal)
/TimeCallerReqIDContext/AllowedLevel/JSON-8           38.0 ± 0%      38.0 ± 0%     ~     (all equal)
```