### PR TITLE
Remove extra newline

### DIFF
--- a/cmd/kitgen/main_test.go
+++ b/cmd/kitgen/main_test.go
@@ -74,7 +74,6 @@ func TestProcess(t *testing.T) {
 				}
 			}
 		})
-
 	}
 
 	testcase := func(dir string) {


### PR DESCRIPTION
This PR shows how CI pipeline fails because `go-kit` relies on the latest version of its dependencies.