### PR TITLE
Remove unnecessary error check.

### DIFF
--- a/log/json_logger.go
+++ b/log/json_logger.go
@@ -44,9 +44,6 @@ func merge(dst map[string]interface{}, k, v interface{}) {
 	default:
 		key = fmt.Sprint(x)
 	}
-	if x, ok := v.(error); ok {
-		v = safeError(x)
-	}
 
 	// We want json.Marshaler and encoding.TextMarshaller to take priority over
 	// err.Error() and v.String(). But json.Marshall (called later) does that by

--- a/log/json_logger_test.go
+++ b/log/json_logger_test.go
@@ -88,6 +88,10 @@ func (aller) String() string {
 	return "string"
 }
 
+func (aller) Error() string {
+	return "error"
+}
+
 // textstringer implements encoding.TextMarshaler and fmt.Stringer.
 type textstringer struct{}
 


### PR DESCRIPTION
#580

If you want to see the test fail, just add the `error` interface in the test without removing the error type check.

![gokit-logger](https://user-images.githubusercontent.com/186643/28404179-a571154e-6d6b-11e7-97c4-713f6bb371b2.png)
