### PR TITLE
Example stringsvc updated to reflect gokit.io

### DIFF
--- a/examples/stringsvc1/main.go
+++ b/examples/stringsvc1/main.go
@@ -18,6 +18,7 @@ type StringService interface {
 	Count(string) int
 }
 
+// stringService is a concrete implementation of StringService
 type stringService struct{}
 
 func (stringService) Uppercase(s string) (string, error) {
@@ -31,6 +32,48 @@ func (stringService) Count(s string) int {
 	return len(s)
 }
 
+// ErrEmpty is returned when an input string is empty.
+var ErrEmpty = errors.New("empty string")
+
+// For each method, we define request and response structs
+type uppercaseRequest struct {
+	S string `json:"s"`
+}
+
+type uppercaseResponse struct {
+	V   string `json:"v"`
+	Err string `json:"err,omitempty"` // errors don't define JSON marshaling
+}
+
+type countRequest struct {
+	S string `json:"s"`
+}
+
+type countResponse struct {
+	V int `json:"v"`
+}
+
+// Endpoints are a primary abstraction in go-kit. An endpoint represents a single RPC (method in our service interface)
+func makeUppercaseEndpoint(svc StringService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(uppercaseRequest)
+		v, err := svc.Uppercase(req.S)
+		if err != nil {
+			return uppercaseResponse{v, err.Error()}, nil
+		}
+		return uppercaseResponse{v, ""}, nil
+	}
+}
+
+func makeCountEndpoint(svc StringService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(countRequest)
+		v := svc.Count(req.S)
+		return countResponse{v}, nil
+	}
+}
+
+// Transports expose the service to the network. In this first example we utilize JSON over HTTP.
 func main() {
 	svc := stringService{}
 
@@ -49,25 +92,6 @@ func main() {
 	http.Handle("/uppercase", uppercaseHandler)
 	http.Handle("/count", countHandler)
 	log.Fatal(http.ListenAndServe(":8080", nil))
-}
-
-func makeUppercaseEndpoint(svc StringService) endpoint.Endpoint {
-	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(uppercaseRequest)
-		v, err := svc.Uppercase(req.S)
-		if err != nil {
-			return uppercaseResponse{v, err.Error()}, nil
-		}
-		return uppercaseResponse{v, ""}, nil
-	}
-}
-
-func makeCountEndpoint(svc StringService) endpoint.Endpoint {
-	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(countRequest)
-		v := svc.Count(req.S)
-		return countResponse{v}, nil
-	}
 }
 
 func decodeUppercaseRequest(_ context.Context, r *http.Request) (interface{}, error) {
@@ -89,23 +113,3 @@ func decodeCountRequest(_ context.Context, r *http.Request) (interface{}, error)
 func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	return json.NewEncoder(w).Encode(response)
 }
-
-type uppercaseRequest struct {
-	S string `json:"s"`
-}
-
-type uppercaseResponse struct {
-	V   string `json:"v"`
-	Err string `json:"err,omitempty"` // errors don't define JSON marshaling
-}
-
-type countRequest struct {
-	S string `json:"s"`
-}
-
-type countResponse struct {
-	V int `json:"v"`
-}
-
-// ErrEmpty is returned when an input string is empty.
-var ErrEmpty = errors.New("empty string")

--- a/examples/stringsvc1/main.go
+++ b/examples/stringsvc1/main.go
@@ -14,21 +14,21 @@ import (
 
 // StringService provides operations on strings.
 type StringService interface {
-	Uppercase(string) (string, error)
-	Count(string) int
+	Uppercase(context.Context, string) (string, error)
+	Count(context.Context, string) int
 }
 
 // stringService is a concrete implementation of StringService
 type stringService struct{}
 
-func (stringService) Uppercase(s string) (string, error) {
+func (stringService) Uppercase(_ context.Context, s string) (string, error) {
 	if s == "" {
 		return "", ErrEmpty
 	}
 	return strings.ToUpper(s), nil
 }
 
-func (stringService) Count(s string) int {
+func (stringService) Count(_ context.Context, s string) int {
 	return len(s)
 }
 
@@ -57,7 +57,7 @@ type countResponse struct {
 func makeUppercaseEndpoint(svc StringService) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(uppercaseRequest)
-		v, err := svc.Uppercase(req.S)
+		v, err := svc.Uppercase(ctx, req.S)
 		if err != nil {
 			return uppercaseResponse{v, err.Error()}, nil
 		}
@@ -68,7 +68,7 @@ func makeUppercaseEndpoint(svc StringService) endpoint.Endpoint {
 func makeCountEndpoint(svc StringService) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(countRequest)
-		v := svc.Count(req.S)
+		v := svc.Count(ctx, req.S)
 		return countResponse{v}, nil
 	}
 }


### PR DESCRIPTION
This is a documentation update pull request to remove discrepancies between the example [stringsvc1](https://github.com/go-kit/kit/tree/master/examples/stringsvc1) and the tutorial on the [gokit website](https://gokit.io/examples/stringsvc.html ). Just trying to make the intro to go-kit as simple as possible. 