### PR TITLE
Tag spans on error (from endpoint or service) in OpenTracing middleware

### DIFF
--- a/tracing/opentracing/endpoint_test.go
+++ b/tracing/opentracing/endpoint_test.go
@@ -6,10 +6,29 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/pkg/errors"
 
 	"github.com/go-kit/kit/endpoint"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 )
+
+var (
+	endpointErr = errors.New("endpoint error")
+	svcErr      = errors.New("svc error")
+)
+
+type svcResponse struct {
+	err error
+}
+
+func (r svcResponse) Failed() error { return r.err }
+
+func passEndpoint(_ context.Context, req interface{}) (interface{}, error) {
+	if err, _ := req.(error); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
 
 func TestTraceServer(t *testing.T) {
 	tracer := mocktracer.New()
@@ -60,6 +79,27 @@ func TestTraceServerNoContextSpan(t *testing.T) {
 	if want, have := "testOp", endpointSpan.OperationName; want != have {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
+}
+
+func TestTraceServerError(t *testing.T) {
+	ctx := context.Background()
+	tracer := mocktracer.New()
+
+	tracedEndpoint := kitot.TraceServer(tracer, "testOp")(passEndpoint)
+
+	// first span with an error returned from the endpoint
+	tracedEndpoint(ctx, endpointErr)
+
+	// second span with a business error in the response
+	tracedEndpoint(ctx, svcResponse{svcErr})
+
+	finishedSpans := tracer.FinishedSpans()
+	if want, have := 2, len(finishedSpans); want != have {
+		t.Fatalf("Want %v span(s), found %v", want, have)
+	}
+
+	spanContainsError(t, finishedSpans[0], endpointErr)
+	spanContainsError(t, finishedSpans[1], svcErr)
 }
 
 func TestTraceClient(t *testing.T) {
@@ -113,5 +153,49 @@ func TestTraceClientNoContextSpan(t *testing.T) {
 	endpointSpan := finishedSpans[0]
 	if want, have := "testOp", endpointSpan.OperationName; want != have {
 		t.Fatalf("Want %q, have %q", want, have)
+	}
+}
+
+func TestTraceClientError(t *testing.T) {
+	ctx := context.Background()
+	tracer := mocktracer.New()
+
+	tracedEndpoint := kitot.TraceClient(tracer, "testOp")(passEndpoint)
+
+	// first span with an error returned from the endpoint
+	tracedEndpoint(ctx, endpointErr)
+
+	// second span with a business error in the response
+	tracedEndpoint(ctx, svcResponse{svcErr})
+
+	finishedSpans := tracer.FinishedSpans()
+	if want, have := 2, len(finishedSpans); want != have {
+		t.Fatalf("Want %v span(s), found %v", want, have)
+	}
+
+	spanContainsError(t, finishedSpans[0], endpointErr)
+	spanContainsError(t, finishedSpans[1], svcErr)
+}
+
+func spanContainsError(t *testing.T, span *mocktracer.MockSpan, err error) {
+	if want, have := true, span.Tag("error"); want != have {
+		t.Fatal("Expected span to have error tag")
+	}
+
+	if want, have := 1, len(span.Logs()); want != have {
+		t.Fatalf("Want %d log entries on span, have %d", want, have)
+	}
+
+	log := span.Logs()[0]
+	if want, have := 1, len(log.Fields); want != have {
+		t.Fatalf("Want %d fields on span log, have %d", want, have)
+	}
+
+	if want, have := "error.object", log.Fields[0].Key; want != have {
+		t.Fatalf("Want %q key on log entry, have %q", want, have)
+	}
+
+	if want, have := err.Error(), log.Fields[0].ValueString; want != have {
+		t.Fatalf("Want %q value on log entry, have %q", want, have)
 	}
 }


### PR DESCRIPTION
Adds error handling for the Open Tracing endpoint middleware, following the recommended conventions: https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table

Closes https://github.com/go-kit/kit/issues/804