### PR TITLE
Rename "package log" to "log package" to fix godoc link handling.

### DIFF
--- a/log/level/doc.go
+++ b/log/level/doc.go
@@ -1,6 +1,6 @@
-// Package level implements leveled logging on top of package log. To use the
-// level package, create a logger as per normal in your func main, and wrap it
-// with level.NewFilter.
+// Package level implements leveled logging on top of Go kit's log package. To
+// use the level package, create a logger as per normal in your func main, and
+// wrap it with level.NewFilter.
 //
 //    var logger log.Logger
 //    logger = log.NewLogfmtLogger(os.Stderr)


### PR DESCRIPTION
Fixes #763.