### PR TITLE
Fix spelling of deregisters

### DIFF
--- a/sd/endpointer.go
+++ b/sd/endpointer.go
@@ -78,7 +78,7 @@ func (de *DefaultEndpointer) receive() {
 	}
 }
 
-// Close de-registeres DefaultEndpointer from the Instancer and stops the internal go-routine.
+// Close deregisters DefaultEndpointer from the Instancer and stops the internal go-routine.
 func (de *DefaultEndpointer) Close() {
 	de.instancer.Deregister(de.ch)
 	close(de.ch)


### PR DESCRIPTION
https://goreportcard.com/report/github.com/go-kit/kit#misspell

https://en.wiktionary.org/wiki/deregister