### PR TITLE
Disable HTML escaping in JSON Logger

### DIFF
--- a/log/json_logger.go
+++ b/log/json_logger.go
@@ -31,7 +31,9 @@ func (l *jsonLogger) Log(keyvals ...interface{}) error {
 		}
 		merge(m, k, v)
 	}
-	return json.NewEncoder(l.Writer).Encode(m)
+	enc := json.NewEncoder(l.Writer)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(m)
 }
 
 func merge(dst map[string]interface{}, k, v interface{}) {

--- a/log/json_logger_test.go
+++ b/log/json_logger_test.go
@@ -73,6 +73,18 @@ func TestJSONLoggerNilErrorValue(t *testing.T) {
 	}
 }
 
+func TestJSONLoggerNoHTMLEscape(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	logger := log.NewJSONLogger(buf)
+	if err := logger.Log("k", "<&>"); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := `{"k":"<&>"}`+"\n", buf.String(); want != have {
+		t.Errorf("\nwant %#v\nhave%#v", want, have)
+	}
+}
+
 // aller implements json.Marshaler, encoding.TextMarshaler, and fmt.Stringer.
 type aller struct{}
 


### PR DESCRIPTION
In #690 @ChrisHines said he'd be open to disabling HTML escaping in the JSON Logger altogether, without changing the API, but it doesn't seem like anyone got around to contributing the change. If this is still something the maintainers would be open to it'd be great to see it put in place.