### PR TITLE
Enable using counters as the other types

### DIFF
--- a/metrics/convert/convert.go
+++ b/metrics/convert/convert.go
@@ -88,3 +88,48 @@ func (gc gaugeCounter) With(labelValues ...string) metrics.Counter {
 func (gc gaugeCounter) Add(delta float64) {
 	gc.g.Set(delta)
 }
+
+type histogramGauge struct {
+	h metrics.Histogram
+}
+
+// NewHistogramAsGauge returns a Gauge that actually writes the
+// value on an underlying Histogram
+func NewHistogramAsGauge(h metrics.Histogram) metrics.Gauge {
+	return histogramGauge{h}
+}
+
+// With implements Gauge.
+func (hg histogramGauge) With(labelValues ...string) metrics.Gauge {
+	return histogramGauge{hg.h.With(labelValues...)}
+}
+
+// Set implements Gauge.
+func (hg histogramGauge) Set(value float64) {
+	hg.h.Observe(value)
+}
+
+// Add implements metrics.Gauge.
+func (hg histogramGauge) Add(delta float64) {
+	hg.h.Observe(delta)
+}
+
+type gaugeHistogram struct {
+	g metrics.Gauge
+}
+
+// NewGaugeAsHistogram returns a Histogram that actually writes the
+// value on an underlying Gauge
+func NewGaugeAsHistogram(g metrics.Gauge) metrics.Histogram {
+	return gaugeHistogram{g}
+}
+
+// With implements Histogram.
+func (gh gaugeHistogram) With(labelValues ...string) metrics.Histogram {
+	return gaugeHistogram{gh.g.With(labelValues...)}
+}
+
+// Observe implements histogram.
+func (gh gaugeHistogram) Observe(value float64) {
+	gh.g.Set(value)
+}

--- a/metrics/convert/convert.go
+++ b/metrics/convert/convert.go
@@ -1,0 +1,90 @@
+// Package convert provides a way to use Counters, Histograms, or Gauges
+// as one of the other types
+package convert
+
+import "github.com/go-kit/kit/metrics"
+
+type counterHistogram struct {
+	c metrics.Counter
+}
+
+// NewCounterAsHistogram returns a Histogram that actually writes the
+// value on an underlying Counter
+func NewCounterAsHistogram(c metrics.Counter) metrics.Histogram {
+	return counterHistogram{c}
+}
+
+// With implements Histogram.
+func (ch counterHistogram) With(labelValues ...string) metrics.Histogram {
+	return counterHistogram{ch.c.With(labelValues...)}
+}
+
+// Observe implements histogram.
+func (ch counterHistogram) Observe(value float64) {
+	ch.c.Add(value)
+}
+
+type histogramCounter struct {
+	h metrics.Histogram
+}
+
+// NewHistogramAsCounter returns a Counter that actually writes the
+// value on an underlying Histogram
+func NewHistogramAsCounter(h metrics.Histogram) metrics.Counter {
+	return histogramCounter{h}
+}
+
+// With implements Counter.
+func (hc histogramCounter) With(labelValues ...string) metrics.Counter {
+	return histogramCounter{hc.h.With(labelValues...)}
+}
+
+// Add implements Counter.
+func (hc histogramCounter) Add(delta float64) {
+	hc.h.Observe(delta)
+}
+
+type counterGauge struct {
+	c metrics.Counter
+}
+
+// NewCounterAsGauge returns a Gauge that actually writes the
+// value on an underlying Counter
+func NewCounterAsGauge(c metrics.Counter) metrics.Gauge {
+	return counterGauge{c}
+}
+
+// With implements Gauge.
+func (cg counterGauge) With(labelValues ...string) metrics.Gauge {
+	return counterGauge{cg.c.With(labelValues...)}
+}
+
+// Set implements Gauge.
+func (cg counterGauge) Set(value float64) {
+	cg.c.Add(value)
+}
+
+// Add implements metrics.Gauge.
+func (cg counterGauge) Add(delta float64) {
+	cg.c.Add(delta)
+}
+
+type gaugeCounter struct {
+	g metrics.Gauge
+}
+
+// NewGaugeAsCounter returns a Counter that actually writes the
+// value on an underlying Gauge
+func NewGaugeAsCounter(g metrics.Gauge) metrics.Counter {
+	return gaugeCounter{g}
+}
+
+// With implements Counter.
+func (gc gaugeCounter) With(labelValues ...string) metrics.Counter {
+	return gaugeCounter{gc.g.With(labelValues...)}
+}
+
+// Add implements Counter.
+func (gc gaugeCounter) Add(delta float64) {
+	gc.g.Set(delta)
+}

--- a/metrics/convert/convert_test.go
+++ b/metrics/convert/convert_test.go
@@ -42,3 +42,21 @@ func TestCounterGaugeConversion(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestHistogramGaugeConversion(t *testing.T) {
+	name := "my_histogram"
+	h := generic.NewHistogram(name, 50)
+	g := NewHistogramAsGauge(h)
+	top := NewGaugeAsHistogram(g).With("label", "histogram").(gaugeHistogram)
+	mid := top.g.(histogramGauge)
+	low := mid.h.(*generic.Histogram)
+	if want, have := name, low.Name; want != have {
+		t.Errorf("Name: want %q, have %q", want, have)
+	}
+	quantiles := func() (float64, float64, float64, float64) {
+		return low.Quantile(0.50), low.Quantile(0.90), low.Quantile(0.95), low.Quantile(0.99)
+	}
+	if err := teststat.TestHistogram(top, quantiles, 0.01); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/metrics/convert/convert_test.go
+++ b/metrics/convert/convert_test.go
@@ -1,0 +1,44 @@
+package convert
+
+// This is package generic_test in order to get around an import cycle: this
+// package imports teststat to do its testing, but package teststat imports
+// generic to use its Histogram in the Quantiles helper function.
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/metrics/generic"
+	"github.com/go-kit/kit/metrics/teststat"
+)
+
+func TestCounterHistogramConversion(t *testing.T) {
+	name := "my_counter"
+	c := generic.NewCounter(name)
+	h := NewCounterAsHistogram(c)
+	top := NewHistogramAsCounter(h).With("label", "counter").(histogramCounter)
+	mid := top.h.(counterHistogram)
+	low := mid.c.(*generic.Counter)
+	if want, have := name, low.Name; want != have {
+		t.Errorf("Name: want %q, have %q", want, have)
+	}
+	value := func() float64 { return low.Value() }
+	if err := teststat.TestCounter(top, value); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCounterGaugeConversion(t *testing.T) {
+	name := "my_counter"
+	c := generic.NewCounter(name)
+	g := NewCounterAsGauge(c)
+	top := NewGaugeAsCounter(g).With("label", "counter").(gaugeCounter)
+	mid := top.g.(counterGauge)
+	low := mid.c.(*generic.Counter)
+	if want, have := name, low.Name; want != have {
+		t.Errorf("Name: want %q, have %q", want, have)
+	}
+	value := func() float64 { return low.Value() }
+	if err := teststat.TestCounter(top, value); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
As a potential answer to my issue #660 ...

Background: I see that the current implementation for `cloudwatch` tries to be helpful at write-time for the metrics: for Histograms it does the aggregation in memory and spits out a couple of entries when sending up to AWS; for Gauges it uses the latest entry in the series per attempt to write.

But, to my understanding, this is actually contrary to how to use CloudWatch. I believe you just send the raw entries up to the server, and Counter/Gauge/Histogram meaning is applied to the data sets at read-time.

So, the rawest ability to send all the data in the `cloudwatch` package is via using the Counter type. But, I would _like_ to keep the contextual intent provided by the go-kit abstractions. ("This value will be read as a gauge."; "This value will be read as a latency."; etc...)

So, this PR represents my attempt at putting Histogram/Gauge decoration on the Counter workhorse. I did it as its own `convert` package (spiritual sibling to the `discard` and `multi` packages) that can be applied to any of the other types, since I don't know if any of them suffer from similar usage/implementation patterns.

So far I've only implemented Counter<->Histogram and Counter<->Gauge. (Leaving out Histogram<->Gauge because I'm not sure if it's a good idea, or if I'm just blindly going for "completeness".)

My main question: does this look like a valid approach? Am I polluting go-kit while trying to address my personal corner case?