### PR TITLE
Add error return to the Registrar interface functions

### DIFF
--- a/sd/consul/registrar.go
+++ b/sd/consul/registrar.go
@@ -3,9 +3,8 @@ package consul
 import (
 	"fmt"
 
-	stdconsul "github.com/hashicorp/consul/api"
-
 	"github.com/go-kit/kit/log"
+	stdconsul "github.com/hashicorp/consul/api"
 )
 
 // Registrar registers service instance liveness information to Consul.
@@ -26,19 +25,23 @@ func NewRegistrar(client Client, r *stdconsul.AgentServiceRegistration, logger l
 }
 
 // Register implements sd.Registrar interface.
-func (p *Registrar) Register() {
-	if err := p.client.Register(p.registration); err != nil {
+func (p *Registrar) Register() error {
+	err := p.client.Register(p.registration)
+	if err != nil {
 		p.logger.Log("err", err)
-	} else {
-		p.logger.Log("action", "register")
+		return err
 	}
+	p.logger.Log("action", "register")
+	return nil
 }
 
 // Deregister implements sd.Registrar interface.
-func (p *Registrar) Deregister() {
-	if err := p.client.Deregister(p.registration); err != nil {
+func (p *Registrar) Deregister() error {
+	err := p.client.Deregister(p.registration)
+	if err != nil {
 		p.logger.Log("err", err)
-	} else {
-		p.logger.Log("action", "deregister")
+		return err
 	}
+	p.logger.Log("action", "deregister")
+	return nil
 }

--- a/sd/consul/registrar_test.go
+++ b/sd/consul/registrar_test.go
@@ -3,9 +3,8 @@ package consul
 import (
 	"testing"
 
-	stdconsul "github.com/hashicorp/consul/api"
-
 	"github.com/go-kit/kit/log"
+	stdconsul "github.com/hashicorp/consul/api"
 )
 
 func TestRegistrar(t *testing.T) {
@@ -15,12 +14,18 @@ func TestRegistrar(t *testing.T) {
 		t.Errorf("want %d, have %d", want, have)
 	}
 
-	p.Register()
+	err := p.Register()
+	if err != nil {
+		t.Errorf("error when registering %s", err)
+	}
 	if want, have := 1, len(client.entries); want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
 
-	p.Deregister()
+	err = p.Deregister()
+	if err != nil {
+		t.Errorf("error when deregistering %s", err)
+	}
 	if want, have := 0, len(client.entries); want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}

--- a/sd/etcdv3/integration_test.go
+++ b/sd/etcdv3/integration_test.go
@@ -33,7 +33,10 @@ func runIntegration(settings integrationSettings, client Client, service Service
 	)
 
 	// Register our instance.
-	registrar.Register()
+	err = registrar.Register()
+	if err != nil {
+		t.Errorf("error when registering %s", err)
+	}
 	t.Log("Registered")
 
 	// Retrieve entries from etcd manually.
@@ -76,7 +79,10 @@ func runIntegration(settings integrationSettings, client Client, service Service
 	t.Log("Endpointer saw Register OK")
 
 	// Deregister first instance of test data.
-	registrar.Deregister()
+	err = registrar.Deregister()
+	if err != nil {
+		t.Errorf("error when deregistering %s", err)
+	}
 	t.Log("Deregistered")
 
 	// Check it was deregistered.
@@ -199,11 +205,17 @@ func TestIntegrationRegistrarOnly(t *testing.T) {
 	)
 
 	// Register our instance.
-	registrar.Register()
+	err = registrar.Register()
+	if err != nil {
+		t.Errorf("error when registering %s", err)
+	}
 	t.Log("Registered")
 
 	// Deregister our instance. (so we test registrar only scenario)
-	registrar.Deregister()
+	err = registrar.Deregister()
+	if err != nil {
+		t.Errorf("error when deregistering %s", err)
+	}
 	t.Log("Deregistered")
 
 }

--- a/sd/etcdv3/registrar.go
+++ b/sd/etcdv3/registrar.go
@@ -66,22 +66,24 @@ func NewRegistrar(client Client, service Service, logger log.Logger) *Registrar 
 
 // Register implements the sd.Registrar interface. Call it when you want your
 // service to be registered in etcd, typically at startup.
-func (r *Registrar) Register() {
+func (r *Registrar) Register() error {
 	if err := r.client.Register(r.service); err != nil {
 		r.logger.Log("err", err)
-		return
+		return err
 	}
 	if r.service.TTL != nil {
 		r.logger.Log("action", "register", "lease", r.client.LeaseID())
 	} else {
 		r.logger.Log("action", "register")
 	}
+	return nil
 }
 
 // Deregister implements the sd.Registrar interface. Call it when you want your
 // service to be deregistered from etcd, typically just prior to shutdown.
-func (r *Registrar) Deregister() {
-	if err := r.client.Deregister(r.service); err != nil {
+func (r *Registrar) Deregister() error {
+	err := r.client.Deregister(r.service)
+	if err != nil {
 		r.logger.Log("err", err)
 	} else {
 		r.logger.Log("action", "deregister")
@@ -93,4 +95,5 @@ func (r *Registrar) Deregister() {
 		close(r.quit)
 		r.quit = nil
 	}
+	return err
 }

--- a/sd/eureka/registrar_test.go
+++ b/sd/eureka/registrar_test.go
@@ -14,34 +14,52 @@ func TestRegistrar(t *testing.T) {
 	registrar2 := NewRegistrar(connection, instanceTest2, loggerTest)
 
 	// Not registered.
-	registrar1.Deregister()
+	err := registrar1.Deregister()
+	if err != nil {
+		t.Errorf("error when deregistering %s", err)
+	}
 	if want, have := 0, len(connection.instances); want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
 
 	// Register.
-	registrar1.Register()
+	err = registrar1.Register()
+	if err != nil {
+		t.Errorf("error when registering %s", err)
+	}
 	if want, have := 1, len(connection.instances); want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
 
-	registrar2.Register()
+	err = registrar2.Register()
+	if err != nil {
+		t.Errorf("error when registering %s", err)
+	}
 	if want, have := 2, len(connection.instances); want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
 
 	// Deregister.
-	registrar1.Deregister()
+	err = registrar1.Deregister()
+	if err != nil {
+		t.Errorf("error when deregistering %s", err)
+	}
 	if want, have := 1, len(connection.instances); want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
 
 	// Already registered.
-	registrar1.Register()
+	err = registrar1.Register()
+	if err != nil {
+		t.Errorf("error when registering %s", err)
+	}
 	if want, have := 2, len(connection.instances); want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
-	registrar1.Register()
+	err = registrar1.Register()
+	if err != nil {
+		t.Errorf("error when registering %s", err)
+	}
 	if want, have := 2, len(connection.instances); want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
@@ -51,7 +69,10 @@ func TestRegistrar(t *testing.T) {
 	if want, have := 2, len(connection.instances); want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
-	registrar1.Deregister()
+	err = registrar1.Deregister()
+	if err != nil {
+		t.Errorf("error when deregistering %s", err)
+	}
 	if want, have := 1, len(connection.instances); want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
@@ -75,7 +96,10 @@ func TestBadDeregister(t *testing.T) {
 	}
 
 	registrar := NewRegistrar(connection, instanceTest1, loggerTest)
-	registrar.Register()
+	err := registrar.Register()
+	if err != nil {
+		t.Errorf("error when registering %s", err)
+	}
 	if want, have := 1, len(connection.instances); want != have {
 		t.Errorf("want %d, have %d", want, have)
 	}
@@ -91,7 +115,10 @@ func TestExpiredInstance(t *testing.T) {
 	}
 
 	registrar := NewRegistrar(connection, instanceTest1, loggerTest)
-	registrar.Register()
+	err := registrar.Register()
+	if err != nil {
+		t.Errorf("error when registering %s", err)
+	}
 
 	// Wait for a heartbeat failure.
 	time.Sleep(1010 * time.Millisecond)

--- a/sd/registrar.go
+++ b/sd/registrar.go
@@ -8,6 +8,6 @@ package sd
 // that identifying instance information (e.g. host:port) must be given via the
 // concrete constructor; this interface merely signals lifecycle changes.
 type Registrar interface {
-	Register()
-	Deregister()
+	Register() error
+	Deregister() error
 }

--- a/sd/zk/integration_test.go
+++ b/sd/zk/integration_test.go
@@ -193,7 +193,10 @@ func TestGetEntriesPayloadOnServer(t *testing.T) {
 		Data: []byte("just some payload"),
 	}
 	registrar := NewRegistrar(c, instance3, logger)
-	registrar.Register()
+	err = registrar.Register()
+	if err != nil {
+		t.Errorf("error when registering %s", err)
+	}
 	select {
 	case event := <-eventc:
 		if want, have := stdzk.EventNodeChildrenChanged.String(), event.Type.String(); want != have {
@@ -208,7 +211,10 @@ func TestGetEntriesPayloadOnServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	registrar.Deregister()
+	err = registrar.Deregister()
+	if err != nil {
+		t.Errorf("error when registering %s", err)
+	}
 	select {
 	case event := <-eventc:
 		if want, have := stdzk.EventNodeChildrenChanged.String(), event.Type.String(); want != have {

--- a/sd/zk/registrar.go
+++ b/sd/zk/registrar.go
@@ -33,19 +33,23 @@ func NewRegistrar(client Client, service Service, logger log.Logger) *Registrar 
 }
 
 // Register implements sd.Registrar interface.
-func (r *Registrar) Register() {
-	if err := r.client.Register(&r.service); err != nil {
+func (r *Registrar) Register() error {
+	err := r.client.Register(&r.service)
+	if err != nil {
 		r.logger.Log("err", err)
-	} else {
-		r.logger.Log("action", "register")
+		return err
 	}
+	r.logger.Log("action", "register")
+	return nil
 }
 
 // Deregister implements sd.Registrar interface.
-func (r *Registrar) Deregister() {
-	if err := r.client.Deregister(&r.service); err != nil {
+func (r *Registrar) Deregister() error {
+	err := r.client.Deregister(&r.service)
+	if err != nil {
 		r.logger.Log("err", err)
-	} else {
-		r.logger.Log("action", "deregister")
+		return err
 	}
+	r.logger.Log("action", "deregister")
+	return nil
 }


### PR DESCRIPTION
The Register and Deregister method are logging errors but not
returning any error, which makes error handling not possible.
The implementation of the error is meant to reflect error from the
client api, not from what we consider an error (re-registering, ...).

* Some test cases haven't been altered since errors are expected.
* Eureka error handling is purely an error return from the client, trying to register several time is not considered as an error.

Closes #780.