### PR TITLE
removed deprecated functions

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -91,7 +91,7 @@ func (c Client) Endpoint() endpoint.Endpoint {
 		for _, f := range c.before {
 			ctx = f(ctx, md)
 		}
-		ctx = metadata.NewContext(ctx, *md)
+		ctx = metadata.NewOutgoingContext(ctx, *md)
 
 		var header, trailer metadata.MD
 		grpcReply := reflect.New(c.grpcReply).Interface()

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -73,7 +73,7 @@ func ServerErrorLogger(logger log.Logger) ServerOption {
 // ServeGRPC implements the Handler interface.
 func (s Server) ServeGRPC(ctx oldcontext.Context, req interface{}) (oldcontext.Context, interface{}, error) {
 	// Retrieve gRPC metadata.
-	md, ok := metadata.FromContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		md = metadata.MD{}
 	}


### PR DESCRIPTION
changed `NewContext -> NewOutgoingContext` and `FromContext ->
FromIncomingContext` as described in
[metadata](https://github.com/grpc/grpc-go/blob/master/metadata/metadata.go)

resolves #597 