### PR TITLE
Add support for Twirp as a Transport

### DIFF
--- a/transport/twirp/client.go
+++ b/transport/twirp/client.go
@@ -6,21 +6,18 @@ import (
 	"github.com/go-kit/kit/endpoint"
 )
 
-// rpcFn is a simple type to represent an RPC method on the Twirp client.
-type rpcFn func(context.Context, interface{}) (interface{}, error)
-
 // Client wraps a Twirp client and provides a method that implements endpoint.Endpoint.
 type Client struct {
-	rpcFn  rpcFn
-	enc    EncodeRequestFunc
-	dec    DecodeResponseFunc
-	before []ClientRequestFunc
-	after  []ClientResponseFunc
+	rpcFn     endpoint.Endpoint
+	enc       EncodeRequestFunc
+	dec       DecodeResponseFunc
+	before    []ClientRequestFunc
+	after     []ClientResponseFunc
 }
 
 // NewClient constructs a usable Client for a single remote method.
 func NewClient(
-	rpcFn rpcFn,
+	rpcFn endpoint.Endpoint,
 	enc EncodeRequestFunc,
 	dec DecodeResponseFunc,
 	options ...ClientOption,

--- a/transport/twirp/client.go
+++ b/transport/twirp/client.go
@@ -1,0 +1,103 @@
+package twirp
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+// rpcFn is a simple type to represent an RPC method on the Twirp client.
+type rpcFn func(context.Context, interface{}) (interface{}, error)
+
+// Client wraps a Twirp client and provides a method that implements endpoint.Endpoint.
+type Client struct {
+	rpcFn  rpcFn
+	enc    EncodeRequestFunc
+	dec    DecodeResponseFunc
+	before []ClientRequestFunc
+	after  []ClientResponseFunc
+}
+
+// NewClient constructs a usable Client for a single remote method.
+func NewClient(
+	rpcFn rpcFn,
+	enc EncodeRequestFunc,
+	dec DecodeResponseFunc,
+	options ...ClientOption,
+) *Client {
+	c := &Client{
+		rpcFn:  rpcFn,
+		enc:    enc,
+		dec:    dec,
+		before: []ClientRequestFunc{},
+		after:  []ClientResponseFunc{},
+	}
+	for _, option := range options {
+		option(c)
+	}
+	return c
+}
+
+// ClientOption sets an optional parameter for clients.
+type ClientOption func(*Client)
+
+// ClientBefore sets the ClientRequestFunc that are applied to the outgoing HTTP
+// request before it's invoked.
+func ClientBefore(before ...ClientRequestFunc) ClientOption {
+	return func(c *Client) { c.before = append(c.before, before...) }
+}
+
+// ClientAfter sets the ClientResponseFuncs applied to the incoming HTTP
+// request prior to it being decoded. This is useful for obtaining anything off
+// of the response and adding onto the context prior to decoding.
+func ClientAfter(after ...ClientResponseFunc) ClientOption {
+	return func(c *Client) { c.after = append(c.after, after...) }
+}
+
+// Endpoint returns a usable endpoint that invokes the remote endpoint.
+func (c Client) Endpoint() endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		// Encode
+		var (
+			req interface{}
+			err error
+		)
+		req, err = c.enc(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		// Process ClientRequestFunctions
+		for _, f := range c.before {
+			ctx, err = f(ctx)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// Call the actual RPC method
+		resp, err := c.rpcFn(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+
+		// Process ClientResponseFunctions
+		for _, f := range c.after {
+			ctx, err = f(ctx)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// Decode
+		response, err := c.dec(ctx, resp)
+		if err != nil {
+			return nil, err
+		}
+
+		return response, nil
+	}
+}

--- a/transport/twirp/doc.go
+++ b/transport/twirp/doc.go
@@ -1,0 +1,2 @@
+// Package twirp provides a general purpose Twirp binding for endpoints.
+package twirp

--- a/transport/twirp/encode_decode.go
+++ b/transport/twirp/encode_decode.go
@@ -1,0 +1,29 @@
+package twirp
+
+import (
+	"context"
+)
+
+// DecodeRequestFunc extracts a user-domain request object from a Twirp request.
+// It's designed to be used in Twirp servers, for server-side endpoints. One
+// straightforward DecodeRequestFunc could be something that decodes from the
+// Twirp request message to the concrete request type.
+type DecodeRequestFunc func(context.Context, interface{}) (request interface{}, err error)
+
+// EncodeRequestFunc encodes the passed request object into the Twirp request
+// object. It's designed to be used in Twirp clients, for client-side endpoints.
+// One straightforward EncodeRequestFunc could something that encodes the object
+// directly to the Twirp request message.
+type EncodeRequestFunc func(context.Context, interface{}) (request interface{}, err error)
+
+// EncodeResponseFunc encodes the passed response object to the Twirp response
+// message. It's designed to be used in Twirp servers, for server-side endpoints.
+// One straightforward EncodeResponseFunc could be something that encodes the
+// object directly to the Twirp response message.
+type EncodeResponseFunc func(context.Context, interface{}) (response interface{}, err error)
+
+// DecodeResponseFunc extracts a user-domain response object from a Twirp
+// response object. It's designed to be used in Twirp clients, for client-side
+// endpoints. One straightforward DecodeResponseFunc could be something that
+// decodes from the Twirp response message to the concrete response type.
+type DecodeResponseFunc func(context.Context, interface{}) (response interface{}, err error)

--- a/transport/twirp/request_response_funcs.go
+++ b/transport/twirp/request_response_funcs.go
@@ -2,40 +2,30 @@ package twirp
 
 import (
 	"context"
-	"github.com/twitchtv/twirp"
 	"net/http"
 )
 
 // ClientRequestFunc may modify the context. ClientRequestFuncs are executed
 // after creating the request but prior to sending the Twirp request to
 // the server.
-type ClientRequestFunc func(context.Context) (context.Context, error)
+type ClientRequestFunc func(context.Context, *http.Header) context.Context
 
 // ServerRequestFunc may take information from the context. ServerRequestFuncs are
 // executed prior to invoking the endpoint.
-type ServerRequestFunc func(context.Context) context.Context
+type ServerRequestFunc func(context.Context, http.Header) context.Context
 
 // ServerResponseFunc may modify the context. ServerResponseFuncs are only executed in
 // servers, after invoking the endpoint but prior to writing a response.
-type ServerResponseFunc func(context.Context) (context.Context, error)
+type ServerResponseFunc func(context.Context) context.Context
 
 // ClientResponseFunc may take information from the context. ClientResponseFuncs are only executed in
 // clients, after a request has been made, but prior to it being decoded.
-type ClientResponseFunc func(context.Context) (context.Context, error)
+type ClientResponseFunc func(context.Context) context.Context
 
-// SetResponseHeader returns a ServerResponseFunc that sets the given header.
-func SetResponseHeader(key, val string) ServerResponseFunc {
-	return func(ctx context.Context) (context.Context, error) {
-		err := twirp.SetHTTPResponseHeader(ctx, key, val)
-		return ctx, err
-	}
-}
-
-// SetRequestHeader returns a RequestFunc that sets the given header.
+// SetRequestHeader returns a RequestFunc that sets the given header. It uses the standard net/http/header Add function and will append the specified value if others already exist.
 func SetRequestHeader(key, val string) ClientRequestFunc {
-	h := &http.Header{}
-	h.Set(key, val)
-	return func(ctx context.Context) (context.Context, error) {
-		return twirp.WithHTTPRequestHeaders(ctx, *h)
+	return func(ctx context.Context, header *http.Header) context.Context {
+		header.Add(key, val)
+		return ctx
 	}
 }

--- a/transport/twirp/request_response_funcs.go
+++ b/transport/twirp/request_response_funcs.go
@@ -1,0 +1,41 @@
+package twirp
+
+import (
+	"context"
+	"github.com/twitchtv/twirp"
+	"net/http"
+)
+
+// ClientRequestFunc may modify the context. ClientRequestFuncs are executed
+// after creating the request but prior to sending the Twirp request to
+// the server.
+type ClientRequestFunc func(context.Context) (context.Context, error)
+
+// ServerRequestFunc may take information from the context. ServerRequestFuncs are
+// executed prior to invoking the endpoint.
+type ServerRequestFunc func(context.Context) context.Context
+
+// ServerResponseFunc may modify the context. ServerResponseFuncs are only executed in
+// servers, after invoking the endpoint but prior to writing a response.
+type ServerResponseFunc func(context.Context) (context.Context, error)
+
+// ClientResponseFunc may take information from the context. ClientResponseFuncs are only executed in
+// clients, after a request has been made, but prior to it being decoded.
+type ClientResponseFunc func(context.Context) (context.Context, error)
+
+// SetResponseHeader returns a ServerResponseFunc that sets the given header.
+func SetResponseHeader(key, val string) ServerResponseFunc {
+	return func(ctx context.Context) (context.Context, error) {
+		err := twirp.SetHTTPResponseHeader(ctx, key, val)
+		return ctx, err
+	}
+}
+
+// SetRequestHeader returns a RequestFunc that sets the given header.
+func SetRequestHeader(key, val string) ClientRequestFunc {
+	h := &http.Header{}
+	h.Set(key, val)
+	return func(ctx context.Context) (context.Context, error) {
+		return twirp.WithHTTPRequestHeaders(ctx, *h)
+	}
+}

--- a/transport/twirp/server.go
+++ b/transport/twirp/server.go
@@ -1,0 +1,105 @@
+package twirp
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/log"
+)
+
+// Handler which should be called from the Twirp binding of the service
+// implementation. The incoming request parameter, and returned response
+// parameter, are both Twirp types, not user-domain.
+type Handler interface {
+	ServeTwirp(ctx context.Context, request interface{}) (context.Context, interface{}, error)
+}
+
+// Server wraps an endpoint and implements Twirp Handler.
+type Server struct {
+	e      endpoint.Endpoint
+	dec    DecodeRequestFunc
+	enc    EncodeResponseFunc
+	before []ServerRequestFunc
+	after  []ServerResponseFunc
+	logger log.Logger
+}
+
+// NewServer constructs a new server, which implements wraps the provided
+// endpoint and implements the Handler interface. Consumers should write
+// bindings that adapt the concrete Twirp methods from their compiled protobuf
+// definitions to individual handlers. Request and response objects are from the
+// caller business domain, not Twirp request and reply types.
+func NewServer(
+	e endpoint.Endpoint,
+	dec DecodeRequestFunc,
+	enc EncodeResponseFunc,
+	options ...ServerOption,
+) *Server {
+	s := &Server{
+		e:      e,
+		dec:    dec,
+		enc:    enc,
+		logger: log.NewNopLogger(),
+	}
+	for _, option := range options {
+		option(s)
+	}
+	return s
+}
+
+// ServerOption sets an optional parameter for servers.
+type ServerOption func(*Server)
+
+// ServerBefore functions are executed on the HTTP request object before the
+// request is decoded.
+func ServerBefore(before ...ServerRequestFunc) ServerOption {
+	return func(s *Server) { s.before = append(s.before, before...) }
+}
+
+// ServerAfter functions are executed on the HTTP response writer after the
+// endpoint is invoked, but before anything is written to the client.
+func ServerAfter(after ...ServerResponseFunc) ServerOption {
+	return func(s *Server) { s.after = append(s.after, after...) }
+}
+
+// ServerErrorLogger is used to log non-terminal errors. By default, no errors
+// are logged.
+func ServerErrorLogger(logger log.Logger) ServerOption {
+	return func(s *Server) { s.logger = logger }
+}
+
+// ServeTwirp implements the Handler interface.
+func (s Server) ServeTwirp(ctx context.Context, req interface{}) (context.Context, interface{}, error) {
+
+	// Process ServerRequestFunctions
+	for _, f := range s.before {
+		ctx = f(ctx)
+	}
+	request, err := s.dec(ctx, req)
+	if err != nil {
+		s.logger.Log("err", err)
+		return ctx, nil, err
+	}
+
+	response, err := s.e(ctx, request)
+	if err != nil {
+		s.logger.Log("err", err)
+		return ctx, nil, err
+	}
+
+	// Process ServerResponseFunctions
+	for _, f := range s.after {
+		ctx, err = f(ctx)
+		if err != nil {
+			return ctx, nil, err
+		}
+	}
+
+	twirpResp, err := s.enc(ctx, response)
+	if err != nil {
+		s.logger.Log("err", err)
+		return ctx, nil, err
+	}
+
+	return ctx, twirpResp, nil
+}


### PR DESCRIPTION
Twirp (https://github.com/twitchtv/twirp) is an RPC system that works
over HTTP/1.1 using either JSON or Protobuf. It's leverages protobuf for
generating servers and clients.

I still need to do a few things, but wanted to get initial feedback. 

## Todo
- [ ] Add tests (planning to mirror what GRPC has)
- [ ] Add Twirp support to addsvc example
- [ ] Add documentation