### PR TITLE
Update cloudwatch2 to latest upstream API.

### DIFF
--- a/metrics/cloudwatch2/cloudwatch2.go
+++ b/metrics/cloudwatch2/cloudwatch2.go
@@ -32,7 +32,7 @@ type CloudWatch struct {
 	mtx                   sync.RWMutex
 	sem                   chan struct{}
 	namespace             string
-	svc                   cloudwatchiface.CloudWatchAPI
+	svc                   cloudwatchiface.ClientAPI
 	counters              *lv.Space
 	logger                log.Logger
 	numConcurrentRequests int
@@ -66,7 +66,7 @@ func WithConcurrentRequests(n int) Option {
 // Namespace is applied to all created metrics and maps to the CloudWatch namespace.
 // Callers must ensure that regular calls to Send are performed, either
 // manually or with one of the helper methods.
-func New(namespace string, svc cloudwatchiface.CloudWatchAPI, options ...Option) *CloudWatch {
+func New(namespace string, svc cloudwatchiface.ClientAPI, options ...Option) *CloudWatch {
 	cw := &CloudWatch{
 		namespace:             namespace,
 		svc:                   svc,

--- a/metrics/cloudwatch2/cloudwatch2_test.go
+++ b/metrics/cloudwatch2/cloudwatch2_test.go
@@ -73,7 +73,7 @@ func TestStats(t *testing.T) {
 }
 
 type mockCloudWatch struct {
-	cloudwatchiface.CloudWatchAPI
+	cloudwatchiface.ClientAPI
 	latestName string
 	latestData []cloudwatch.MetricDatum
 }


### PR DESCRIPTION
A name change in the upstream AWS SDK caused breakage in cloudwatch2 metrics. This commits updates our usage of the API to match the new upstream naming.

Closes #877 