### PR TITLE
Add SetKey() to log/level package to overwrite default key

### DIFF
--- a/log/level/level.go
+++ b/log/level/level.go
@@ -163,6 +163,11 @@ type Value interface {
 // package.
 func Key() interface{} { return key }
 
+// SetKey sets the unique key added to log events by the loggers in this
+// package. This is useful for situations where log aggregation
+// uses e.g. severity and not level.
+func SetKey(k interface{}) { key = k }
+
 // ErrorValue returns the unique value added to log events by Error.
 func ErrorValue() Value { return errorValue }
 

--- a/log/level/level_test.go
+++ b/log/level/level_test.go
@@ -233,3 +233,26 @@ func TestInjector(t *testing.T) {
 		t.Errorf("wrong level value: got %#v, want %#v", got, want)
 	}
 }
+
+func TestSetKey(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.NewJSONLogger(&buf)
+
+	level.Error(logger).Log("foo", "bar")
+	if want, have := `{"foo":"bar","level":"error"}`, strings.TrimSpace(buf.String()); want != have {
+		t.Errorf("want %v, have %v", want, have)
+	}
+	buf.Reset()
+
+	// Set the key to severity overwriting the default: level
+	level.SetKey("severity")
+
+	level.Error(logger).Log("foo", "bar")
+	if want, have := `{"foo":"bar","severity":"error"}`, strings.TrimSpace(buf.String()); want != have {
+		t.Errorf("want %v, have %v", want, have)
+	}
+	buf.Reset()
+
+	// Reset the key to level for other tests running next.
+	level.SetKey("level")
+}


### PR DESCRIPTION
The default `level` key is perfect for most cases. Sadly GCP's logging doesn't parse the `level` key. Instead they use `severity`. I've seen a few workarounds but would really like to see this in go-kit itself, as I need to incorporate the workaround in a dozen projects.

I've added a simple `func SetKey(k interface{}) { key = k }` to the level package. Tests are included too.

Example `main.go`:
```go
func main() {
	logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
	logger = log.With(logger,
		"ts", log.DefaultTimestampUTC,
		"caller", log.DefaultCaller,
	)

	level.SetKey("severity")
	logger = level.NewFilter(logger, level.AllowDebug())
}
```
Before using the level package **set the key once** and then **don't change it afterwards**.

I'm not a 100% sure about the implications of this change. One could possibly change the key from multiple goroutines at the same time.

Without this change I feel like using the level package doesn't have an actual impact, because log levels aren't parsed on GCP.