### PR TITLE
Type in level test cases

### DIFF
--- a/log/level/level_test.go
+++ b/log/level/level_test.go
@@ -38,7 +38,7 @@ func TestVariousLevels(t *testing.T) {
 			}, "\n"),
 		},
 		{
-			"AllowDebug",
+			"AllowInfo",
 			level.AllowInfo(),
 			strings.Join([]string{
 				`{"level":"info","this is":"info log"}`,


### PR DESCRIPTION
This PR fixes a basic typo in the test cases for log levels