### PR TITLE
Fix typo in addsvc's doc block

### DIFF
--- a/examples/addsvc/doc.go
+++ b/examples/addsvc/doc.go
@@ -1,5 +1,5 @@
 // Package addsvc is an example microservice, useful for education. It can sum
 // integers and concatenate strings. A client library is available in the client
-// subdirectory. A server binary is available in cmd/addsrv. An example client
+// subdirectory. A server binary is available in cmd/addsvc. An example client
 // binary is available in cmd/addcli.
 package addsvc


### PR DESCRIPTION
The server binary is available in `cmd/addsvc`, not in `cmd/addsrv`.