### PR TITLE
Catch panic in http and grpc servers

### DIFF
--- a/transport/grpc/request_response_funcs.go
+++ b/transport/grpc/request_response_funcs.go
@@ -10,10 +10,6 @@ import (
 
 const (
 	binHdrSuffix = "-bin"
-
-	// ContextKeyRecoveredFromPanic is populated in the context whenever a
-	// panic is recovered in ServeGRPC. Its value is the one given to panic.
-	ContextKeyRecoveredFromPanic contextKey = iota
 )
 
 // ClientRequestFunc may take information from context and use it to construct

--- a/transport/grpc/request_response_funcs.go
+++ b/transport/grpc/request_response_funcs.go
@@ -10,6 +10,10 @@ import (
 
 const (
 	binHdrSuffix = "-bin"
+
+	// ContextKeyRecoveredFromPanic is populated in the context whenever a
+	// panic is recovered in ServeGRPC. Its value is the one given to panic.
+	ContextKeyRecoveredFromPanic contextKey = iota
 )
 
 // ClientRequestFunc may take information from context and use it to construct

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -72,6 +72,14 @@ func ServerErrorLogger(logger log.Logger) ServerOption {
 
 // ServeGRPC implements the Handler interface.
 func (s Server) ServeGRPC(ctx oldcontext.Context, req interface{}) (oldcontext.Context, interface{}, error) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			ctx = oldcontext.WithValue(ctx, ContextKeyRecoveredFromPanic, r)
+			s.logger.Log("panic", r)
+		}
+	}()
+
 	// Retrieve gRPC metadata.
 	md, ok := metadata.FromContext(ctx)
 	if !ok {

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -75,7 +75,6 @@ func (s Server) ServeGRPC(ctx oldcontext.Context, req interface{}) (oldcontext.C
 
 	defer func() {
 		if r := recover(); r != nil {
-			ctx = oldcontext.WithValue(ctx, ContextKeyRecoveredFromPanic, r)
 			s.logger.Log("panic", r)
 		}
 	}()

--- a/transport/http/request_response_funcs.go
+++ b/transport/http/request_response_funcs.go
@@ -130,4 +130,8 @@ const (
 	// ContextKeyResponseSize is populated in the context whenever a
 	// ServerFinalizerFunc is specified. Its value is of type int64.
 	ContextKeyResponseSize
+
+	// ContextKeyRecoveredFromPanic is populated in the context whenever a
+	// panic is recovered in ServeHTTP. Its value is the one given to panic.
+	ContextKeyRecoveredFromPanic
 )

--- a/transport/http/request_response_funcs.go
+++ b/transport/http/request_response_funcs.go
@@ -131,7 +131,7 @@ const (
 	// ServerFinalizerFunc is specified. Its value is of type int64.
 	ContextKeyResponseSize
 
-	// ContextKeyRecoveredFromPanic is populated in the context whenever a
+	// ContextKeyPanicValue is populated in the context whenever a
 	// panic is recovered in ServeHTTP. Its value is the one given to panic.
-	ContextKeyRecoveredFromPanic
+	ContextKeyPanicValue
 )

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -89,6 +89,10 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			ctx = context.WithValue(ctx, ContextKeyResponseHeaders, iw.Header())
 			ctx = context.WithValue(ctx, ContextKeyResponseSize, iw.written)
+			if r := recover(); r != nil {
+				ctx = context.WithValue(ctx, ContextKeyRecoveredFromPanic, r)
+				s.logger.Log("panic", r)
+			}
 			s.finalizer(ctx, iw.code, r)
 		}()
 		w = iw

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -371,7 +371,6 @@ func TestServerRecoverPanic(t *testing.T) {
 				}),
 				httptransport.ServerCatchPanic(testCase.catchPanic),
 			)
-
 			server := httptest.NewServer(func(http.Handler) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					defer func() {


### PR DESCRIPTION
As discussed in #551, this PR adds recovering from panic capability to both `kit/transport/http.Server` and `kit/transport/grpc.Server`. In the first case, the value given to panic is also put in context in order to be handled by the `finalizer`. In both cases the panic is logged.