### PR TITLE
Fix race condition in NATS transport tests

### DIFF
--- a/transport/nats/publisher_test.go
+++ b/transport/nats/publisher_test.go
@@ -19,8 +19,8 @@ func TestPublisher(t *testing.T) {
 		}
 	)
 
-	nc, closenc := newNatsConn(t)
-	defer closenc()
+	nc := newNatsConn(t)
+	defer nc.Close()
 
 	sub, err := nc.QueueSubscribe("natstransport.test", "natstransport", func(msg *nats.Msg) {
 		if err := nc.Publish(msg.Reply, []byte(testdata)); err != nil {
@@ -63,8 +63,8 @@ func TestPublisherBefore(t *testing.T) {
 		}
 	)
 
-	nc, closenc := newNatsConn(t)
-	defer closenc()
+	nc := newNatsConn(t)
+	defer nc.Close()
 
 	sub, err := nc.QueueSubscribe("natstransport.test", "natstransport", func(msg *nats.Msg) {
 		if err := nc.Publish(msg.Reply, msg.Data); err != nil {
@@ -111,8 +111,8 @@ func TestPublisherAfter(t *testing.T) {
 		}
 	)
 
-	nc, closenc := newNatsConn(t)
-	defer closenc()
+	nc := newNatsConn(t)
+	defer nc.Close()
 
 	sub, err := nc.QueueSubscribe("natstransport.test", "natstransport", func(msg *nats.Msg) {
 		if err := nc.Publish(msg.Reply, []byte(testdata)); err != nil {
@@ -158,8 +158,8 @@ func TestPublisherTimeout(t *testing.T) {
 		}
 	)
 
-	nc, closenc := newNatsConn(t)
-	defer closenc()
+	nc := newNatsConn(t)
+	defer nc.Close()
 
 	ch := make(chan struct{})
 	defer close(ch)
@@ -189,8 +189,8 @@ func TestPublisherTimeout(t *testing.T) {
 func TestEncodeJSONRequest(t *testing.T) {
 	var data string
 
-	nc, closenc := newNatsConn(t)
-	defer closenc()
+	nc := newNatsConn(t)
+	defer nc.Close()
 
 	sub, err := nc.QueueSubscribe("natstransport.test", "natstransport", func(msg *nats.Msg) {
 		data = string(msg.Data)


### PR DESCRIPTION
The tests for PR #680 have a small race that leads to sporadic test failures (https://travis-ci.org/go-kit/kit/jobs/372140473#L1732).

Closing subscriptions and connections is asynchronous, so when the next test runs and tries to receive messages there may still be an old connection subscribed to the same topic used by the next test. 

Since the tests are using queue subscriptions only one client will ever get a message, meaning that a message may never arrive on the newer connection.

This PR refactors the logic for opening and closing the connections to check for open subscriptions before opening new connections and, if there are any, waiting a bit before failing.

Other options are to use different topic or queue names or even not using queue subscriptions, but checking the server seemed safer to me and requires less changes to the tests.