### PR TITLE
HTTPClient interface

### DIFF
--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -12,9 +12,14 @@ import (
 	"github.com/go-kit/kit/endpoint"
 )
 
+// HTTPClient is an interface for http clients
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Client wraps a URL and provides a method that implements endpoint.Endpoint.
 type Client struct {
-	client         *http.Client
+	client         HTTPClient
 	method         string
 	tgt            *url.URL
 	enc            EncodeRequestFunc
@@ -54,7 +59,7 @@ type ClientOption func(*Client)
 
 // SetClient sets the underlying HTTP client used for requests.
 // By default, http.DefaultClient is used.
-func SetClient(client *http.Client) ClientOption {
+func SetClient(client HTTPClient) ClientOption {
 	return func(c *Client) { c.client = client }
 }
 

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 )
 
-// HTTPClient is an interface for http clients
+// HTTPClient is an interface that models *http.Client.
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }

--- a/transport/http/jsonrpc/client.go
+++ b/transport/http/jsonrpc/client.go
@@ -15,7 +15,7 @@ import (
 
 // Client wraps a JSON RPC method and provides a method that implements endpoint.Endpoint.
 type Client struct {
-	client *http.Client
+	client httptransport.HTTPClient
 
 	// JSON RPC endpoint URL
 	tgt *url.URL
@@ -86,7 +86,7 @@ type ClientOption func(*Client)
 
 // SetClient sets the underlying HTTP client used for requests.
 // By default, http.DefaultClient is used.
-func SetClient(client *http.Client) ClientOption {
+func SetClient(client httptransport.HTTPClient) ClientOption {
 	return func(c *Client) { c.client = client }
 }
 


### PR DESCRIPTION
Use HTTPClient interface instead of *http.Client in transport to facilitate use of http middlewares.
https://github.com/go-kit/kit/issues/753