### PR TITLE
Use separate dimension/label for percentile

### DIFF
--- a/metrics/cloudwatch/cloudwatch.go
+++ b/metrics/cloudwatch/cloudwatch.go
@@ -138,9 +138,15 @@ func (cw *CloudWatch) Send() error {
 			{"95", 0.95},
 			{"99", 0.99},
 		} {
+			dims := makeDimensions(h.h.LabelValues()...)
+			dims = append(dims, &cloudwatch.Dimension{
+				Name:  aws.String("percentile"),
+				Value: aws.String(p.s),
+			})
+
 			datums = append(datums, &cloudwatch.MetricDatum{
-				MetricName: aws.String(fmt.Sprintf("%s_%s", name, p.s)),
-				Dimensions: makeDimensions(h.h.LabelValues()...),
+				MetricName: aws.String(name),
+				Dimensions: dims,
 				Value:      aws.Float64(h.h.Quantile(p.f)),
 				Timestamp:  aws.Time(now),
 			})

--- a/metrics/cloudwatch/cloudwatch_test.go
+++ b/metrics/cloudwatch/cloudwatch_test.go
@@ -80,6 +80,9 @@ func TestCounter(t *testing.T) {
 	if err := teststat.TestCounter(counter, valuef); err != nil {
 		t.Fatal(err)
 	}
+	if err := teststat.TestCounter(counter, valuef); err != nil {
+		t.Fatal("Fill and flush counter 2nd time: ", err)
+	}
 	if err := testDimensions(svc, name, label, value); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Currently for a Cloudwatch histogram, the percentile-values (50,90,95,99) are appended after the metrics name. 

This looks like: https://files.slack.com/files-pri/T029RQSE6-F6GHUGMNW/pasted_image_at_2017_08_01_06_09_pm.png

This makes is harder to filter for all the 50th percentiles of your metrics; In the current situation, if you plot all the 50th percentiles of metrics A, B and C, you will see the lines annotated with A_50, B_50, C_50. 
If you show all percentiles for A, you will see A_50, A_90, A_95, A_99. 

If you would have the percentiles as a separate tag, you: 
* will be able to filter more easily 
* just see A, B, C if you chose to plot 50th percentile for each metric
* just see 50, 90, 95, 99 if you plot all percentiles for A. 


