### PR TITLE
zipkin server middleware: set error tag on http error status codes

### DIFF
--- a/tracing/zipkin/http.go
+++ b/tracing/zipkin/http.go
@@ -193,6 +193,10 @@ func HTTPServerTrace(tracer *zipkin.Tracer, options ...TracerOption) kithttp.Ser
 		func(ctx context.Context, code int, r *http.Request) {
 			if span := zipkin.SpanFromContext(ctx); span != nil {
 				zipkin.TagHTTPStatusCode.Set(span, strconv.Itoa(code))
+				if code > 399 {
+					// set http status as error tag (if already set, this is a noop)
+					zipkin.TagError.Set(span, http.StatusText(code))
+				}
 				if rs, ok := ctx.Value(kithttp.ContextKeyResponseSize).(int64); ok {
 					zipkin.TagHTTPResponseSize.Set(span, strconv.FormatInt(rs, 10))
 				}

--- a/tracing/zipkin/http_test.go
+++ b/tracing/zipkin/http_test.go
@@ -2,6 +2,7 @@ package zipkin_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -173,7 +174,7 @@ func TestHTTPServerTrace(t *testing.T) {
 	handler := kithttp.NewServer(
 		endpoint.Nop,
 		func(context.Context, *http.Request) (interface{}, error) { return nil, nil },
-		func(context.Context, http.ResponseWriter, interface{}) error { return nil },
+		func(context.Context, http.ResponseWriter, interface{}) error { return errors.New("dummy") },
 		zipkinkit.HTTPServerTrace(tr),
 	)
 
@@ -213,5 +214,9 @@ func TestHTTPServerTrace(t *testing.T) {
 
 	if want, have := httpMethod, spans[0].Name; want != have {
 		t.Errorf("incorrect span name, want %s, have %s", want, have)
+	}
+
+	if want, have := http.StatusText(500), spans[0].Tags["error"]; want != have {
+		t.Fatalf("incorrect error tag, want %s, have %s", want, have)
 	}
 }


### PR DESCRIPTION
When a HTTP status code indicating an error is returned to the client, this update to the Zipkin middleware will set an error tag to the server span. 

If an error tag was already set on the span (due to explicit error handling) the operation is a noop.