### PR TITLE
sd: add Stop method to Instancer interface

### DIFF
--- a/sd/consul/instancer_test.go
+++ b/sd/consul/instancer_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-kit/kit/sd"
 )
 
-var _ sd.Instancer = &Instancer{} // API check
+var _ sd.Instancer = (*Instancer)(nil) // API check
 
 var consulState = []*consul.ServiceEntry{
 	{

--- a/sd/dnssrv/instancer_test.go
+++ b/sd/dnssrv/instancer_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-kit/kit/sd"
 )
 
-var _ sd.Instancer = &Instancer{} // API check
+var _ sd.Instancer = (*Instancer)(nil) // API check
 
 func TestRefresh(t *testing.T) {
 	name := "some.service.internal"

--- a/sd/endpointer_test.go
+++ b/sd/endpointer_test.go
@@ -19,9 +19,7 @@ func TestDefaultEndpointer(t *testing.T) {
 		f  = func(instance string) (endpoint.Endpoint, io.Closer, error) {
 			return endpoint.Nop, c[instance], nil
 		}
-		instancer = &mockInstancer{
-			cache: instance.NewCache(),
-		}
+		instancer = &mockInstancer{instance.NewCache()}
 	)
 	// set initial state
 	instancer.Update(sd.Event{Instances: []string{"a", "b"}})
@@ -59,21 +57,7 @@ func TestDefaultEndpointer(t *testing.T) {
 	// and therefore does not have access to the endpointer's private members.
 }
 
-type mockInstancer struct {
-	cache *instance.Cache
-}
-
-func (m *mockInstancer) Update(event sd.Event) {
-	m.cache.Update(event)
-}
-
-func (m *mockInstancer) Register(ch chan<- sd.Event) {
-	m.cache.Register(ch)
-}
-
-func (m *mockInstancer) Deregister(ch chan<- sd.Event) {
-	m.cache.Deregister(ch)
-}
+type mockInstancer struct{ *instance.Cache }
 
 type closer chan struct{}
 

--- a/sd/etcd/instancer_test.go
+++ b/sd/etcd/instancer_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-kit/kit/sd"
 )
 
+var _ sd.Instancer = (*Instancer)(nil) // API check
+
 var (
 	node = &stdetcd.Node{
 		Key: "/foo",

--- a/sd/eureka/instancer_test.go
+++ b/sd/eureka/instancer_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-kit/kit/sd"
 )
 
-var _ sd.Instancer = &Instancer{} // API check
+var _ sd.Instancer = (*Instancer)(nil) // API check
 
 func TestInstancer(t *testing.T) {
 	connection := &testConnection{

--- a/sd/instancer.go
+++ b/sd/instancer.go
@@ -22,6 +22,7 @@ type Event struct {
 type Instancer interface {
 	Register(chan<- Event)
 	Deregister(chan<- Event)
+	Stop()
 }
 
 // FixedInstancer yields a fixed set of instances.
@@ -32,3 +33,6 @@ func (d FixedInstancer) Register(ch chan<- Event) { ch <- Event{Instances: d} }
 
 // Deregister implements Instancer.
 func (d FixedInstancer) Deregister(ch chan<- Event) {}
+
+// Stop implements Instancer.
+func (d FixedInstancer) Stop() {}

--- a/sd/internal/instance/cache.go
+++ b/sd/internal/instance/cache.go
@@ -45,6 +45,10 @@ func (c *Cache) State() sd.Event {
 	return c.state
 }
 
+// Stop implements Instancer. Since the cache is just a plain-old store of data,
+// Stop is a no-op.
+func (c *Cache) Stop() {}
+
 // Register implements Instancer.
 func (c *Cache) Register(ch chan<- sd.Event) {
 	c.mtx.Lock()

--- a/sd/internal/instance/cache_test.go
+++ b/sd/internal/instance/cache_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-kit/kit/sd"
 )
 
-var _ sd.Instancer = &Cache{} // API check
+var _ sd.Instancer = (*Cache)(nil) // API check
 
 // The test verifies the following:
 //   registering causes initial notification of the current state

--- a/sd/zk/instancer_test.go
+++ b/sd/zk/instancer_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-kit/kit/sd"
 )
 
-var _ sd.Instancer = &Instancer{}
+var _ sd.Instancer = (*Instancer)(nil) // API check
 
 func TestInstancer(t *testing.T) {
 	client := newFakeClient()


### PR DESCRIPTION
Every implementation (modulo mock/test impls) already provided this method, and so it makes sense to lift it to the interface definition.

Closes #566.