### PR TITLE
go1.9 and tip only, to support latest coreos/etcd/client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,5 @@ script:
   - ./coveralls.bash
 
 go:
-  - 1.7.x
-  - 1.8.x
+  - 1.9.x
   - tip

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   pre:
     - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
     - sudo rm -rf /usr/local/go
-    - curl -sSL https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz | sudo tar xz -C /usr/local
+    - curl -sSL https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz | sudo tar xz -C /usr/local
   services:
     - docker
 

--- a/update_deps.bash
+++ b/update_deps.bash
@@ -20,7 +20,7 @@ function go_get_update {
 	while read d
 	do
 		echo $d
-		go get -u $d
+		go get -u $d || echo "failed, trying again with master" && cd $GOPATH/src/$d && git checkout master && go get -u $d
 	done
 }
 


### PR DESCRIPTION
Basically, we can only support Go 1.9 (and tip) forward on master, unless we opt-in to some really obnoxious contortions re: package context. Closes #612.