### PR TITLE
Introduce ErrorHandlerFunc

### DIFF
--- a/transport/error_handler.go
+++ b/transport/error_handler.go
@@ -26,3 +26,14 @@ func NewLogErrorHandler(logger log.Logger) *LogErrorHandler {
 func (h *LogErrorHandler) Handle(ctx context.Context, err error) {
 	h.logger.Log("err", err)
 }
+
+// The ErrorHandlerFunc type is an adapter to allow the use of
+// ordinary function as ErrorHandler. If f is a function
+// with the appropriate signature, ErrorHandlerFunc(f) is a
+// ErrorHandler that calls f.
+type ErrorHandlerFunc func(ctx context.Context, err error)
+
+// Handle calls f(ctx, err).
+func (f ErrorHandlerFunc) Handle(ctx context.Context, err error) {
+	f(ctx, err)
+}


### PR DESCRIPTION
Introduce type `ErrorHandlerFunc` that allows you to use ordinary function as `ErrorHandler`.