### PR TITLE
Add DisableEscapeHTML option for json logger

### DIFF
--- a/log/json_logger.go
+++ b/log/json_logger.go
@@ -10,7 +10,7 @@ import (
 
 type jsonLogger struct {
 	io.Writer
-	disableEscapeHTML bool
+	escapeHTML bool
 }
 
 // NewJSONLogger returns a Logger that encodes keyvals to the Writer as a
@@ -30,9 +30,9 @@ func NewJSONLogger(w io.Writer, options ...JSONLoggerOption) Logger {
 // JSONLoggerOption sets a parameter for json logger
 type JSONLoggerOption func(*jsonLogger)
 
-// DisableEscapeHTML disable to escape &, <, >.
-func DisableEscapeHTML(v bool) JSONLoggerOption {
-	return func(j *jsonLogger) { j.disableEscapeHTML = v }
+// SetEscapeHTML escape &, <, > inside JSON quoted strings.
+func SetEscapeHTML(v bool) JSONLoggerOption {
+	return func(j *jsonLogger) { j.escapeHTML = v }
 }
 
 func (l *jsonLogger) Log(keyvals ...interface{}) error {
@@ -47,7 +47,7 @@ func (l *jsonLogger) Log(keyvals ...interface{}) error {
 		merge(m, k, v)
 	}
 	enc := json.NewEncoder(l.Writer)
-	enc.SetEscapeHTML(!l.disableEscapeHTML)
+	enc.SetEscapeHTML(l.escapeHTML)
 	return enc.Encode(m)
 }
 

--- a/log/json_logger_test.go
+++ b/log/json_logger_test.go
@@ -73,17 +73,24 @@ func TestJSONLoggerNilErrorValue(t *testing.T) {
 	}
 }
 
-func TestJSONLoggerWithDisableHTMLEscapeOption(t *testing.T) {
+func TestJSONLoggerWithSetHTMLEscapeOption(t *testing.T) {
 	t.Parallel()
 
 	buf := &bytes.Buffer{}
-	logger := log.NewJSONLogger(buf, log.DisableEscapeHTML(true))
-	if err := logger.Log("a", "<&>"); err != nil {
-		t.Fatal(err)
+	for b, want := range map[bool]string{
+		false: `{"a":"<&>"}` + "\n",
+		true:  `{"a":"\u003c\u0026\u003e"}` + "\n",
+	} {
+		buf.Reset()
+		logger := log.NewJSONLogger(buf, log.SetEscapeHTML(b))
+		if err := logger.Log("a", "<&>"); err != nil {
+			t.Fatal(err)
+		}
+		if have := buf.String(); want != have {
+			t.Errorf("\nwant %#v\nhave %#v", want, have)
+		}
 	}
-	if want, have := `{"a":"<&>"}`+"\n", buf.String(); want != have {
-		t.Errorf("\nwant %#v\nhave %#v", want, have)
-	}
+
 }
 
 // aller implements json.Marshaler, encoding.TextMarshaler, and fmt.Stringer.

--- a/log/json_logger_test.go
+++ b/log/json_logger_test.go
@@ -73,6 +73,19 @@ func TestJSONLoggerNilErrorValue(t *testing.T) {
 	}
 }
 
+func TestJSONLoggerWithDisableHTMLEscapeOption(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	logger := log.NewJSONLogger(buf, log.DisableEscapeHTML(true))
+	if err := logger.Log("a", "<&>"); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := `{"a":"<&>"}`+"\n", buf.String(); want != have {
+		t.Errorf("\nwant %#v\nhave %#v", want, have)
+	}
+}
+
 // aller implements json.Marshaler, encoding.TextMarshaler, and fmt.Stringer.
 type aller struct{}
 


### PR DESCRIPTION
Hi.
I add DisableEscapeHTML option for json logger. If pass ```log.DisableEscapeHTML(true)``` to NewJSONLogger, we can get more readability.

Thanks.