### PR TITLE
Make level color example work

### DIFF
--- a/log/term/example_test.go
+++ b/log/term/example_test.go
@@ -32,7 +32,11 @@ func ExampleNewLogger_levelColors() {
 			if keyvals[i] != "level" {
 				continue
 			}
-			switch keyvals[i+1] {
+			s, ok := keyvals[i+1].(fmt.Stringer)
+			if !ok {
+				return term.FgBgColor{}
+			}
+			switch s.String() {
 			case "debug":
 				return term.FgBgColor{Fg: term.DarkGray}
 			case "info":

--- a/log/term/example_test.go
+++ b/log/term/example_test.go
@@ -2,6 +2,7 @@ package term_test
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/go-kit/kit/log"


### PR DESCRIPTION
The value is typically a `*level.levelValue` so the switch over string constants will always evaluate to false.
Since the type is not exported, casting to `fmt.Stringer` seems to be the best approach. I could also change it to `fmt.Sprintf` to handle more arbitrary cases. But for the example working with the `level` package seems fine.