### PR TITLE
fix: `ProtectedEphemeralSequential` in the wrong zk path

### DIFF
--- a/sd/zk/client.go
+++ b/sd/zk/client.go
@@ -238,6 +238,9 @@ func (c *client) Register(s *Service) error {
 	if err := c.CreateParentNodes(path); err != nil {
 		return err
 	}
+	if path[len(path)-1] != '/' {
+		path += "/"
+	}
 	node, err := c.CreateProtectedEphemeralSequential(path, s.Data, c.acl)
 	if err != nil {
 		return err


### PR DESCRIPTION
```golang
register := zk.NewRegistrar(client,zk.Service{
	Path: "/services/hello",
	Name: "abc",
	Data: []byte("http://127.0.0.1:8080"),
},logger)
```
> It will be created in zk
```sh
[zk: localhost:2181(CONNECTED) 161] ls /services/hello
[_c_c83db041ac654566228b72cbd541bcb5-abc0000000006, abc]
```
**/services/hello/_c_c83db041ac654566228b72cbd541bcb5** is correct
**/services/hello/abc** is empty node

```golang
//will get 0 instance
zk.NewInstancer(client,"/services/hello/abc",logger)
//will get 2 instances, one of them is <nil>
zk.NewInstancer(client,"/services/hello",logger)
```
In my understanding, [CreateProtectedEphemeralSequential](https://github.com/go-kit/kit/blob/master/sd/zk/client.go#L241) function will be created under `/services/hello/abc`

So is this a bug? Or there's something wrong with my usage？