### PR TITLE
Use opencensus's DefaultSampler instead of AlwaysSampler as default

### DIFF
--- a/tracing/opencensus/grpc.go
+++ b/tracing/opencensus/grpc.go
@@ -22,10 +22,6 @@ func GRPCClientTrace(options ...TracerOption) kitgrpc.ClientOption {
 		option(&cfg)
 	}
 
-	if cfg.Sampler == nil {
-		cfg.Sampler = trace.AlwaysSample()
-	}
-
 	clientBefore := kitgrpc.ClientBefore(
 		func(ctx context.Context, md *metadata.MD) context.Context {
 			var name string
@@ -77,10 +73,6 @@ func GRPCServerTrace(options ...TracerOption) kitgrpc.ServerOption {
 
 	for _, option := range options {
 		option(&cfg)
-	}
-
-	if cfg.Sampler == nil {
-		cfg.Sampler = trace.AlwaysSample()
 	}
 
 	serverBefore := kitgrpc.ServerBefore(

--- a/tracing/opencensus/http.go
+++ b/tracing/opencensus/http.go
@@ -19,10 +19,6 @@ func HTTPClientTrace(options ...TracerOption) kithttp.ClientOption {
 		option(&cfg)
 	}
 
-	if cfg.Sampler == nil {
-		cfg.Sampler = trace.AlwaysSample()
-	}
-
 	if !cfg.Public && cfg.HTTPPropagate == nil {
 		cfg.HTTPPropagate = &b3.HTTPFormat{}
 	}
@@ -99,10 +95,6 @@ func HTTPServerTrace(options ...TracerOption) kithttp.ServerOption {
 
 	for _, option := range options {
 		option(&cfg)
-	}
-
-	if cfg.Sampler == nil {
-		cfg.Sampler = trace.AlwaysSample()
 	}
 
 	if !cfg.Public && cfg.HTTPPropagate == nil {


### PR DESCRIPTION
The `GRPCServerTrace` and `HTTPServerTrace`  provided in the `tracing/opencensus` package will use `trace.AlwaysSample()` to trace span by default.

But I think using `trace.AlwaysSample()` as default is not a good idea, because it might cost a lot of money, especially when sending spans to cloud service providers, for example Stackdriver.

This pull request remove the lines that setting `trace.AlwaysSample()` as default value of `cfg.Sampler`, and leave the `cfg.Sampler` default to nil.

And the `trace.StartSpanWithRemoteParent()` and `trace.StartSpan()` will use their default sampler if `cfg.Sampler` is nil.

Users can change their default sampler by `trace.ApplyConfig()` first:
```golang
import "go.opencensus.io/trace"

sampler := trace.AlwaysSample() // or trace.ProbabilitySampler(1e-4)

trace.ApplyConfig(trace.Config{
    DefaultSampler: sampler,
})
```


