### PR TITLE
WebSocket Support

### DIFF
--- a/examples/addsvc/pkg/addtransport/ws.go
+++ b/examples/addsvc/pkg/addtransport/ws.go
@@ -1,0 +1,112 @@
+package addtransport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/go-stomp/stomp/frame"
+	"github.com/gorilla/websocket"
+
+	"github.com/go-kit/kit/examples/addsvc/pkg/addendpoint"
+	"github.com/go-kit/kit/log"
+	wstransport "github.com/go-kit/kit/transport/http/ws"
+)
+
+func NewWSHandler(endpoints addendpoint.Set, logger log.Logger) http.Handler {
+	m := http.NewServeMux()
+	m.Handle("/ws", wstransport.NewServer(
+		websocket.Upgrader{
+			Subprotocols: []string{"v12.stomp"},
+			CheckOrigin: func(r *http.Request) bool {
+				return true
+			},
+		},
+		makeWSSubprotocolCodecMap(),
+		makeWSEndpointCodecMap(endpoints),
+	))
+	return m
+}
+
+func makeWSSubprotocolCodecMap() wstransport.SubprotocolCodecMap {
+	return wstransport.SubprotocolCodecMap{
+		"v12.stomp": wstransport.SubprotocolCodec{
+			Decode: decodeStompRequest,
+			Encode: encodeStompResponse,
+		},
+	}
+}
+
+// makeEndpointCodecMap returns a codec map configured for the addsvc.
+func makeWSEndpointCodecMap(endpoints addendpoint.Set) wstransport.EndpointCodecMap {
+	return wstransport.EndpointCodecMap{
+		"sum": wstransport.EndpointCodec{
+			Endpoint: endpoints.SumEndpoint,
+			Decode:   decodeWSSumRequest,
+			Encode:   encodeWSSumResponse,
+		},
+		"concat": wstransport.EndpointCodec{
+			Endpoint: endpoints.ConcatEndpoint,
+			Decode:   decodeWSConcatRequest,
+			Encode:   encodeWSConcatResponse,
+		},
+	}
+}
+
+func decodeStompRequest(_ context.Context, req io.Reader) (string, io.Reader, error) {
+	rf := frame.NewReader(req)
+	f, err := rf.Read()
+	if err != nil && err != io.EOF {
+		return "", nil, err
+	}
+
+	if f.Command != frame.SEND {
+		return "", nil, errors.New("SEND messages supported only")
+	}
+
+	return f.Header.Get("destination"), bytes.NewReader(f.Body), nil
+}
+
+func encodeStompResponse(_ context.Context, topic string, res io.Writer, msg io.Reader) error {
+	body, err := ioutil.ReadAll(msg)
+	if err != nil {
+		return err
+	}
+
+	var h frame.Header
+	h.Add("destination", topic)
+	h.Add("content-type", "application/json")
+
+	f := frame.Frame{
+		Command: frame.MESSAGE,
+		Header:  &h,
+		Body:    body,
+	}
+
+	w := frame.NewWriter(res)
+	return w.Write(&f)
+}
+
+func decodeWSSumRequest(_ context.Context, msg io.Reader) (interface{}, error) {
+	var req addendpoint.SumRequest
+	err := json.NewDecoder(msg).Decode(&req)
+	return req, err
+}
+
+func encodeWSSumResponse(_ context.Context, res io.Writer, msg interface{}) error {
+	return json.NewEncoder(res).Encode(msg)
+}
+
+func decodeWSConcatRequest(_ context.Context, msg io.Reader) (interface{}, error) {
+	var req addendpoint.ConcatRequest
+	err := json.NewDecoder(msg).Decode(&req)
+	return req, err
+}
+
+func encodeWSConcatResponse(_ context.Context, res io.Writer, msg interface{}) error {
+	return json.NewEncoder(res).Encode(msg)
+}

