### PR TITLE
fix(transport/grpc): add client option to disable prefix

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -79,6 +79,11 @@ func ClientAfter(after ...ClientResponseFunc) ClientOption {
 	return func(c *Client) { c.after = append(c.after, after...) }
 }
 
+// ClientNoPrefix reverts the auto-prefixing of "pb" to serviceName.
+func ClientNoPrefix() ClientOption {
+	return func(c *Client) { c.method = strings.Replace(c.method, "/pb.", "/", 1) }
+}
+
 // Endpoint returns a usable endpoint that will invoke the gRPC specified by the
 // client.
 func (c Client) Endpoint() endpoint.Endpoint {


### PR DESCRIPTION
Add a ClientOption to revert the auto-prefixing of "pb" to service names
when there's no other prefix already specified.

Relates to #447.

---

This implementation touches the fewest lines of code, at the expense at perhaps being a bit more complex. An alternative implementation I have in mind avoids the `fmt.Sprintf` on line 45 to construct the method, stores them separately, until the method is actually needed to `Invoke`. The `ClientOption` could then just set a flag to turn off the prefixing.

What do you think?

---

Additionally, is there something I can do to denote that auto-prefixing is deprecated, so we can re-evaluate this in a future breaking change?