### PR TITLE
more convenient log: add FullPathCaller and TrimPathPrefixCaller

### DIFF
--- a/log/value.go
+++ b/log/value.go
@@ -92,30 +92,22 @@ func Caller(depth int) Valuer {
 	}
 }
 
-// Caller returns a Valuer that returns a file and line from a specified depth
+// FullPathCaller returns a Valuer that returns the full path of a file and line from a specified depth
 // in the callstack. Users will probably want to use DefaultFullPathCaller.
 func FullPathCaller(depth int) Valuer {
 	return func() interface{} {
 		_, file, line, _ := runtime.Caller(depth)
-		//idx := strings.LastIndexByte(file, '/')
-		// using idx+1 below handles both of following cases:
-		// idx == -1 because no "/" was found, or
-		// idx >= 0 and we want to start at the character after the found "/".
 		return file + ":" + strconv.Itoa(line)
 	}
 }
 
-// Caller returns a Valuer that returns a file and line from a specified depth
+// TrimPathPrefixCaller returns a Valuer that returns a file path(full path) with prefix trimmed and line from a specified depth
 // in the callstack. Users will probably want to use DefaultTrimmedPrefixPathCaller
 // eg:
 // logger = log.With(logger, "caller", log.DefaultTrimmedPrefixPathCaller("YOU-GOPATH/src/github.com/go-kit/"))
 func TrimPathPrefixCaller(depth int, prefix string) Valuer {
 	return func() interface{} {
 		_, file, line, _ := runtime.Caller(depth)
-		//idx := strings.LastIndexByte(file, '/')
-		// using idx+1 below handles both of following cases:
-		// idx == -1 because no "/" was found, or
-		// idx >= 0 and we want to start at the character after the found "/".
 		f := strings.TrimPrefix(file, prefix)
 		return f + ":" + strconv.Itoa(line)
 	}
@@ -137,7 +129,12 @@ var (
 	// method was invoked. It can only be used with log.With.
 	DefaultCaller = Caller(3)
 
-	DefaultFullPathCaller          = FullPathCaller(3)
+	// DefaultFullPathCaller is a Valuer that returns the full path of a file and line
+	// when the log method was invoked. It can only be used with log.With.
+	DefaultFullPathCaller = FullPathCaller(3)
+
+	// DefaultTrimmedPrefixPathCaller is a Valuer that returns a file path(full path) with prefix trimmed and line
+	// when the log method was invoked. It can only be used with log.With.
 	DefaultTrimmedPrefixPathCaller = func(prefix string) Valuer { return TrimPathPrefixCaller(3, prefix) }
 
 	_ = DefaultFullPathCaller          // fix: unused variable

--- a/log/value_test.go
+++ b/log/value_test.go
@@ -39,7 +39,7 @@ func TestValueBinding(t *testing.T) {
 	if want, have := start.Add(time.Second), timestamp; want != have {
 		t.Errorf("output[1]: want %v, have %v", want, have)
 	}
-	if want, have := "value_test.go:31", fmt.Sprint(output[3]); want != have {
+	if want, have := "value_test.go:34", fmt.Sprint(output[3]); want != have {
 		t.Errorf("output[3]: want %s, have %s", want, have)
 	}
 
@@ -52,7 +52,7 @@ func TestValueBinding(t *testing.T) {
 	if want, have := start.Add(2*time.Second), timestamp; want != have {
 		t.Errorf("output[1]: want %v, have %v", want, have)
 	}
-	if want, have := "value_test.go:44", fmt.Sprint(output[3]); want != have {
+	if want, have := "value_test.go:47", fmt.Sprint(output[3]); want != have {
 		t.Errorf("output[3]: want %s, have %s", want, have)
 	}
 }

--- a/log/value_test.go
+++ b/log/value_test.go
@@ -1,9 +1,12 @@
 package log_test
 
 import (
+	"bytes"
 	"encoding"
 	"fmt"
 	"reflect"
+	"regexp"
+	"runtime"
 	"testing"
 	"time"
 
@@ -146,5 +149,45 @@ func BenchmarkValueBindingCaller(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		lc.Log("k", "v")
+	}
+}
+
+func TestDefaultFullPathCaller(t *testing.T) {
+	var buf []byte
+	buffer := bytes.NewBuffer(buf)
+	logger := log.NewLogfmtLogger(buffer)
+	loggerName := "DefaultFullPathCaller"
+	lc := log.With(logger, loggerName, log.DefaultFullPathCaller)
+	err := lc.Log("DefaultFullPathCaller", "should see the file full path")
+	//t.Log(buffer.String())
+	if err != nil {
+		t.Errorf("error calling log.DefaultFullPathCaller. err: %v", err)
+		return
+	}
+	if runtime.GOOS != "widows" {
+		fullPathPattern := regexp.MustCompile(fmt.Sprintf(`%s=/.*:\d+`, loggerName))
+		if !fullPathPattern.Match(buffer.Bytes()) {
+			t.Errorf("output log text does not contain full path")
+		}
+	}
+}
+
+func TestDefaultTrimmedPrefixPathCaller(t *testing.T) {
+	var buf []byte
+	buffer := bytes.NewBuffer(buf)
+	logger := log.NewLogfmtLogger(buffer)
+	loggerName := "DefaultTrimmedPrefixPathCaller"
+	lc := log.With(logger, loggerName, log.DefaultTrimmedPrefixPathCaller("/"))
+	err := lc.Log("DefaultFullPathCaller", "should see the file full path")
+	//t.Log(buffer.String())
+	if err != nil {
+		t.Errorf("error calling log.DefaultFullPathCaller. err: %v", err)
+		return
+	}
+	if runtime.GOOS != "widows" {
+		fullPathPattern := regexp.MustCompile(fmt.Sprintf(`%s=.*:\d+`, loggerName))
+		if !fullPathPattern.Match(buffer.Bytes()) {
+			t.Errorf("output log text does not contain full path")
+		}
 	}
 }


### PR DESCRIPTION
In real app, we might need a log which records the full path or a path with prefix trimmed.

pros && cons:
Old default caller: might be appropriate, but also might be too succinct;
FullPathCaller: verbose(good for quick debugging and jumping ) but might be too long;
TrimPathPrefixCaller: user controlled file path.