### PR TITLE
Fix for dogstatsd metrics with default tags and no labelValues

### DIFF
--- a/metrics/dogstatsd/dogstatsd.go
+++ b/metrics/dogstatsd/dogstatsd.go
@@ -215,7 +215,7 @@ func sampling(r float64) string {
 }
 
 func (d *Dogstatsd) tagValues(labelValues []string) string {
-	if len(labelValues) == 0 {
+	if len(labelValues) == 0 && len(d.lvs) == 0 {
 		return ""
 	}
 	if len(labelValues)%2 != 0 {


### PR DESCRIPTION
Only omit dogstatsd tag values if there are no labelValues AND there are no default tags.