### PR TITLE
fix(transport/grpc): remove autoprefixing logic

### DIFF
--- a/examples/addsvc/client/grpc/client.go
+++ b/examples/addsvc/client/grpc/client.go
@@ -34,7 +34,7 @@ func New(conn *grpc.ClientConn, tracer stdopentracing.Tracer, logger log.Logger)
 	{
 		sumEndpoint = grpctransport.NewClient(
 			conn,
-			"Add",
+			"pb.Add",
 			"Sum",
 			addsvc.EncodeGRPCSumRequest,
 			addsvc.DecodeGRPCSumResponse,
@@ -53,7 +53,7 @@ func New(conn *grpc.ClientConn, tracer stdopentracing.Tracer, logger log.Logger)
 	{
 		concatEndpoint = grpctransport.NewClient(
 			conn,
-			"Add",
+			"pb.Add",
 			"Concat",
 			addsvc.EncodeGRPCConcatRequest,
 			addsvc.DecodeGRPCConcatResponse,

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -37,9 +36,6 @@ func NewClient(
 	grpcReply interface{},
 	options ...ClientOption,
 ) *Client {
-	if strings.IndexByte(serviceName, '.') == -1 {
-		serviceName = "pb." + serviceName
-	}
 	c := &Client{
 		client: cc,
 		method: fmt.Sprintf("/%s/%s", serviceName, method),


### PR DESCRIPTION
Removes the autoprefixing of "pb" to service names, to allow for
grpc services created without a package prefix.

Fixes #447.

BREAKING CHANGE: Existing users of the grpc client transport who were
relying on the autoprefixing of the "pb" package name must manually
update their clients to add it. No change is required if a package name
was already being manually prefixed.