### PR TITLE
Fix 'Client.Endpoint' to not 'cancel' when bufferedStream

### DIFF
--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -85,7 +85,7 @@ func ClientFinalizer(f ...ClientFinalizerFunc) ClientOption {
 
 // BufferedStream sets whether the Response.Body is left open, allowing it
 // to be read from later. Useful for transporting a file as a buffered stream.
-// That body has to be Closed to propery end the request
+// That body has to be Closed to propery end the request.
 func BufferedStream(buffered bool) ClientOption {
 	return func(c *Client) { c.bufferedStream = buffered }
 }

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -85,6 +85,7 @@ func ClientFinalizer(f ...ClientFinalizerFunc) ClientOption {
 
 // BufferedStream sets whether the Response.Body is left open, allowing it
 // to be read from later. Useful for transporting a file as a buffered stream.
+// That body has to be Closed to propery end the request
 func BufferedStream(buffered bool) ClientOption {
 	return func(c *Client) { c.bufferedStream = buffered }
 }
@@ -132,6 +133,8 @@ func (c Client) Endpoint() endpoint.Endpoint {
 			return nil, err
 		}
 
+		// If we expect a buffered stream, we don't cancel the context when the endpoint returns.
+		// Instead, we should call the cancel func when closing the response body.
 		if c.bufferedStream {
 			resp.Body = bodyWithCancel{ReadCloser: resp.Body, cancel: cancel}
 		} else {

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -99,7 +99,7 @@ func TestHTTPClient(t *testing.T) {
 
 func TestHTTPClientBufferedStream(t *testing.T) {
 	var (
-		testbody = "testbody"
+		testbody = string(make([]byte, 6000))
 		encode   = func(context.Context, *http.Request, interface{}) error { return nil }
 		decode   = func(_ context.Context, r *http.Response) (interface{}, error) {
 			return TestResponse{r.Body, ""}, nil
@@ -129,6 +129,7 @@ func TestHTTPClientBufferedStream(t *testing.T) {
 	if !ok {
 		t.Fatal("response should be TestResponse")
 	}
+	time.Sleep(time.Second * 1)
 
 	// Check that response body was NOT closed
 	b := make([]byte, len(testbody))

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -98,8 +98,12 @@ func TestHTTPClient(t *testing.T) {
 }
 
 func TestHTTPClientBufferedStream(t *testing.T) {
+	// bodysize has a size big enought to make the resopnse.Body not an instant read
+	// so if the response is cancelled it wount be all readed and the test would fail
+	// The 6000 has not a particular meaning, it big enough to fulfill the usecase.
+	const bodysize = 6000
 	var (
-		testbody = string(make([]byte, 6000))
+		testbody = string(make([]byte, bodysize))
 		encode   = func(context.Context, *http.Request, interface{}) error { return nil }
 		decode   = func(_ context.Context, r *http.Response) (interface{}, error) {
 			return TestResponse{r.Body, ""}, nil
@@ -130,6 +134,7 @@ func TestHTTPClientBufferedStream(t *testing.T) {
 		t.Fatal("response should be TestResponse")
 	}
 	defer response.Body.Close()
+	// Faking work
 	time.Sleep(time.Second * 1)
 
 	// Check that response body was NOT closed

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -129,6 +129,7 @@ func TestHTTPClientBufferedStream(t *testing.T) {
 	if !ok {
 		t.Fatal("response should be TestResponse")
 	}
+	defer response.Body.Close()
 	time.Sleep(time.Second * 1)
 
 	// Check that response body was NOT closed


### PR DESCRIPTION
Fixes #773 by adding a wrapper to the `Resonse.Body` when the `bufferedStream` is specified.

For now it's a PoC as it may change.

The biggest **drawback** is that old users of `bufferedStream` that where not closing the `Resopnse.Body` may end up with an open connection :cry: . The only **solution** I can have for that is to have another option to tell the client that the user will close the connection, so all this logic I did would be placed in an if condition of that other option (which maybe cleaner, but with the bug on `bufferedStream` will still be there).

To make the test fail I had to fake a "big" body (`string(make([]byte, 6000))`) and "fake work" (`time.Sleep`), then those where fixed with the implementation.

Depending on how does this evolve, I could include the [jsonrpc.Client.Endpoint](https://github.com/go-kit/kit/blob/master/transport/http/jsonrpc/client.go#L143) to this PR or a new PR, as it has the same/similar implementation so I suppose the same "bug" (did not try it).