### PR TITLE
jsonrpc add id from request to response

### DIFF
--- a/transport/http/jsonrpc/request_response_types.go
+++ b/transport/http/jsonrpc/request_response_types.go
@@ -35,6 +35,16 @@ func (id *RequestID) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (id *RequestID) MarshalJSON() ([]byte, error) {
+	if id.intError == nil {
+		return json.Marshal(id.intValue)
+	} else if id.floatError == nil {
+		return json.Marshal(id.floatValue)
+	} else {
+		return json.Marshal(id.stringValue)
+	}
+}
+
 // Int returns the ID as an integer value.
 // An error is returned if the ID can't be treated as an int.
 func (id *RequestID) Int() (int, error) {
@@ -59,6 +69,7 @@ type Response struct {
 	JSONRPC string          `json:"jsonrpc"`
 	Result  json.RawMessage `json:"result,omitempty"`
 	Error   *Error          `json:"error,omitempty"`
+	ID      *RequestID      `json:"id"`
 }
 
 const (

--- a/transport/http/jsonrpc/request_response_types_test.go
+++ b/transport/http/jsonrpc/request_response_types_test.go
@@ -119,6 +119,7 @@ func TestCanMarshalID(t *testing.T) {
 		{`12345`, "int", 12345},
 		{`12345.6`, "float", 12345.6},
 		{`"stringaling"`, "string", "stringaling"},
+		{`null`, "null", nil},
 	}
 
 	for _, c := range cases {
@@ -133,19 +134,5 @@ func TestCanMarshalID(t *testing.T) {
 		if got != want {
 			t.Fatalf("'%s': want %s, got %s.", c.expType, want, got)
 		}
-	}
-}
-
-func TestCanMarshalNullID(t *testing.T) {
-	req := jsonrpc.Request{}
-	JSON := `{"jsonrpc":"2.0","id":null}`
-	json.Unmarshal([]byte(JSON), &req)
-	resp := jsonrpc.Response{ID: req.ID, JSONRPC: req.JSONRPC}
-
-	want := JSON
-	bol, _ := json.Marshal(resp)
-	got := string(bol)
-	if got != want {
-		t.Fatalf("'null': want %s, got %s.", want, got)
 	}
 }

--- a/transport/http/jsonrpc/request_response_types_test.go
+++ b/transport/http/jsonrpc/request_response_types_test.go
@@ -109,3 +109,43 @@ func TestCanUnmarshalNullID(t *testing.T) {
 		t.Fatalf("Expected ID to be nil, got %+v.\n", r.ID)
 	}
 }
+
+func TestCanMarshalID(t *testing.T) {
+	cases := []struct {
+		JSON     string
+		expType  string
+		expValue interface{}
+	}{
+		{`12345`, "int", 12345},
+		{`12345.6`, "float", 12345.6},
+		{`"stringaling"`, "string", "stringaling"},
+	}
+
+	for _, c := range cases {
+		req := jsonrpc.Request{}
+		JSON := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s}`, c.JSON)
+		json.Unmarshal([]byte(JSON), &req)
+		resp := jsonrpc.Response{ID: req.ID, JSONRPC: req.JSONRPC}
+
+		want := JSON
+		bol, _ := json.Marshal(resp)
+		got := string(bol)
+		if got != want {
+			t.Fatalf("'%s': want %s, got %s.", c.expType, want, got)
+		}
+	}
+}
+
+func TestCanMarshalNullID(t *testing.T) {
+	req := jsonrpc.Request{}
+	JSON := `{"jsonrpc":"2.0","id":null}`
+	json.Unmarshal([]byte(JSON), &req)
+	resp := jsonrpc.Response{ID: req.ID, JSONRPC: req.JSONRPC}
+
+	want := JSON
+	bol, _ := json.Marshal(resp)
+	got := string(bol)
+	if got != want {
+		t.Fatalf("'null': want %s, got %s.", want, got)
+	}
+}

--- a/transport/http/jsonrpc/server.go
+++ b/transport/http/jsonrpc/server.go
@@ -136,6 +136,7 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res := Response{
+		ID:      req.ID,
 		JSONRPC: Version,
 	}
 


### PR DESCRIPTION
According to https://www.jsonrpc.org/specification:

> **id**
> This member is REQUIRED.
> It MUST be the same as the value of the id member in the Request Object.
> If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it > MUST be Null.

This pull request add req.ID to response object.