### PR TITLE
sd/eureka: remove data races in unit tests

### DIFF
--- a/sd/eureka/instancer_test.go
+++ b/sd/eureka/instancer_test.go
@@ -13,94 +13,80 @@ var _ sd.Instancer = &Instancer{} // API check
 
 func TestInstancer(t *testing.T) {
 	connection := &testConnection{
-		instances:      []*fargo.Instance{instanceTest1},
-		application:    appUpdateTest,
+		instances:      []*fargo.Instance{instanceTest1, instanceTest2},
 		errApplication: nil,
 	}
 
 	instancer := NewInstancer(connection, appNameTest, loggerTest)
 	defer instancer.Stop()
 
-	state := instancer.cache.State()
+	state := instancer.state()
 	if state.Err != nil {
 		t.Fatal(state.Err)
 	}
 
-	if want, have := 1, len(state.Instances); want != have {
+	if want, have := 2, len(state.Instances); want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
 }
 
-func TestInstancerScheduleUpdates(t *testing.T) {
+func TestInstancerReceivesUpdates(t *testing.T) {
 	connection := &testConnection{
 		instances:      []*fargo.Instance{instanceTest1},
-		application:    appUpdateTest,
 		errApplication: nil,
 	}
 
 	instancer := NewInstancer(connection, appNameTest, loggerTest)
 	defer instancer.Stop()
 
-	state := instancer.cache.State()
-	if want, have := 1, len(state.Instances); want != have {
-		t.Errorf("want %d, have %d", want, have)
+	verifyCount := func(want int) (have int, converged bool) {
+		const maxPollAttempts = 5
+		const delayPerAttempt = 200 * time.Millisecond
+		for i := 1; ; i++ {
+			state := instancer.state()
+			if have := len(state.Instances); want == have {
+				return have, true
+			} else if i == maxPollAttempts {
+				return have, false
+			}
+			time.Sleep(delayPerAttempt)
+		}
 	}
 
-	time.Sleep(50 * time.Millisecond)
-
-	state = instancer.cache.State()
-	if want, have := 2, len(state.Instances); want != have {
-		t.Errorf("want %v, have %v", want, have)
-	}
-}
-
-func TestBadInstancerInstances(t *testing.T) {
-	connection := &testConnection{
-		instances:      []*fargo.Instance{},
-		errInstances:   errTest,
-		application:    appUpdateTest,
-		errApplication: nil,
+	if have, converged := verifyCount(1); !converged {
+		t.Fatalf("initial: want %d, have %d", 1, have)
 	}
 
-	instancer := NewInstancer(connection, appNameTest, loggerTest)
-	defer instancer.Stop()
-
-	state := instancer.cache.State()
-	if state.Err == nil {
-		t.Fatal("expecting error")
+	if err := connection.RegisterInstance(instanceTest2); err != nil {
+		t.Fatalf("failed to register an instance: %v", err)
+	}
+	if have, converged := verifyCount(2); !converged {
+		t.Fatalf("after registration: want %d, have %d", 2, have)
 	}
 
-	if want, have := 0, len(state.Instances); want != have {
-		t.Errorf("want %d, have %d", want, have)
+	if err := connection.DeregisterInstance(instanceTest1); err != nil {
+		t.Fatalf("failed to unregister an instance: %v", err)
+	}
+	if have, converged := verifyCount(1); !converged {
+		t.Fatalf("after deregistration: want %d, have %d", 1, have)
 	}
 }
 
 func TestBadInstancerScheduleUpdates(t *testing.T) {
 	connection := &testConnection{
 		instances:      []*fargo.Instance{instanceTest1},
-		application:    appUpdateTest,
 		errApplication: errTest,
 	}
 
 	instancer := NewInstancer(connection, appNameTest, loggerTest)
 	defer instancer.Stop()
 
-	state := instancer.cache.State()
-	if state.Err != nil {
-		t.Error(state.Err)
-	}
-	if want, have := 1, len(state.Instances); want != have {
-		t.Errorf("want %d, have %d", want, have)
-	}
-
-	time.Sleep(50 * time.Millisecond)
-
-	state = instancer.cache.State()
+	state := instancer.state()
 	if state.Err == nil {
 		t.Fatal("expecting error")
 	}
 
 	if want, have := 0, len(state.Instances); want != have {
-		t.Errorf("want %v, have %v", want, have)
+		t.Errorf("want %d, have %d", want, have)
 	}
 }


### PR DESCRIPTION
Addressing #545, revise the fake _fargo_ components used in the Eureka-related tests to behave more like a real Eureka server, and reduce the tests' vulnerability to delays in asynchronously-arriving responses from the server by polling, with a limit in place to make the tests fail after polling for one second.

This proposal changes `eureka.Instancer`'s cache priming implementation, though the behavior observable by callers shouldn't change.