### PR TITLE
Issue #529: Partition API requests to CloudWatch into separate concur…

### DIFF
--- a/metrics/teststat/teststat.go
+++ b/metrics/teststat/teststat.go
@@ -14,6 +14,16 @@ import (
 // TestCounter puts some deltas through the counter, and then calls the value
 // func to check that the counter has the correct final value.
 func TestCounter(counter metrics.Counter, value func() float64) error {
+	want := FillCounter(counter)
+	if have := value(); want != have {
+		return fmt.Errorf("want %f, have %f", want, have)
+	}
+
+	return nil
+}
+
+// FillCounter puts some deltas through the counter and returns the total value.
+func FillCounter(counter metrics.Counter) float64 {
 	a := rand.Perm(100)
 	n := rand.Intn(len(a))
 
@@ -23,12 +33,7 @@ func TestCounter(counter metrics.Counter, value func() float64) error {
 		counter.Add(f)
 		want += f
 	}
-
-	if have := value(); want != have {
-		return fmt.Errorf("want %f, have %f", want, have)
-	}
-
-	return nil
+	return want
 }
 
 // TestGauge puts some values through the gauge, and then calls the value func


### PR DESCRIPTION
…rent batches to circumvent the 20 data per request limit that they have