### PR TITLE
Use supplied context in NATS endpoint constructor

### DIFF
--- a/transport/nats/publisher.go
+++ b/transport/nats/publisher.go
@@ -64,7 +64,7 @@ func PublisherTimeout(timeout time.Duration) PublisherOption {
 // Endpoint returns a usable endpoint that invokes the remote endpoint.
 func (p Publisher) Endpoint() endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
+		ctx, cancel := context.WithTimeout(ctx, p.timeout)
 		defer cancel()
 
 		msg := nats.Msg{Subject: p.subject}


### PR DESCRIPTION
Previous implementation used a new background context which prevented proper context cancellation.

Fixes #869.