--- a/transport/http/ws/README.md
+++ b/transport/http/ws/README.md
@@ -1,0 +1,181 @@
+# WebSocket
+
+[JSON RPC](http://www.ws.org) is "A light weight remote procedure call protocol". It allows for the creation of simple RPC-style APIs with human-readable messages that are front-end friendly.
+
+## Using WebSocket with Go-Kit
+Using WebSocket and go-kit together is quite simple.
+
+A WebSocket _server_ acts as an [HTTP Handler](https://godoc.org/net/http#Handler), receiving all requests to the WebSockets's URL. On initial handshake to the WebSocket URL the server performs the following:
+
+1. The server upgrades the incoming `http.Request` with the configured `github.com/gorilla/websocket.Upgrader` with the [`Subprotocols`](https://tools.ietf.org/html/rfc6455#section-1.9) you wish to support.
+2. Once the Subprotocol requested by the client is verified by the server that it is supported it will fire off a go routine with the WebSocket connection and `SubprotocolCodec`.
+3. Each WebSocket message is decoded by the `DecodeSubprotocolFunc` and the resulting _method_ is implemented as an `EndpointCodec`, a go-kit [Endpoint](https://godoc.org/github.com/go-kit/kit/endpoint#Endpoint), sandwiched between a decoder and encoder. The decoder picks apart the message request params, which can be passed to your endpoint as an `io.Reader`.
+4. The encoder receives the output from the endpoint and encodes the result to the `io.Writer` which is passed through the `EncodeSubprotocolFunc` as well so it can be sent back to the client.
+
+## Example — Add Service
+
+### `SubprotocolCodecMap`
+
+Let's say we want a service that adds two ints together and utilize the [STOMP](https://stomp.github.io) protocol with JSON messages. We'll serve this at `ws://localhost/ws`. First we establish a WebSocket connection specifying the STOP protocol.
+
+	ws.SubprotocolCodecMap{
+		"v12.stomp": ws.SubprotocolCodec{
+			Decode: decodeStompRequest,
+			Encode: encodeStompResponse,
+		},
+	}
+
+The `Sec-WebSocket-Protocol` maps to our `SubprotocolCodecMap`.
+
+	GET /ws HTTP/1.1
+	Host: localhost
+	Upgrade: websocket
+	Connection: Upgrade
+	Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==
+	Sec-WebSocket-Protocol: v12.stomp
+	Sec-WebSocket-Version: 13
+	Origin: http://example.com
+
+Our client connection should receive an acknoledgement of the request.
+
+	HTTP/1.1 101 Switching Protocols
+	Upgrade: websocket
+	Connection: Upgrade
+	Sec-WebSocket-Accept: HSmrc0sMlYUkAGmm5OPpG2HaGWk=
+	Sec-WebSocket-Protocol: v12.stomp
+
+So a request to our `sum` endpoint will be STOMP message:
+
+	SEND
+	destination:sum
+	content-type:application/json
+
+	{"a":1,"b":2}\0
+
+The `destination` header is what our `DecodeSubprotocolFunc` maps to our `EndpointCodecMap`.
+
+### Subprotocol Decoder
+
+	DecodeSubprotocolFunc func(context.Context, io.Reader) (string, io.Reader, error)
+
+A `DecodeSubprotocolFunc` is given the `io.Reader` from the WebSocket connection. It returns an object that will be the input to the Endpoint. For our purposes, the output should be a SumRequest, like this:
+
+	type SumRequest struct {
+		A, B int
+	}
+
+So here's our decoder:
+
+	func decodeStompRequest(_ context.Context, req io.Reader) (string, io.Reader, error) {
+		rf := frame.NewReader(req)
+		f, err := rf.Read()
+		if err != nil && err != io.EOF {
+			return "", nil, err
+		}
+
+		if f.Command != frame.SEND {
+			return "", nil, errors.New("SEND messages supported only")
+		}
+
+		return f.Header.Get("destination"), bytes.NewReader(f.Body), nil
+	}
+
+A new `io.Reader` with just the message body will now be passed to the endpoint decoder. Once the endpoint has done its work, we hand over to the…
+
+### Subprotocol Encoder
+	
+	EncodeSubprotocolFunc func(context.Context, string, io.Writer, io.Reader) error
+
+The encoder takes the output of the endpoint encoder, and writes the message to the `io.Writer` that is sent back to the client in STOMP protocol format. Here's our encoder:
+
+	func encodeStompResponse(_ context.Context, topic string, res io.Writer, msg io.Reader) error {
+		body, err := ioutil.ReadAll(msg)
+		if err != nil {
+			return err
+		}
+
+		var h frame.Header
+		h.Add("destination", topic)
+		h.Add("content-type", "application/json")
+
+		f := frame.Frame{
+			Command: frame.MESSAGE,
+			Header:  &h,
+			Body:    body,
+		}
+
+		w := frame.NewWriter(res)
+		return w.Write(&f)
+	}
+
+### `EndpointCodecMap`
+The routing table for incoming requests is the `EndpointCodecMap`. The key of the map is the STOMP destination header value. Here, we're routing the `sum` method to an `EndpointCodec` wrapped around `sumEndpoint`.
+
+	ws.EndpointCodecMap{
+		"sum": ws.EndpointCodec{
+			Endpoint: sumEndpoint,
+			Decode:   decodeSumRequest,
+			Encode:   encodeSumResponse,
+		},
+	}
+
+### Endpoint Decoder
+	type DecodeRequestFunc func(context.Context, json.RawMessage) (request interface{}, err error)
+
+A `DecodeRequestFunc` is given the raw JSON from the `params` property of the Request object, _not_ the whole request object. It returns an object that will be the input to the Endpoint. For our purposes, the output should be a SumRequest, like this:
+
+	type SumRequest struct {
+		A, B int
+	}
+
+So here's our decoder:
+
+	func decodeWSSumRequest(_ context.Context, msg io.Reader) (interface{}, error) {
+		var req addendpoint.SumRequest
+		err := json.NewDecoder(msg).Decode(&req)
+		return req, err
+	}
+
+So our `SumRequest` will now be passed to the endpoint. Once the endpoint has done its work, we hand over to the…
+
+### Endpoint Encoder
+The encoder takes the output of the endpoint, and builds the raw JSON message that will form the `result` field of a [Response Object](http://www.ws.org/specification#response_object). Our result is going to be a plain int. Here's our encoder:
+
+	func encodeWSSumResponse(_ context.Context, res io.Writer, msg interface{}) error {
+		return json.NewEncoder(res).Encode(msg)
+	}
+
+### Server
+Now that we have an SubprotocolCodec and an EndpointCodec we can wire up the server:
+
+	handler := ws.NewServer(
+		websocket.Upgrader{
+			Subprotocols: []string{"v12.stomp"},
+			CheckOrigin: func(r *http.Request) bool {
+				return true
+			},
+		},
+		ws.SubprotocolCodecMap{
+			"v12.stomp": ws.SubprotocolCodec{
+				Decode: decodeStompRequest,
+				Encode: encodeStompResponse,
+			},
+		},
+		ws.EndpointCodecMap{
+			"sum": ws.EndpointCodec{
+				Endpoint: sumEndpoint,
+				Decode:   decodeSumRequest,
+				Encode:   encodeSumResponse,
+			},
+		}
+	)
+	http.Handle("/ws", handler)
+	http.ListenAndServe(":80", nil)
+
+With all of this done, our example request above should result in a response like this:
+
+	MESSAGE
+	destination:sum
+	content-type:application/json
+
+	{"v":3}\0

--- a/transport/http/ws/README.md
+++ b/transport/http/ws/README.md
@@ -1,6 +1,6 @@
 # WebSocket
 
-[JSON RPC](http://www.ws.org) is "A light weight remote procedure call protocol". It allows for the creation of simple RPC-style APIs with human-readable messages that are front-end friendly.
+> [The WebSocket Protocol](https://tools.ietf.org/html/rfc6455) enables two-way communication between a client running untrusted code in a controlled environment to a remote host that has opted-in to communications from that code.  The security model used for this is the origin-based security model commonly used by web browsers.  The protocol consists of an opening handshake followed by basic message framing, layered over TCP.
 
 ## Using WebSocket with Go-Kit
 Using WebSocket and go-kit together is quite simple.

--- a/transport/http/ws/client.go
+++ b/transport/http/ws/client.go
@@ -1,0 +1,240 @@
+package ws
+
+// import (
+// 	"bytes"
+// 	"context"
+// 	"encoding/json"
+// 	"io/ioutil"
+// 	"net/http"
+// 	"net/url"
+// 	"sync/atomic"
+
+// 	"github.com/go-kit/kit/endpoint"
+// 	httptransport "github.com/go-kit/kit/transport/http"
+// )
+
+// // Client wraps a JSON RPC method and provides a method that implements endpoint.Endpoint.
+// type Client struct {
+// 	client httptransport.HTTPClient
+
+// 	// JSON RPC endpoint URL
+// 	tgt *url.URL
+
+// 	// JSON RPC method name.
+// 	method string
+
+// 	enc            EncodeRequestFunc
+// 	dec            DecodeResponseFunc
+// 	before         []httptransport.RequestFunc
+// 	after          []httptransport.ClientResponseFunc
+// 	finalizer      httptransport.ClientFinalizerFunc
+// 	requestID      RequestIDGenerator
+// 	bufferedStream bool
+// }
+
+// type clientRequest struct {
+// 	JSONRPC string          `json:"ws"`
+// 	Method  string          `json:"method"`
+// 	Params  json.RawMessage `json:"params"`
+// 	ID      interface{}     `json:"id"`
+// }
+
+// // NewClient constructs a usable Client for a single remote method.
+// func NewClient(
+// 	tgt *url.URL,
+// 	method string,
+// 	options ...ClientOption,
+// ) *Client {
+// 	c := &Client{
+// 		client:         http.DefaultClient,
+// 		method:         method,
+// 		tgt:            tgt,
+// 		enc:            DefaultRequestEncoder,
+// 		dec:            DefaultResponseDecoder,
+// 		before:         []httptransport.RequestFunc{},
+// 		after:          []httptransport.ClientResponseFunc{},
+// 		requestID:      NewAutoIncrementID(0),
+// 		bufferedStream: false,
+// 	}
+// 	for _, option := range options {
+// 		option(c)
+// 	}
+// 	return c
+// }
+
+// // DefaultRequestEncoder marshals the given request to JSON.
+// func DefaultRequestEncoder(_ context.Context, req interface{}) (json.RawMessage, error) {
+// 	return json.Marshal(req)
+// }
+
+// // DefaultResponseDecoder unmarshals the result to interface{}, or returns an
+// // error, if found.
+// func DefaultResponseDecoder(_ context.Context, res Response) (interface{}, error) {
+// 	if res.Error != nil {
+// 		return nil, *res.Error
+// 	}
+// 	var result interface{}
+// 	err := json.Unmarshal(res.Result, &result)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return result, nil
+// }
+
+// // ClientOption sets an optional parameter for clients.
+// type ClientOption func(*Client)
+
+// // SetClient sets the underlying HTTP client used for requests.
+// // By default, http.DefaultClient is used.
+// func SetClient(client httptransport.HTTPClient) ClientOption {
+// 	return func(c *Client) { c.client = client }
+// }
+
+// // ClientBefore sets the RequestFuncs that are applied to the outgoing HTTP
+// // request before it's invoked.
+// func ClientBefore(before ...httptransport.RequestFunc) ClientOption {
+// 	return func(c *Client) { c.before = append(c.before, before...) }
+// }
+
+// // ClientAfter sets the ClientResponseFuncs applied to the server's HTTP
+// // response prior to it being decoded. This is useful for obtaining anything
+// // from the response and adding onto the context prior to decoding.
+// func ClientAfter(after ...httptransport.ClientResponseFunc) ClientOption {
+// 	return func(c *Client) { c.after = append(c.after, after...) }
+// }
+
+// // ClientFinalizer is executed at the end of every HTTP request.
+// // By default, no finalizer is registered.
+// func ClientFinalizer(f httptransport.ClientFinalizerFunc) ClientOption {
+// 	return func(c *Client) { c.finalizer = f }
+// }
+
+// // ClientRequestEncoder sets the func used to encode the request params to JSON.
+// // If not set, DefaultRequestEncoder is used.
+// func ClientRequestEncoder(enc EncodeRequestFunc) ClientOption {
+// 	return func(c *Client) { c.enc = enc }
+// }
+
+// // ClientResponseDecoder sets the func used to decode the response params from
+// // JSON. If not set, DefaultResponseDecoder is used.
+// func ClientResponseDecoder(dec DecodeResponseFunc) ClientOption {
+// 	return func(c *Client) { c.dec = dec }
+// }
+
+// // RequestIDGenerator returns an ID for the request.
+// type RequestIDGenerator interface {
+// 	Generate() interface{}
+// }
+
+// // ClientRequestIDGenerator is executed before each request to generate an ID
+// // for the request.
+// // By default, AutoIncrementRequestID is used.
+// func ClientRequestIDGenerator(g RequestIDGenerator) ClientOption {
+// 	return func(c *Client) { c.requestID = g }
+// }
+
+// // BufferedStream sets whether the Response.Body is left open, allowing it
+// // to be read from later. Useful for transporting a file as a buffered stream.
+// func BufferedStream(buffered bool) ClientOption {
+// 	return func(c *Client) { c.bufferedStream = buffered }
+// }
+
+// // Endpoint returns a usable endpoint that invokes the remote endpoint.
+// func (c Client) Endpoint() endpoint.Endpoint {
+// 	return func(ctx context.Context, request interface{}) (interface{}, error) {
+// 		ctx, cancel := context.WithCancel(ctx)
+// 		defer cancel()
+
+// 		var (
+// 			resp *http.Response
+// 			err  error
+// 		)
+// 		if c.finalizer != nil {
+// 			defer func() {
+// 				if resp != nil {
+// 					ctx = context.WithValue(ctx, httptransport.ContextKeyResponseHeaders, resp.Header)
+// 					ctx = context.WithValue(ctx, httptransport.ContextKeyResponseSize, resp.ContentLength)
+// 				}
+// 				c.finalizer(ctx, err)
+// 			}()
+// 		}
+
+// 		var params json.RawMessage
+// 		if params, err = c.enc(ctx, request); err != nil {
+// 			return nil, err
+// 		}
+// 		rpcReq := clientRequest{
+// 			JSONRPC: "",
+// 			Method:  c.method,
+// 			Params:  params,
+// 			ID:      c.requestID.Generate(),
+// 		}
+
+// 		req, err := http.NewRequest("POST", c.tgt.String(), nil)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+
+// 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+// 		var b bytes.Buffer
+// 		req.Body = ioutil.NopCloser(&b)
+// 		err = json.NewEncoder(&b).Encode(rpcReq)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+
+// 		for _, f := range c.before {
+// 			ctx = f(ctx, req)
+// 		}
+
+// 		resp, err = c.client.Do(req.WithContext(ctx))
+// 		if err != nil {
+// 			return nil, err
+// 		}
+
+// 		if !c.bufferedStream {
+// 			defer resp.Body.Close()
+// 		}
+
+// 		// Decode the body into an object
+// 		var rpcRes Response
+// 		err = json.NewDecoder(resp.Body).Decode(&rpcRes)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+
+// 		for _, f := range c.after {
+// 			ctx = f(ctx, resp)
+// 		}
+
+// 		return c.dec(ctx, rpcRes)
+// 	}
+// }
+
+// // ClientFinalizerFunc can be used to perform work at the end of a client HTTP
+// // request, after the response is returned. The principal
+// // intended use is for error logging. Additional response parameters are
+// // provided in the context under keys with the ContextKeyResponse prefix.
+// // Note: err may be nil. There maybe also no additional response parameters
+// // depending on when an error occurs.
+// type ClientFinalizerFunc func(ctx context.Context, err error)
+
+// // autoIncrementID is a RequestIDGenerator that generates
+// // auto-incrementing integer IDs.
+// type autoIncrementID struct {
+// 	v *uint64
+// }
+
+// // NewAutoIncrementID returns an auto-incrementing request ID generator,
+// // initialised with the given value.
+// func NewAutoIncrementID(init uint64) RequestIDGenerator {
+// 	// Offset by one so that the first generated value = init.
+// 	v := init - 1
+// 	return &autoIncrementID{v: &v}
+// }
+
+// // Generate satisfies RequestIDGenerator
+// func (i *autoIncrementID) Generate() interface{} {
+// 	id := atomic.AddUint64(i.v, 1)
+// 	return id
+// }

--- a/transport/http/ws/client_test.go
+++ b/transport/http/ws/client_test.go
@@ -1,0 +1,271 @@
+package ws_test
+
+// import (
+// 	"context"
+// 	"encoding/json"
+// 	"io"
+// 	"io/ioutil"
+// 	"net/http"
+// 	"net/http/httptest"
+// 	"net/url"
+// 	"testing"
+
+// 	"github.com/go-kit/kit/transport/http/ws"
+// )
+
+// type TestResponse struct {
+// 	Body   io.ReadCloser
+// 	String string
+// }
+
+// func TestCanCallBeforeFunc(t *testing.T) {
+// 	called := false
+// 	u, _ := url.Parse("http://senseye.io/ws")
+// 	sut := ws.NewClient(
+// 		u,
+// 		"add",
+// 		ws.ClientBefore(func(ctx context.Context, req *http.Request) context.Context {
+// 			called = true
+// 			return ctx
+// 		}),
+// 	)
+
+// 	sut.Endpoint()(context.TODO(), "foo")
+
+// 	if !called {
+// 		t.Fatal("Expected client before func to be called. Wasn't.")
+// 	}
+// }
+
+// type staticIDGenerator int
+
+// func (g staticIDGenerator) Generate() interface{} { return g }
+
+// func TestClientHappyPath(t *testing.T) {
+// 	var (
+// 		afterCalledKey    = "AC"
+// 		beforeHeaderKey   = "BF"
+// 		beforeHeaderValue = "beforeFuncWozEre"
+// 		testbody          = `{"ws":"2.0", "result":5}`
+// 		requestBody       []byte
+// 		beforeFunc        = func(ctx context.Context, r *http.Request) context.Context {
+// 			r.Header.Add(beforeHeaderKey, beforeHeaderValue)
+// 			return ctx
+// 		}
+// 		encode = func(ctx context.Context, req interface{}) (json.RawMessage, error) {
+// 			return json.Marshal(req)
+// 		}
+// 		afterFunc = func(ctx context.Context, r *http.Response) context.Context {
+// 			return context.WithValue(ctx, afterCalledKey, true)
+// 		}
+// 		finalizerCalled = false
+// 		fin             = func(ctx context.Context, err error) {
+// 			finalizerCalled = true
+// 		}
+// 		decode = func(ctx context.Context, res ws.Response) (interface{}, error) {
+// 			if ac := ctx.Value(afterCalledKey); ac == nil {
+// 				t.Fatal("after not called")
+// 			}
+// 			var result int
+// 			err := json.Unmarshal(res.Result, &result)
+// 			if err != nil {
+// 				return nil, err
+// 			}
+// 			return result, nil
+// 		}
+
+// 		wantID = 666
+// 		gen    = staticIDGenerator(wantID)
+// 	)
+
+// 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 		if r.Header.Get(beforeHeaderKey) != beforeHeaderValue {
+// 			t.Fatal("Header not set by before func.")
+// 		}
+
+// 		b, err := ioutil.ReadAll(r.Body)
+// 		if err != nil && err != io.EOF {
+// 			t.Fatal(err)
+// 		}
+// 		requestBody = b
+
+// 		w.WriteHeader(http.StatusOK)
+// 		w.Write([]byte(testbody))
+// 	}))
+
+// 	sut := ws.NewClient(
+// 		mustParse(server.URL),
+// 		"add",
+// 		ws.ClientRequestEncoder(encode),
+// 		ws.ClientResponseDecoder(decode),
+// 		ws.ClientBefore(beforeFunc),
+// 		ws.ClientAfter(afterFunc),
+// 		ws.ClientRequestIDGenerator(gen),
+// 		ws.ClientFinalizer(fin),
+// 		ws.SetClient(http.DefaultClient),
+// 		ws.BufferedStream(false),
+// 	)
+
+// 	type addRequest struct {
+// 		A int
+// 		B int
+// 	}
+
+// 	in := addRequest{2, 2}
+
+// 	result, err := sut.Endpoint()(context.Background(), in)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	ri, ok := result.(int)
+// 	if !ok {
+// 		t.Fatalf("result is not int: (%T)%+v", result, result)
+// 	}
+// 	if ri != 5 {
+// 		t.Fatalf("want=5, got=%d", ri)
+// 	}
+
+// 	var requestAtServer ws.Request
+// 	err = json.Unmarshal(requestBody, &requestAtServer)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	if id, _ := requestAtServer.ID.Int(); id != wantID {
+// 		t.Fatalf("Request ID at server: want=%d, got=%d", wantID, id)
+// 	}
+
+// 	var paramsAtServer addRequest
+// 	err = json.Unmarshal(requestAtServer.Params, &paramsAtServer)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+
+// 	if paramsAtServer != in {
+// 		t.Fatalf("want=%+v, got=%+v", in, paramsAtServer)
+// 	}
+
+// 	if !finalizerCalled {
+// 		t.Fatal("Expected finalizer to be called. Wasn't.")
+// 	}
+// }
+
+// func TestCanUseDefaults(t *testing.T) {
+// 	var (
+// 		testbody    = `{"ws":"2.0", "result":"boogaloo"}`
+// 		requestBody []byte
+// 	)
+
+// 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 		b, err := ioutil.ReadAll(r.Body)
+// 		if err != nil && err != io.EOF {
+// 			t.Fatal(err)
+// 		}
+// 		requestBody = b
+
+// 		w.WriteHeader(http.StatusOK)
+// 		w.Write([]byte(testbody))
+// 	}))
+
+// 	sut := ws.NewClient(
+// 		mustParse(server.URL),
+// 		"add",
+// 	)
+
+// 	type addRequest struct {
+// 		A int
+// 		B int
+// 	}
+
+// 	in := addRequest{2, 2}
+
+// 	result, err := sut.Endpoint()(context.Background(), in)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	rs, ok := result.(string)
+// 	if !ok {
+// 		t.Fatalf("result is not string: (%T)%+v", result, result)
+// 	}
+// 	if rs != "boogaloo" {
+// 		t.Fatalf("want=boogaloo, got=%s", rs)
+// 	}
+
+// 	var requestAtServer ws.Request
+// 	err = json.Unmarshal(requestBody, &requestAtServer)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	var paramsAtServer addRequest
+// 	err = json.Unmarshal(requestAtServer.Params, &paramsAtServer)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+
+// 	if paramsAtServer != in {
+// 		t.Fatalf("want=%+v, got=%+v", in, paramsAtServer)
+// 	}
+// }
+
+// func TestClientCanHandleJSONRPCError(t *testing.T) {
+// 	var testbody = `{
+// 		"ws": "2.0",
+// 		"error": {
+// 			"code": -32603,
+// 			"message": "Bad thing happened."
+// 		}
+// 	}`
+// 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 		w.WriteHeader(http.StatusOK)
+// 		w.Write([]byte(testbody))
+// 	}))
+
+// 	sut := ws.NewClient(mustParse(server.URL), "add")
+
+// 	_, err := sut.Endpoint()(context.Background(), 5)
+// 	if err == nil {
+// 		t.Fatal("Expected error, got none.")
+// 	}
+
+// 	{
+// 		want := "Bad thing happened."
+// 		got := err.Error()
+// 		if got != want {
+// 			t.Fatalf("error message: want=%s, got=%s", want, got)
+// 		}
+// 	}
+
+// 	type errorCoder interface {
+// 		ErrorCode() int
+// 	}
+// 	ec, ok := err.(errorCoder)
+// 	if !ok {
+// 		t.Fatal("Error is not errorCoder")
+// 	}
+
+// 	{
+// 		want := -32603
+// 		got := ec.ErrorCode()
+// 		if got != want {
+// 			t.Fatalf("error code: want=%d, got=%d", want, got)
+// 		}
+// 	}
+// }
+
+// func TestDefaultAutoIncrementer(t *testing.T) {
+// 	sut := ws.NewAutoIncrementID(0)
+// 	var want uint64
+// 	for ; want < 100; want++ {
+// 		got := sut.Generate()
+// 		if got != want {
+// 			t.Fatalf("want=%d, got=%d", want, got)
+// 		}
+// 	}
+// }
+
+// func mustParse(s string) *url.URL {
+// 	u, err := url.Parse(s)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	return u
+// }

--- a/transport/http/ws/doc.go
+++ b/transport/http/ws/doc.go
@@ -1,0 +1,3 @@
+// Package ws provides a WebSocket binding for endpoints.
+// See https://tools.ietf.org/html/rfc6455
+package ws

--- a/transport/http/ws/encode_decode.go
+++ b/transport/http/ws/encode_decode.go
@@ -1,0 +1,48 @@
+package ws
+
+import (
+	"io"
+
+	"github.com/go-kit/kit/endpoint"
+
+	"context"
+)
+
+// Server-Side Codec
+
+// EndpointCodec defines a server Endpoint and its associated codecs
+type EndpointCodec struct {
+	Endpoint endpoint.Endpoint
+	Decode   DecodeRequestFunc
+	Encode   EncodeResponseFunc
+}
+
+// EndpointCodecMap maps the Request.Method to the proper EndpointCodec
+type EndpointCodecMap map[string]EndpointCodec
+
+// DecodeRequestFunc extracts a user-domain io.Reader from the incoming WebSocket Subprotocol
+// It's designed to be used in WebSocket servers, for server-side endpoints.
+// One straightforward DecodeRequestFunc could be something that unmarshals
+// JSON from the request reader to the concrete request type.
+type DecodeRequestFunc func(context.Context, io.Reader) (request interface{}, err error)
+
+// EncodeResponseFunc encodes the passed response object to a WebSocket Subprotocol result.
+// It's designed to be used in WebSocket servers, for server-side endpoints.
+// One straightforward EncodeResponseFunc could be something that JSON encodes
+// the object directly.
+type EncodeResponseFunc func(context.Context, io.Writer, interface{}) (err error)
+
+// Client-Side Codec
+
+// EncodeRequestFunc encodes the given request object to raw JSON.
+// It's designed to be used in JSON RPC clients, for client-side
+// endpoints. One straightforward EncodeResponseFunc could be something that
+// JSON encodes the object directly.
+// type EncodeRequestFunc func(context.Context, interface{}) (response interface{}, err error)
+
+// DecodeResponseFunc extracts a user-domain response object from an JSON RPC
+// response object. It's designed to be used in JSON RPC clients, for
+// client-side endpoints. It is the responsibility of this function to decide
+// whether any error present in the JSON RPC response should be surfaced to the
+// client endpoint.
+// type DecodeResponseFunc func(context.Context, interface{}) (response interface{}, err error)

--- a/transport/http/ws/error.go
+++ b/transport/http/ws/error.go
@@ -1,0 +1,100 @@
+package ws
+
+// Error defines a JSON RPC error that can be returned
+// in a Response from the spec
+// http://www.ws.org/specification#error_object
+type Error struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// Error implements error.
+func (e Error) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return errorMessage[e.Code]
+}
+
+// ErrorCode returns the JSON RPC error code associated with the error.
+func (e Error) ErrorCode() int {
+	return e.Code
+}
+
+const (
+	// ParseError defines invalid JSON was received by the server.
+	// An error occurred on the server while parsing the JSON text.
+	ParseError int = -32700
+
+	// InvalidRequestError defines the JSON sent is not a valid Request object.
+	InvalidRequestError int = -32600
+
+	// MethodNotFoundError defines the method does not exist / is not available.
+	MethodNotFoundError int = -32601
+
+	// InvalidParamsError defines invalid method parameter(s).
+	InvalidParamsError int = -32602
+
+	// InternalError defines a server error
+	InternalError int = -32603
+)
+
+var errorMessage = map[int]string{
+	ParseError:          "An error occurred on the server while parsing the JSON text.",
+	InvalidRequestError: "The JSON sent is not a valid Request object.",
+	MethodNotFoundError: "The method does not exist / is not available.",
+	InvalidParamsError:  "Invalid method parameter(s).",
+	InternalError:       "Internal JSON-RPC error.",
+}
+
+// ErrorMessage returns a message for the JSON RPC error code. It returns the empty
+// string if the code is unknown.
+func ErrorMessage(code int) string {
+	return errorMessage[code]
+}
+
+type parseError string
+
+func (e parseError) Error() string {
+	return string(e)
+}
+func (e parseError) ErrorCode() int {
+	return ParseError
+}
+
+type invalidRequestError string
+
+func (e invalidRequestError) Error() string {
+	return string(e)
+}
+func (e invalidRequestError) ErrorCode() int {
+	return InvalidRequestError
+}
+
+type methodNotFoundError string
+
+func (e methodNotFoundError) Error() string {
+	return string(e)
+}
+func (e methodNotFoundError) ErrorCode() int {
+	return MethodNotFoundError
+}
+
+type invalidParamsError string
+
+func (e invalidParamsError) Error() string {
+	return string(e)
+}
+func (e invalidParamsError) ErrorCode() int {
+	return InvalidParamsError
+}
+
+type internalError string
+
+func (e internalError) Error() string {
+	return string(e)
+}
+func (e internalError) ErrorCode() int {
+	return InternalError
+}

--- a/transport/http/ws/error_test.go
+++ b/transport/http/ws/error_test.go
@@ -1,0 +1,54 @@
+package ws
+
+import "testing"
+
+func TestError(t *testing.T) {
+	wantCode := ParseError
+	sut := Error{
+		Code: wantCode,
+	}
+
+	gotCode := sut.ErrorCode()
+	if gotCode != wantCode {
+		t.Fatalf("want=%d, got=%d", gotCode, wantCode)
+	}
+
+	if sut.Error() == "" {
+		t.Fatal("Empty error string.")
+	}
+
+	want := "override"
+	sut.Message = want
+	got := sut.Error()
+	if sut.Error() != want {
+		t.Fatalf("overridden error message: want=%s, got=%s", want, got)
+	}
+
+}
+func TestErrorsSatisfyError(t *testing.T) {
+	errs := []interface{}{
+		parseError("parseError"),
+		invalidRequestError("invalidRequestError"),
+		methodNotFoundError("methodNotFoundError"),
+		invalidParamsError("invalidParamsError"),
+		internalError("internalError"),
+	}
+	for _, e := range errs {
+		err, ok := e.(error)
+		if !ok {
+			t.Fatalf("Couldn't assert %s as error.", e)
+		}
+		errString := err.Error()
+		if errString == "" {
+			t.Fatal("Empty error string")
+		}
+
+		ec, ok := e.(ErrorCoder)
+		if !ok {
+			t.Fatalf("Couldn't assert %s as ErrorCoder.", e)
+		}
+		if ErrorMessage(ec.ErrorCode()) == "" {
+			t.Fatalf("Error type %s returned code of %d, which does not map to error string", e, ec.ErrorCode())
+		}
+	}
+}

--- a/transport/http/ws/server.go
+++ b/transport/http/ws/server.go
@@ -1,0 +1,252 @@
+package ws
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/go-kit/kit/log"
+)
+
+const (
+	DefaultBufferSize = 1024
+)
+
+// Server wraps an endpoint and implements http.Handler.
+type Server struct {
+	upgrader websocket.Upgrader
+	scm      SubprotocolCodecMap
+	ecm      EndpointCodecMap
+	// before       []RequestFunc
+	// after        []ServerResponseFunc
+	errorEncoder ErrorEncoder
+	finalizer    ServerFinalizerFunc
+	logger       log.Logger
+}
+
+// NewServer constructs a new server, which implements http.Server.
+func NewServer(
+	upgrader websocket.Upgrader,
+	scm SubprotocolCodecMap,
+	ecm EndpointCodecMap,
+	options ...ServerOption,
+) *Server {
+	s := &Server{
+		upgrader:     upgrader,
+		scm:          scm,
+		ecm:          ecm,
+		errorEncoder: DefaultErrorEncoder,
+		logger:       log.NewNopLogger(),
+	}
+	for _, option := range options {
+		option(s)
+	}
+	return s
+}
+
+// ServerOption sets an optional parameter for servers.
+type ServerOption func(*Server)
+
+// ServerBefore functions are executed on the HTTP request object before the
+// request is decoded.
+// func ServerBefore(before ...RequestFunc) ServerOption {
+// 	return func(s *Server) { s.before = append(s.before, before...) }
+// }
+
+// ServerAfter functions are executed on the HTTP response writer after the
+// endpoint is invoked, but before anything is written to the client.
+// func ServerAfter(after ...ServerResponseFunc) ServerOption {
+// 	return func(s *Server) { s.after = append(s.after, after...) }
+// }
+
+// ServerErrorEncoder is used to encode errors to the http.ResponseWriter
+// whenever they're encountered in the processing of a request. Clients can
+// use this to provide custom error formatting and response codes. By default,
+// errors will be written with the DefaultErrorEncoder.
+func ServerErrorEncoder(ee ErrorEncoder) ServerOption {
+	return func(s *Server) { s.errorEncoder = ee }
+}
+
+// ServerErrorLogger is used to log non-terminal errors. By default, no errors
+// are logged. This is intended as a diagnostic measure. Finer-grained control
+// of error handling, including logging in more detail, should be performed in a
+// custom ServerErrorEncoder or ServerFinalizer, both of which have access to
+// the context.
+func ServerErrorLogger(logger log.Logger) ServerOption {
+	return func(s *Server) { s.logger = logger }
+}
+
+// ServerFinalizer is executed at the end of every HTTP request.
+// By default, no finalizer is registered.
+func ServerFinalizer(f ServerFinalizerFunc) ServerOption {
+	return func(s *Server) { s.finalizer = f }
+}
+
+// ServeHTTP implements http.Handler.
+func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Upgrade the incoming HTTP request to a WebSocket connection
+	wsconn, err := s.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		s.logger.Log("err", err)
+		return
+	}
+
+	// Extract the negotiated WebSocket Subprotocol and look it up
+	// in the SubprotocolCodecMap
+	subprotocol := wsconn.Subprotocol()
+	sc, ok := s.scm[subprotocol]
+	if !ok {
+		s.logger.Log("err", fmt.Sprintf("subprotocol '%s' not supported", subprotocol))
+		wsconn.Close()
+		return
+	}
+
+	// Handle the WebSocket in a separate go routine with the WebSocket connection itself
+	// and the proper SubprotocolCodec
+	go s.serveWS(ctx, sc, wsconn)
+}
+
+func (s Server) serveWS(ctx context.Context, sc SubprotocolCodec, wsconn *websocket.Conn) {
+	// Loop forever until error or close
+	for {
+		// Get the next Reader from the WebSocket connection
+		msgtype, reader, err := wsconn.NextReader()
+		if err != nil {
+			s.logger.Log("err", err)
+			s.errorEncoder(ctx, err, wsconn)
+			break
+		}
+
+		// Use the SubprotocolCodec to decode the contents
+		// of the Reader to extract the Endpoint method
+		// to invoke.
+		method, reader, err := sc.Decode(ctx, reader)
+		if err != nil {
+			s.logger.Log("err", err)
+			s.errorEncoder(ctx, err, wsconn)
+			break
+		}
+
+		// Find the method in the EndpointCodecMap
+		e, ok := s.ecm[method]
+		if !ok {
+			err := methodNotFoundError(fmt.Sprintf("Method %s was not found.", method))
+			s.logger.Log("err", err)
+			s.errorEncoder(ctx, err, wsconn)
+			return
+		}
+
+		// Use the EndpointCodec to decode the rests
+		// of the contents of the reader.
+		req, err := e.Decode(ctx, reader)
+		fmt.Println(req, err)
+		if err != nil {
+			s.logger.Log("err", err)
+			s.errorEncoder(ctx, err, wsconn)
+			break
+		}
+
+		// Invoke the Endpoint with the concrete request object
+		es, err := e.Endpoint(ctx, req)
+		fmt.Println(es, err)
+		if err != nil {
+			s.logger.Log("err", err)
+			s.errorEncoder(ctx, err, wsconn)
+			break
+		}
+
+		// Set up a Buffer and encode the results of the Endpoint
+		// into the Buffer.
+		var buf bytes.Buffer
+		err = e.Encode(ctx, &buf, es)
+		if err != nil {
+			s.logger.Log("err", err)
+			s.errorEncoder(ctx, err, wsconn)
+			break
+		}
+
+		// Get a WebSocket Writer to respond to the client
+		// with the result of the Endpoint
+		writer, err := wsconn.NextWriter(msgtype)
+		if err != nil {
+			s.logger.Log("err", err)
+			s.errorEncoder(ctx, err, wsconn)
+			break
+		}
+
+		// Encode the results of the Endpoint with the
+		// SubprotocolCodec and write the results to the
+		// WebSocket writer, close the writer to flush
+		// the results to the client.
+		err = sc.Encode(ctx, method, writer, &buf)
+		if err != nil {
+			s.logger.Log("err", err)
+			s.errorEncoder(ctx, err, wsconn)
+			break
+		}
+		writer.Close()
+	}
+
+	wsconn.Close()
+}
+
+// ErrorEncoder is responsible for encoding an error to the ResponseWriter.
+// Users are encouraged to use custom ErrorEncoders to encode HTTP errors to
+// their clients, and will likely want to pass and check for their own error
+// types. See the example shipping/handling service.
+type ErrorEncoder func(ctx context.Context, err error, wsconn *websocket.Conn)
+
+// ServerFinalizerFunc can be used to perform work at the end of an HTTP
+// request, after the response has been written to the client. The principal
+// intended use is for request logging. In addition to the response code
+// provided in the function signature, additional response parameters are
+// provided in the context under keys with the ContextKeyResponse prefix.
+type ServerFinalizerFunc func(ctx context.Context, code int, wsconn *websocket.Conn)
+
+// DefaultErrorEncoder writes the error to the ResponseWriter,
+// as a json-rpc error response, with an InternalError status code.
+// The Error() string of the error will be used as the response error message.
+// If the error implements ErrorCoder, the provided code will be set on the
+// response error.
+// If the error implements Headerer, the given headers will be set.
+func DefaultErrorEncoder(_ context.Context, err error, wsconn *websocket.Conn) {
+	e := Error{
+		Code:    websocket.CloseInternalServerErr,
+		Message: err.Error(),
+	}
+	if sc, ok := err.(ErrorCoder); ok {
+		e.Code = sc.ErrorCode()
+	}
+
+	msg := websocket.FormatCloseMessage(e.Code, e.Message)
+	wsconn.WriteControl(websocket.CloseMessage, msg, time.Now())
+}
+
+// ErrorCoder is checked by DefaultErrorEncoder. If an error value implements
+// ErrorCoder, the integer result of ErrorCode() will be used as the JSONRPC
+// error code when encoding the error.
+//
+// By default, InternalError (-32603) is used.
+type ErrorCoder interface {
+	ErrorCode() int
+}
+
+// interceptingWriter intercepts calls to WriteHeader, so that a finalizer
+// can be given the correct status code.
+type interceptingWriter struct {
+	http.ResponseWriter
+	code int
+}
+
+// WriteHeader may not be explicitly called, so care must be taken to
+// initialize w.code to its default value of http.StatusOK.
+func (w *interceptingWriter) WriteHeader(code int) {
+	w.code = code
+	w.ResponseWriter.WriteHeader(code)
+}

--- a/transport/http/ws/server_test.go
+++ b/transport/http/ws/server_test.go
@@ -1,0 +1,343 @@
+package ws_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/gorilla/websocket"
+
+	"github.com/go-kit/kit/transport/http/ws"
+)
+
+func addBody() io.Reader {
+	return body(`{"ws": "2.0", "method": "add", "params": [3, 2], "id": 1}`)
+}
+
+func body(in string) io.Reader {
+	return strings.NewReader(in)
+}
+
+func expectErrorCode(t *testing.T, want int, body []byte) {
+	var r ws.Response
+	err := json.Unmarshal(body, &r)
+	if err != nil {
+		t.Fatalf("Cant' decode response. err=%s, body=%s", err, body)
+	}
+	if r.Error == nil {
+		t.Fatalf("Expected error on response. Got none: %s", body)
+	}
+	if have := r.Error.Code; want != have {
+		t.Fatalf("Unexpected error code. Want %d, have %d: %s", want, have, body)
+	}
+}
+
+func nopDecoder(context.Context, int, []byte) (interface{}, error) { return struct{}{}, nil }
+func nopEncoder(context.Context, interface{}) (int, []byte, error) { return 1, []byte("[]"), nil }
+
+type mockLogger struct {
+	Called   bool
+	LastArgs []interface{}
+}
+
+func (l *mockLogger) Log(keyvals ...interface{}) error {
+	l.Called = true
+	l.LastArgs = append(l.LastArgs, keyvals)
+	return nil
+}
+
+// func TestServerBadDecode(t *testing.T) {
+// 	ecm := ws.EndpointCodecMap{
+// 		"add": ws.EndpointCodec{
+// 			Endpoint: endpoint.Nop,
+// 			Decode:   func(context.Context, json.RawMessage) (interface{}, error) { return struct{}{}, errors.New("oof") },
+// 			Encode:   nopEncoder,
+// 		},
+// 	}
+// 	logger := mockLogger{}
+// 	handler := ws.NewServer(ecm, ws.ServerErrorLogger(&logger))
+// 	server := httptest.NewServer(handler)
+// 	defer server.Close()
+// 	resp, _ := http.Post(server.URL, "application/json", addBody())
+// 	buf, _ := ioutil.ReadAll(resp.Body)
+// 	if want, have := http.StatusOK, resp.StatusCode; want != have {
+// 		t.Errorf("want %d, have %d: %s", want, have, buf)
+// 	}
+// 	expectErrorCode(t, ws.InternalError, buf)
+// 	if !logger.Called {
+// 		t.Fatal("Expected logger to be called with error. Wasn't.")
+// 	}
+// }
+
+// func TestServerBadEndpoint(t *testing.T) {
+// 	ecm := ws.EndpointCodecMap{
+// 		"add": ws.EndpointCodec{
+// 			Endpoint: func(context.Context, interface{}) (interface{}, error) { return struct{}{}, errors.New("oof") },
+// 			Decode:   nopDecoder,
+// 			Encode:   nopEncoder,
+// 		},
+// 	}
+// 	handler := ws.NewServer(ecm)
+// 	server := httptest.NewServer(handler)
+// 	defer server.Close()
+// 	resp, _ := http.Post(server.URL, "application/json", addBody())
+// 	if want, have := http.StatusOK, resp.StatusCode; want != have {
+// 		t.Errorf("want %d, have %d", want, have)
+// 	}
+// 	buf, _ := ioutil.ReadAll(resp.Body)
+// 	expectErrorCode(t, ws.InternalError, buf)
+// }
+
+// func TestServerBadEncode(t *testing.T) {
+// 	ecm := ws.EndpointCodecMap{
+// 		"add": ws.EndpointCodec{
+// 			Endpoint: endpoint.Nop,
+// 			Decode:   nopDecoder,
+// 			Encode:   func(context.Context, interface{}) (json.RawMessage, error) { return []byte{}, errors.New("oof") },
+// 		},
+// 	}
+// 	handler := ws.NewServer(ecm)
+// 	server := httptest.NewServer(handler)
+// 	defer server.Close()
+// 	resp, _ := http.Post(server.URL, "application/json", addBody())
+// 	if want, have := http.StatusOK, resp.StatusCode; want != have {
+// 		t.Errorf("want %d, have %d", want, have)
+// 	}
+// 	buf, _ := ioutil.ReadAll(resp.Body)
+// 	expectErrorCode(t, ws.InternalError, buf)
+// }
+
+// func TestServerErrorEncoder(t *testing.T) {
+// 	errTeapot := errors.New("teapot")
+// 	code := func(err error) int {
+// 		if err == errTeapot {
+// 			return http.StatusTeapot
+// 		}
+// 		return http.StatusInternalServerError
+// 	}
+// 	ecm := ws.EndpointCodecMap{
+// 		"add": ws.EndpointCodec{
+// 			Endpoint: func(context.Context, interface{}) (interface{}, error) { return struct{}{}, errTeapot },
+// 			Decode:   nopDecoder,
+// 			Encode:   nopEncoder,
+// 		},
+// 	}
+// 	handler := ws.NewServer(
+// 		ecm,
+// 		ws.ServerErrorEncoder(func(_ context.Context, err error, w http.ResponseWriter) { w.WriteHeader(code(err)) }),
+// 	)
+// 	server := httptest.NewServer(handler)
+// 	defer server.Close()
+// 	resp, _ := http.Post(server.URL, "application/json", addBody())
+// 	if want, have := http.StatusTeapot, resp.StatusCode; want != have {
+// 		t.Errorf("want %d, have %d", want, have)
+// 	}
+// }
+
+// func TestCanRejectNonPostRequest(t *testing.T) {
+// 	ecm := ws.EndpointCodecMap{}
+// 	handler := ws.NewServer(ecm)
+// 	server := httptest.NewServer(handler)
+// 	defer server.Close()
+// 	resp, _ := http.Get(server.URL)
+// 	if want, have := http.StatusMethodNotAllowed, resp.StatusCode; want != have {
+// 		t.Errorf("want %d, have %d", want, have)
+// 	}
+// }
+
+// func TestCanRejectInvalidJSON(t *testing.T) {
+// 	ecm := ws.EndpointCodecMap{}
+// 	handler := ws.NewServer(ecm)
+// 	server := httptest.NewServer(handler)
+// 	defer server.Close()
+// 	resp, _ := http.Post(server.URL, "application/json", body("clearlynotjson"))
+// 	if want, have := http.StatusOK, resp.StatusCode; want != have {
+// 		t.Errorf("want %d, have %d", want, have)
+// 	}
+// 	buf, _ := ioutil.ReadAll(resp.Body)
+// 	expectErrorCode(t, ws.ParseError, buf)
+// }
+
+// func TestServerUnregisteredMethod(t *testing.T) {
+// 	ecm := ws.EndpointCodecMap{}
+// 	handler := ws.NewServer(ecm)
+// 	server := httptest.NewServer(handler)
+// 	defer server.Close()
+// 	resp, _ := http.Post(server.URL, "application/json", addBody())
+// 	if want, have := http.StatusOK, resp.StatusCode; want != have {
+// 		t.Errorf("want %d, have %d", want, have)
+// 	}
+// 	buf, _ := ioutil.ReadAll(resp.Body)
+// 	expectErrorCode(t, ws.MethodNotFoundError, buf)
+// }
+
+func TestServerHappyPath(t *testing.T) {
+	step, response := testServer(t)
+	step()
+	resp := <-response
+	defer resp.Body.Close() // nolint
+	buf, _ := ioutil.ReadAll(resp.Body)
+	if want, have := http.StatusOK, resp.StatusCode; want != have {
+		t.Errorf("want %d, have %d (%s)", want, have, buf)
+	}
+	var r ws.Response
+	err := json.Unmarshal(buf, &r)
+	if err != nil {
+		t.Fatalf("Cant' decode response. err=%s, body=%s", err, buf)
+	}
+	if r.JSONRPC != ws.Version {
+		t.Fatalf("JSONRPC Version: want=%s, got=%s", ws.Version, r.JSONRPC)
+	}
+	if r.Error != nil {
+		t.Fatalf("Unxpected error on response: %s", buf)
+	}
+}
+
+// func TestMultipleServerBefore(t *testing.T) {
+// 	var done = make(chan struct{})
+// 	ecm := ws.EndpointCodecMap{
+// 		"add": ws.EndpointCodec{
+// 			Endpoint: endpoint.Nop,
+// 			Decode:   nopDecoder,
+// 			Encode:   nopEncoder,
+// 		},
+// 	}
+// 	handler := ws.NewServer(
+// 		ecm,
+// 		ws.ServerBefore(func(ctx context.Context, r *http.Request) context.Context {
+// 			ctx = context.WithValue(ctx, "one", 1)
+
+// 			return ctx
+// 		}),
+// 		ws.ServerBefore(func(ctx context.Context, r *http.Request) context.Context {
+// 			if _, ok := ctx.Value("one").(int); !ok {
+// 				t.Error("Value was not set properly when multiple ServerBefores are used")
+// 			}
+
+// 			close(done)
+// 			return ctx
+// 		}),
+// 	)
+// 	server := httptest.NewServer(handler)
+// 	defer server.Close()
+// 	http.Post(server.URL, "application/json", addBody()) // nolint
+
+// 	select {
+// 	case <-done:
+// 	case <-time.After(time.Second):
+// 		t.Fatal("timeout waiting for finalizer")
+// 	}
+// }
+
+// func TestMultipleServerAfter(t *testing.T) {
+// 	var done = make(chan struct{})
+// 	ecm := ws.EndpointCodecMap{
+// 		"add": ws.EndpointCodec{
+// 			Endpoint: endpoint.Nop,
+// 			Decode:   nopDecoder,
+// 			Encode:   nopEncoder,
+// 		},
+// 	}
+// 	handler := ws.NewServer(
+// 		ecm,
+// 		ws.ServerAfter(func(ctx context.Context, w http.ResponseWriter) context.Context {
+// 			ctx = context.WithValue(ctx, "one", 1)
+
+// 			return ctx
+// 		}),
+// 		ws.ServerAfter(func(ctx context.Context, w http.ResponseWriter) context.Context {
+// 			if _, ok := ctx.Value("one").(int); !ok {
+// 				t.Error("Value was not set properly when multiple ServerAfters are used")
+// 			}
+
+// 			close(done)
+// 			return ctx
+// 		}),
+// 	)
+// 	server := httptest.NewServer(handler)
+// 	defer server.Close()
+// 	http.Post(server.URL, "application/json", addBody()) // nolint
+
+// 	select {
+// 	case <-done:
+// 	case <-time.After(time.Second):
+// 		t.Fatal("timeout waiting for finalizer")
+// 	}
+// }
+
+// func TestCanFinalize(t *testing.T) {
+// 	var done = make(chan struct{})
+// 	var finalizerCalled bool
+// 	ecm := ws.EndpointCodecMap{
+// 		"add": ws.EndpointCodec{
+// 			Endpoint: endpoint.Nop,
+// 			Decode:   nopDecoder,
+// 			Encode:   nopEncoder,
+// 		},
+// 	}
+// 	handler := ws.NewServer(
+// 		ecm,
+// 		ws.ServerFinalizer(func(ctx context.Context, code int, req *http.Request) {
+// 			finalizerCalled = true
+// 			close(done)
+// 		}),
+// 	)
+// 	server := httptest.NewServer(handler)
+// 	defer server.Close()
+// 	http.Post(server.URL, "application/json", addBody()) // nolint
+
+// 	select {
+// 	case <-done:
+// 	case <-time.After(time.Second):
+// 		t.Fatal("timeout waiting for finalizer")
+// 	}
+
+// 	if !finalizerCalled {
+// 		t.Fatal("Finalizer was not called.")
+// 	}
+// }
+
+type endpointMapper struct {
+	e   endpoint.Endpoint
+	dec ws.DecodeRequestFunc
+	enc ws.EncodeResponseFunc
+}
+
+func (em *endpointMapper) Map([]byte) (endpoint.Endpoint, ws.DecodeRequestFunc, ws.EncodeResponseFunc) {
+	return em.e, em.dec, em.enc
+}
+
+func testServer(t *testing.T) (step func(), resp <-chan *http.Response) {
+	var (
+		stepch   = make(chan bool)
+		endpoint = func(ctx context.Context, request interface{}) (response interface{}, err error) {
+			<-stepch
+			return struct{}{}, nil
+		}
+		response = make(chan *http.Response)
+		ecm      = endpointMapper{
+			e:   endpoint,
+			dec: nopDecoder,
+			enc: nopEncoder,
+		}
+		handler = ws.NewServer(&ecm, websocket.Upgrader{})
+	)
+	go func() {
+		server := httptest.NewServer(handler)
+		defer server.Close()
+		rb := strings.NewReader(`{"ws": "2.0", "method": "add", "params": [3, 2], "id": 1}`)
+		resp, err := http.Post(server.URL, "application/json", rb)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		response <- resp
+	}()
+	return func() { stepch <- true }, response
+}

--- a/transport/http/ws/subprotocol.go
+++ b/transport/http/ws/subprotocol.go
@@ -1,0 +1,25 @@
+package ws
+
+import (
+	"context"
+	"io"
+)
+
+// Server-Side Codec
+
+// SubprotocolCodec defines a WebSocket Subprotocol to use for decoding and encoding data
+type SubprotocolCodec struct {
+	Decode DecodeSubprotocolFunc
+	Encode EncodeSubprotocolFunc
+}
+
+// SubprotocolCodecMap maps the WebSocket Sec-WebSocket-Protocol initial handshake header to a SubprotocolCodec
+type SubprotocolCodecMap map[string]SubprotocolCodec
+
+// DecodeSubprotocolFunc extracts the incoming WebSocket request into a string that maps
+// to the EndpointsCodecMap and remaining request data into an io.Reader.
+type DecodeSubprotocolFunc func(context.Context, io.Reader) (string, io.Reader, error)
+
+// EncodeSubprotocolFunc reads from the io.Reader which contains the results from EncodeResponseFunc
+// and writes it to the WebSocket io.Writer to return to the connected client.
+type EncodeSubprotocolFunc func(context.Context, string, io.Writer, io.Reader) error


### PR DESCRIPTION
I saw a lot of requests kicking around about WebSocket support so I thought I would take an initial pass at what something like that would look like. A lot of this code is a WIP, but the happy path in the addsvc example does work.

The README has a lot of the information to cover the concepts about handling the initial WebSocket connection and defining the Subprotocol to route incoming messages to the proper Endpoints. Because WebSockets are agnostic about what messages look like it was up to leveraging the Subprotocol to define what the server will accept and know how to decode and encode. I left the implementation of Subprotocol decoding/encoding up to the user of the package, but the addsvc does make use of a simple STOMP protocol to illustrate how to wire up a sever.

So now I am just gauging interest if this is something people would use and/or this should belong in the core kit. Questions/comments/concerns welcome!