### PR TITLE
Update imports for NATS

### DIFF
--- a/examples/stringsvc4/main.go
+++ b/examples/stringsvc4/main.go
@@ -13,7 +13,7 @@ import (
 	natstransport "github.com/go-kit/kit/transport/nats"
 	httptransport "github.com/go-kit/kit/transport/http"
 
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 // StringService provides operations on strings.

--- a/transport/nats/encode_decode.go
+++ b/transport/nats/encode_decode.go
@@ -3,7 +3,7 @@ package nats
 import (
 	"context"
 
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 // DecodeRequestFunc extracts a user-domain request object from a publisher

--- a/transport/nats/publisher.go
+++ b/transport/nats/publisher.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/go-kit/kit/endpoint"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"time"
 )
 

--- a/transport/nats/publisher_test.go
+++ b/transport/nats/publisher_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	natstransport "github.com/go-kit/kit/transport/nats"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 func TestPublisher(t *testing.T) {

--- a/transport/nats/request_response_funcs.go
+++ b/transport/nats/request_response_funcs.go
@@ -3,7 +3,7 @@ package nats
 import (
 	"context"
 
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 // RequestFunc may take information from a publisher request and put it into a

--- a/transport/nats/subscriber.go
+++ b/transport/nats/subscriber.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/transport"
 
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 // Subscriber wraps an endpoint and provides nats.MsgHandler.

--- a/transport/nats/subscriber_test.go
+++ b/transport/nats/subscriber_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/gnatsd/server"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats-server/server"
+	"github.com/nats-io/nats.go"
 
 	"github.com/go-kit/kit/endpoint"
 	natstransport "github.com/go-kit/kit/transport/nats"


### PR DESCRIPTION
Hi, sorry for the inconvenience but the NATS project has recently renamed some of its repos. Most of the time Github redirects would help but in case a project is using Go modules, it can help to have the correct paths in the imports just in case.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>