### PR TITLE
Remove dependency on github.com/go-stack/stack

### DIFF
--- a/log/value.go
+++ b/log/value.go
@@ -1,9 +1,10 @@
 package log
 
 import (
+	"runtime"
+	"strconv"
+	"strings"
 	"time"
-
-	"github.com/go-stack/stack"
 )
 
 // A Valuer generates a log value. When passed to With or WithPrefix in a
@@ -81,7 +82,14 @@ func (tf timeFormat) MarshalText() (text []byte, err error) {
 // Caller returns a Valuer that returns a file and line from a specified depth
 // in the callstack. Users will probably want to use DefaultCaller.
 func Caller(depth int) Valuer {
-	return func() interface{} { return stack.Caller(depth) }
+	return func() interface{} {
+		_, file, line, _ := runtime.Caller(depth)
+		idx := strings.LastIndexByte(file, '/')
+		// using idx+1 below handles both of following cases:
+		// idx == -1 because no "/" was found, or
+		// idx >= 0 and we want to start at the character after the found "/".
+		return file[idx+1:] + ":" + strconv.Itoa(line)
+	}
 }
 
 var (


### PR DESCRIPTION
The main reason we used github.com/go-stack/stack was because it handled several subtle idiosyncrasies about acquiring correct stack frame information from Go's runtime package that existed until Go 1.7. We don't need it for that anymore.

go-stack/stack also provides some nice features to help format stack frame information that we don't expose in the log package. The `log.Valuer` facility provides a mechanism for others to use those features of go-stack/stack if they want to, but I don't think there is a compelling reason to use go-stack/stack to implement `log.Caller` anymore. One less external dependency without any loss of features is nice.