### PR TITLE
JSON-RPC empty error parameter not omitted in encoding (#728)

### DIFF
--- a/transport/http/jsonrpc/README.md
+++ b/transport/http/jsonrpc/README.md
@@ -87,6 +87,5 @@ With all of this done, our example request above should result in a response lik
 
 	{
 	    "jsonrpc": "2.0",
-	    "result": 4,
-	    "error": null
+	    "result": 4
 	}

--- a/transport/http/jsonrpc/request_response_types.go
+++ b/transport/http/jsonrpc/request_response_types.go
@@ -58,7 +58,7 @@ func (id *RequestID) String() (string, error) {
 type Response struct {
 	JSONRPC string          `json:"jsonrpc"`
 	Result  json.RawMessage `json:"result,omitempty"`
-	Error   *Error          `json:"error,omitemty"`
+	Error   *Error          `json:"error,omitempty"`
 }
 
 const (


### PR DESCRIPTION
Example in JSON-RPC doc shows empty error being encoded in the example output, which is incorrect.

Found the issue in the JSON response type which had a typo in the json omitempty tag.

Closes #728.