### PR TITLE
refactor(lint/unconvert): remove base64 call returns a string

### DIFF
--- a/examples/addsvc/cmd/addsvc/pact_test.go
+++ b/examples/addsvc/cmd/addsvc/pact_test.go
@@ -27,7 +27,7 @@ func TestPactStringsvcUppercase(t *testing.T) {
 		WithRequest(dsl.Request{
 			Headers: map[string]string{"Content-Type": "application/json; charset=utf-8"},
 			Method:  "POST",
-			Path:    "/uppercase",
+			Path:    dsl.String("/uppercase"),
 			Body:    `{"s":"foo"}`,
 		}).
 		WillRespondWith(dsl.Response{

--- a/tracing/opentracing/grpc.go
+++ b/tracing/opentracing/grpc.go
@@ -53,7 +53,7 @@ type metadataReaderWriter struct {
 func (w metadataReaderWriter) Set(key, val string) {
 	key = strings.ToLower(key)
 	if strings.HasSuffix(key, "-bin") {
-		val = string(base64.StdEncoding.EncodeToString([]byte(val)))
+		val = base64.StdEncoding.EncodeToString([]byte(val))
 	}
 	(*w.MD)[key] = append((*w.MD)[key], val)
 }

--- a/transport/grpc/request_response_funcs.go
+++ b/transport/grpc/request_response_funcs.go
@@ -69,8 +69,7 @@ func SetResponseTrailer(key, val string) ServerResponseFunc {
 func EncodeKeyValue(key, val string) (string, string) {
 	key = strings.ToLower(key)
 	if strings.HasSuffix(key, binHdrSuffix) {
-		v := base64.StdEncoding.EncodeToString([]byte(val))
-		val = string(v)
+		val = base64.StdEncoding.EncodeToString([]byte(val))
 	}
 	return key, val
 }

--- a/transport/nats/publisher.go
+++ b/transport/nats/publisher.go
@@ -19,7 +19,7 @@ type Publisher struct {
 	timeout   time.Duration
 }
 
-// NewClient constructs a usable Publisher for a single remote method.
+// NewPublisher constructs a usable Publisher for a single remote method.
 func NewPublisher(
 	publisher *nats.Conn,
 	subject string,


### PR DESCRIPTION
currently `base64.StdEncoding.EncodeToString` returns an string, extra conversion is not necessary 