### PR TITLE
fix for etcdv3 client panic when only using sd.Registrar

### DIFF
--- a/examples/addsvc/cmd/addcli/addcli.go
+++ b/examples/addsvc/cmd/addcli/addcli.go
@@ -205,7 +205,7 @@ func main() {
 		fmt.Fprintf(os.Stdout, "%q + %q = %q\n", a, b, v)
 
 	default:
-		fmt.Fprintf(os.Stderr, "error: invalid method %q\n", method)
+		fmt.Fprintf(os.Stderr, "error: invalid method %q\n", *method)
 		os.Exit(1)
 	}
 }

--- a/sd/etcdv3/client.go
+++ b/sd/etcdv3/client.go
@@ -228,6 +228,8 @@ func (c *client) close() {
 	}
 	if c.watcher != nil {
 		c.watcher.Close()
+	}
+	if c.wcf != nil {
 		c.wcf()
 	}
 }

--- a/sd/etcdv3/integration_test.go
+++ b/sd/etcdv3/integration_test.go
@@ -14,6 +14,23 @@ import (
 	"github.com/go-kit/kit/sd"
 )
 
+func runIntegrationRegistrarOnly(settings integrationSettings, client Client, service Service, t *testing.T) {
+	// Instantiate a new Registrar, passing in test data.
+	registrar := NewRegistrar(
+		client,
+		service,
+		log.With(log.NewLogfmtLogger(os.Stderr), "component", "registrar"),
+	)
+
+	// Register our instance.
+	registrar.Register()
+	t.Log("Registered")
+
+	// Deregister our instance.
+	registrar.Deregister()
+	t.Log("Deregistered")
+}
+
 func runIntegration(settings integrationSettings, client Client, service Service, t *testing.T) {
 	// Verify test data is initially empty.
 	entries, err := client.GetEntries(settings.key)
@@ -34,7 +51,7 @@ func runIntegration(settings integrationSettings, client Client, service Service
 
 	// Register our instance.
 	registrar.Register()
-	t.Logf("Registered")
+	t.Log("Registered")
 
 	// Retrieve entries from etcd manually.
 	entries, err = client.GetEntries(settings.key)
@@ -56,7 +73,7 @@ func runIntegration(settings integrationSettings, client Client, service Service
 	if err != nil {
 		t.Fatalf("NewInstancer: %v", err)
 	}
-	t.Logf("Constructed Instancer OK")
+	t.Log("Constructed Instancer OK")
 	defer instancer.Stop()
 
 	endpointer := sd.NewEndpointer(
@@ -64,20 +81,20 @@ func runIntegration(settings integrationSettings, client Client, service Service
 		func(string) (endpoint.Endpoint, io.Closer, error) { return endpoint.Nop, nil, nil },
 		log.With(log.NewLogfmtLogger(os.Stderr), "component", "instancer"),
 	)
-	t.Logf("Constructed Endpointer OK")
+	t.Log("Constructed Endpointer OK")
 	defer endpointer.Close()
 
 	if !within(time.Second, func() bool {
 		endpoints, err := endpointer.Endpoints()
 		return err == nil && len(endpoints) == 1
 	}) {
-		t.Fatalf("Endpointer didn't see Register in time")
+		t.Fatal("Endpointer didn't see Register in time")
 	}
-	t.Logf("Endpointer saw Register OK")
+	t.Log("Endpointer saw Register OK")
 
 	// Deregister first instance of test data.
 	registrar.Deregister()
-	t.Logf("Deregistered")
+	t.Log("Deregistered")
 
 	// Check it was deregistered.
 	if !within(time.Second, func() bool {
@@ -141,6 +158,7 @@ func TestIntegration(t *testing.T) {
 		Value: settings.value,
 	}
 
+	runIntegrationRegistrarOnly(settings, client, service, t)
 	runIntegration(settings, client, service, t)
 }
 

--- a/sd/etcdv3/integration_test.go
+++ b/sd/etcdv3/integration_test.go
@@ -14,23 +14,6 @@ import (
 	"github.com/go-kit/kit/sd"
 )
 
-func runIntegrationRegistrarOnly(settings integrationSettings, client Client, service Service, t *testing.T) {
-	// Instantiate a new Registrar, passing in test data.
-	registrar := NewRegistrar(
-		client,
-		service,
-		log.With(log.NewLogfmtLogger(os.Stderr), "component", "registrar"),
-	)
-
-	// Register our instance.
-	registrar.Register()
-	t.Log("Registered")
-
-	// Deregister our instance.
-	registrar.Deregister()
-	t.Log("Deregistered")
-}
-
 func runIntegration(settings integrationSettings, client Client, service Service, t *testing.T) {
 	// Verify test data is initially empty.
 	entries, err := client.GetEntries(settings.key)
@@ -50,6 +33,14 @@ func runIntegration(settings integrationSettings, client Client, service Service
 	)
 
 	// Register our instance.
+	registrar.Register()
+	t.Log("Registered")
+
+	// Deregister our instance. (so we test registrar only scenario)
+	registrar.Deregister()
+	t.Log("Deregistered")
+
+	// Re-Register our instance.
 	registrar.Register()
 	t.Log("Registered")
 
@@ -158,7 +149,6 @@ func TestIntegration(t *testing.T) {
 		Value: settings.value,
 	}
 
-	runIntegrationRegistrarOnly(settings, client, service, t)
 	runIntegration(settings, client, service, t)
 }
 


### PR DESCRIPTION
When using etcdv3 client on a service only registering and deregistering itself, the client would panic on close. 

This fixes the issue and adds an integration test for testing this use case.