### PR TITLE
Export makeEndpoint in kitgen

### DIFF
--- a/cmd/kitgen/method.go
+++ b/cmd/kitgen/method.go
@@ -143,7 +143,7 @@ func (m method) encoderFunc() ast.Decl {
 }
 
 func (m method) endpointMakerName() *ast.Ident {
-	return id("make" + m.name.Name + "Endpoint")
+	return id("Make" + m.name.Name + "Endpoint")
 }
 
 func (m method) requestStruct() ast.Decl {

--- a/cmd/kitgen/testdata/anonfields/default/endpoints/endpoints.go
+++ b/cmd/kitgen/testdata/anonfields/default/endpoints/endpoints.go
@@ -15,7 +15,7 @@ type FooResponse struct {
 	Err error
 }
 
-func makeFooEndpoint(s service.Service) endpoint.Endpoint {
+func MakeFooEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(FooRequest)
 		i, err := s.Foo(ctx, req.I, req.S)

--- a/cmd/kitgen/testdata/anonfields/flat/gokit.go
+++ b/cmd/kitgen/testdata/anonfields/flat/gokit.go
@@ -23,7 +23,7 @@ type FooResponse struct {
 	Err error
 }
 
-func makeFooEndpoint(s Service) endpoint.Endpoint {
+func MakeFooEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(FooRequest)
 		i, err := s.Foo(ctx, req.I, req.S)

--- a/cmd/kitgen/testdata/foo/default/endpoints/endpoints.go
+++ b/cmd/kitgen/testdata/foo/default/endpoints/endpoints.go
@@ -15,7 +15,7 @@ type BarResponse struct {
 	Err error
 }
 
-func makeBarEndpoint(f service.FooService) endpoint.Endpoint {
+func MakeBarEndpoint(f service.FooService) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(BarRequest)
 		s, err := f.Bar(ctx, req.I, req.S)

--- a/cmd/kitgen/testdata/foo/flat/gokit.go
+++ b/cmd/kitgen/testdata/foo/flat/gokit.go
@@ -23,7 +23,7 @@ type BarResponse struct {
 	Err error
 }
 
-func makeBarEndpoint(f FooService) endpoint.Endpoint {
+func MakeBarEndpoint(f FooService) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(BarRequest)
 		s, err := f.Bar(ctx, req.I, req.S)

--- a/cmd/kitgen/testdata/profilesvc/default/endpoints/endpoints.go
+++ b/cmd/kitgen/testdata/profilesvc/default/endpoints/endpoints.go
@@ -13,7 +13,7 @@ type PostProfileResponse struct {
 	Err error
 }
 
-func makePostProfileEndpoint(s service.Service) endpoint.Endpoint {
+func MakePostProfileEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(PostProfileRequest)
 		err := s.PostProfile(ctx, req.P)
@@ -29,7 +29,7 @@ type GetProfileResponse struct {
 	Err error
 }
 
-func makeGetProfileEndpoint(s service.Service) endpoint.Endpoint {
+func MakeGetProfileEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(GetProfileRequest)
 		P, err := s.GetProfile(ctx, req.Id)
@@ -45,7 +45,7 @@ type PutProfileResponse struct {
 	Err error
 }
 
-func makePutProfileEndpoint(s service.Service) endpoint.Endpoint {
+func MakePutProfileEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(PutProfileRequest)
 		err := s.PutProfile(ctx, req.Id, req.P)
@@ -61,7 +61,7 @@ type PatchProfileResponse struct {
 	Err error
 }
 
-func makePatchProfileEndpoint(s service.Service) endpoint.Endpoint {
+func MakePatchProfileEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(PatchProfileRequest)
 		err := s.PatchProfile(ctx, req.Id, req.P)
@@ -76,7 +76,7 @@ type DeleteProfileResponse struct {
 	Err error
 }
 
-func makeDeleteProfileEndpoint(s service.Service) endpoint.Endpoint {
+func MakeDeleteProfileEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(DeleteProfileRequest)
 		err := s.DeleteProfile(ctx, req.Id)
@@ -92,7 +92,7 @@ type GetAddressesResponse struct {
 	Err error
 }
 
-func makeGetAddressesEndpoint(s service.Service) endpoint.Endpoint {
+func MakeGetAddressesEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(GetAddressesRequest)
 		slice1, err := s.GetAddresses(ctx, req.ProfileID)
@@ -109,7 +109,7 @@ type GetAddressResponse struct {
 	Err error
 }
 
-func makeGetAddressEndpoint(s service.Service) endpoint.Endpoint {
+func MakeGetAddressEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(GetAddressRequest)
 		A, err := s.GetAddress(ctx, req.ProfileID, req.AddressID)
@@ -125,7 +125,7 @@ type PostAddressResponse struct {
 	Err error
 }
 
-func makePostAddressEndpoint(s service.Service) endpoint.Endpoint {
+func MakePostAddressEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(PostAddressRequest)
 		err := s.PostAddress(ctx, req.ProfileID, req.A)
@@ -141,7 +141,7 @@ type DeleteAddressResponse struct {
 	Err error
 }
 
-func makeDeleteAddressEndpoint(s service.Service) endpoint.Endpoint {
+func MakeDeleteAddressEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(DeleteAddressRequest)
 		err := s.DeleteAddress(ctx, req.ProfileID, req.AddressID)

--- a/cmd/kitgen/testdata/profilesvc/flat/gokit.go
+++ b/cmd/kitgen/testdata/profilesvc/flat/gokit.go
@@ -30,7 +30,7 @@ type PostProfileResponse struct {
 	Err error
 }
 
-func makePostProfileEndpoint(s Service) endpoint.Endpoint {
+func MakePostProfileEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(PostProfileRequest)
 		err := s.PostProfile(ctx, req.P)
@@ -49,7 +49,7 @@ type GetProfileResponse struct {
 	Err error
 }
 
-func makeGetProfileEndpoint(s Service) endpoint.Endpoint {
+func MakeGetProfileEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(GetProfileRequest)
 		P, err := s.GetProfile(ctx, req.Id)
@@ -68,7 +68,7 @@ type PutProfileResponse struct {
 	Err error
 }
 
-func makePutProfileEndpoint(s Service) endpoint.Endpoint {
+func MakePutProfileEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(PutProfileRequest)
 		err := s.PutProfile(ctx, req.Id, req.P)
@@ -87,7 +87,7 @@ type PatchProfileResponse struct {
 	Err error
 }
 
-func makePatchProfileEndpoint(s Service) endpoint.Endpoint {
+func MakePatchProfileEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(PatchProfileRequest)
 		err := s.PatchProfile(ctx, req.Id, req.P)
@@ -105,7 +105,7 @@ type DeleteProfileResponse struct {
 	Err error
 }
 
-func makeDeleteProfileEndpoint(s Service) endpoint.Endpoint {
+func MakeDeleteProfileEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(DeleteProfileRequest)
 		err := s.DeleteProfile(ctx, req.Id)
@@ -124,7 +124,7 @@ type GetAddressesResponse struct {
 	Err error
 }
 
-func makeGetAddressesEndpoint(s Service) endpoint.Endpoint {
+func MakeGetAddressesEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(GetAddressesRequest)
 		slice1, err := s.GetAddresses(ctx, req.ProfileID)
@@ -144,7 +144,7 @@ type GetAddressResponse struct {
 	Err error
 }
 
-func makeGetAddressEndpoint(s Service) endpoint.Endpoint {
+func MakeGetAddressEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(GetAddressRequest)
 		A, err := s.GetAddress(ctx, req.ProfileID, req.AddressID)
@@ -163,7 +163,7 @@ type PostAddressResponse struct {
 	Err error
 }
 
-func makePostAddressEndpoint(s Service) endpoint.Endpoint {
+func MakePostAddressEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(PostAddressRequest)
 		err := s.PostAddress(ctx, req.ProfileID, req.A)
@@ -182,7 +182,7 @@ type DeleteAddressResponse struct {
 	Err error
 }
 
-func makeDeleteAddressEndpoint(s Service) endpoint.Endpoint {
+func MakeDeleteAddressEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(DeleteAddressRequest)
 		err := s.DeleteAddress(ctx, req.ProfileID, req.AddressID)

--- a/cmd/kitgen/testdata/stringservice/default/endpoints/endpoints.go
+++ b/cmd/kitgen/testdata/stringservice/default/endpoints/endpoints.go
@@ -15,7 +15,7 @@ type ConcatResponse struct {
 	Err error
 }
 
-func makeConcatEndpoint(s service.Service) endpoint.Endpoint {
+func MakeConcatEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(ConcatRequest)
 		string1, err := s.Concat(ctx, req.A, req.B)
@@ -30,7 +30,7 @@ type CountResponse struct {
 	Count int
 }
 
-func makeCountEndpoint(s service.Service) endpoint.Endpoint {
+func MakeCountEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(CountRequest)
 		count := s.Count(ctx, req.S)

--- a/cmd/kitgen/testdata/stringservice/flat/gokit.go
+++ b/cmd/kitgen/testdata/stringservice/flat/gokit.go
@@ -23,7 +23,7 @@ type ConcatResponse struct {
 	Err error
 }
 
-func makeConcatEndpoint(s Service) endpoint.Endpoint {
+func MakeConcatEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(ConcatRequest)
 		string1, err := s.Concat(ctx, req.A, req.B)
@@ -41,7 +41,7 @@ type CountResponse struct {
 	Count int
 }
 
-func makeCountEndpoint(s Service) endpoint.Endpoint {
+func MakeCountEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(CountRequest)
 		count := s.Count(ctx, req.S)

--- a/cmd/kitgen/testdata/underscores/default/endpoints/endpoints.go
+++ b/cmd/kitgen/testdata/underscores/default/endpoints/endpoints.go
@@ -14,7 +14,7 @@ type FooResponse struct {
 	Err error
 }
 
-func makeFooEndpoint(s service.Service) endpoint.Endpoint {
+func MakeFooEndpoint(s service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(FooRequest)
 		i, err := s.Foo(ctx, req.I)

--- a/cmd/kitgen/testdata/underscores/flat/gokit.go
+++ b/cmd/kitgen/testdata/underscores/flat/gokit.go
@@ -22,7 +22,7 @@ type FooResponse struct {
 	Err error
 }
 
-func makeFooEndpoint(s Service) endpoint.Endpoint {
+func MakeFooEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(FooRequest)
 		i, err := s.Foo(ctx, req.I)


### PR DESCRIPTION
This PR addresses a comment regarding exported `makeEndpoint` function in #639: with this fix, we will make those function exported which allow to use them, for example like that: 

```
package main

import (
	"net/http"
	"os"

	kit_http "test/foo/http"

	"test/foo/endpoints"
	"test/foo/service"

	"github.com/go-kit/kit/log"
)

func main() {
	logger := log.NewLogfmtLogger(os.Stderr)

	var svc service.Service
	svc = service.ServiceStruct{}

	e := endpoints.Endpoints{}

	e.Concat = endpoints.MakeConcatEndpoint(svc)
	e.Sum = endpoints.MakeSumEndpoint(svc)

	handler := kit_http.NewHTTPHandler(e)

	http.Handle("/", handler)
	logger.Log("msg", "HTTP", "addr", ":8080")
	logger.Log("err", http.ListenAndServe(":8080", nil))
}
```
