### PR TITLE
Fix Consul SD deregister service if id empty

### DIFF
--- a/sd/consul/client.go
+++ b/sd/consul/client.go
@@ -31,7 +31,12 @@ func (c *client) Register(r *consul.AgentServiceRegistration) error {
 }
 
 func (c *client) Deregister(r *consul.AgentServiceRegistration) error {
-	return c.consul.Agent().ServiceDeregister(r.ID)
+	id := r.ID
+	if id == "" {
+		id = r.Name	
+	}
+	
+	return c.consul.Agent().ServiceDeregister(id)
 }
 
 func (c *client) Service(service, tag string, passingOnly bool, queryOpts *consul.QueryOptions) ([]*consul.ServiceEntry, *consul.QueryMeta, error) {


### PR DESCRIPTION
Consul allows [register service without `ID`](https://www.consul.io/api/agent/service.html).

> `ID (string: "")` - Specifies a unique ID for this service. This must be unique per agent. This defaults to the `Name` parameter if not provided.

Then, deregister must be by `Name`.