### PR TITLE
Support logrus.Field logger in the logrus adapter

### DIFF
--- a/log/logrus/logrus_logger.go
+++ b/log/logrus/logrus_logger.go
@@ -11,13 +11,13 @@ import (
 )
 
 type logrusLogger struct {
-	*logrus.Logger
+	logrus.FieldLogger
 }
 
 var errMissingValue = errors.New("(MISSING)")
 
 // NewLogrusLogger returns a go-kit log.Logger that sends log events to a Logrus logger.
-func NewLogrusLogger(logger *logrus.Logger) log.Logger {
+func NewLogrusLogger(logger logrus.FieldLogger) log.Logger {
 	return &logrusLogger{logger}
 }
 


### PR DESCRIPTION
Logrus exposes an interface `FieldLogger`. It is usually better to hint against this interface, because the main logger instance returns a different type for loggers preannotated with structured context (namely `*Entry`). This way one can do this:

```go
logger := kitlogrus.NewLogrusLogger(logrusLogger.With("component", "my_component"))
```
