### PR TITLE
(#796) User should be responsible for request encoding with client endpoint

### DIFF
--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -13,85 +13,23 @@ import (
 	"github.com/go-kit/kit/endpoint"
 )
 
-// HTTPClient is an interface that models *http.Client.
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
-// Client wraps a URL and provides a method that implements endpoint.Endpoint.
-type Client struct {
-	client         HTTPClient
-	method         string
-	tgt            *url.URL
-	enc            EncodeRequestFunc
-	dec            DecodeResponseFunc
-	before         []RequestFunc
-	after          []ClientResponseFunc
-	finalizer      []ClientFinalizerFunc
-	bufferedStream bool
-}
-
-// NewClient constructs a usable Client for a single remote method.
-func NewClient(
+// NewClientEndpoint returns a usable endpoint that invokes the remote endpoint.
+func NewClientEndpoint(
 	method string,
 	tgt *url.URL,
-	enc EncodeRequestFunc,
+	enc EncodeClientRequestFunc,
 	dec DecodeResponseFunc,
-	options ...ClientOption,
-) *Client {
-	c := &Client{
+	options ...ClientEndpointOption,
+) endpoint.Endpoint {
+	opts := &clientEndpointOpts{
 		client:         http.DefaultClient,
-		method:         method,
-		tgt:            tgt,
-		enc:            enc,
-		dec:            dec,
 		before:         []RequestFunc{},
 		after:          []ClientResponseFunc{},
 		bufferedStream: false,
 	}
 	for _, option := range options {
-		option(c)
+		option(opts)
 	}
-	return c
-}
-
-// ClientOption sets an optional parameter for clients.
-type ClientOption func(*Client)
-
-// SetClient sets the underlying HTTP client used for requests.
-// By default, http.DefaultClient is used.
-func SetClient(client HTTPClient) ClientOption {
-	return func(c *Client) { c.client = client }
-}
-
-// ClientBefore sets the RequestFuncs that are applied to the outgoing HTTP
-// request before it's invoked.
-func ClientBefore(before ...RequestFunc) ClientOption {
-	return func(c *Client) { c.before = append(c.before, before...) }
-}
-
-// ClientAfter sets the ClientResponseFuncs applied to the incoming HTTP
-// request prior to it being decoded. This is useful for obtaining anything off
-// of the response and adding onto the context prior to decoding.
-func ClientAfter(after ...ClientResponseFunc) ClientOption {
-	return func(c *Client) { c.after = append(c.after, after...) }
-}
-
-// ClientFinalizer is executed at the end of every HTTP request.
-// By default, no finalizer is registered.
-func ClientFinalizer(f ...ClientFinalizerFunc) ClientOption {
-	return func(s *Client) { s.finalizer = append(s.finalizer, f...) }
-}
-
-// BufferedStream sets whether the Response.Body is left open, allowing it
-// to be read from later. Useful for transporting a file as a buffered stream.
-// That body has to be Closed to propery end the request.
-func BufferedStream(buffered bool) ClientOption {
-	return func(c *Client) { c.bufferedStream = buffered }
-}
-
-// Endpoint returns a usable endpoint that invokes the remote endpoint.
-func (c Client) Endpoint() endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		ctx, cancel := context.WithCancel(ctx)
 
@@ -99,34 +37,37 @@ func (c Client) Endpoint() endpoint.Endpoint {
 			resp *http.Response
 			err  error
 		)
-		if c.finalizer != nil {
+		if opts.finalizer != nil {
 			defer func() {
 				if resp != nil {
 					ctx = context.WithValue(ctx, ContextKeyResponseHeaders, resp.Header)
 					ctx = context.WithValue(ctx, ContextKeyResponseSize, resp.ContentLength)
 				}
-				for _, f := range c.finalizer {
+				for _, f := range opts.finalizer {
 					f(ctx, err)
 				}
 			}()
 		}
 
-		req, err := http.NewRequest(c.method, c.tgt.String(), nil)
+		req, err := enc(ctx, method, tgt.String(), request)
 		if err != nil {
 			cancel()
 			return nil, err
 		}
-
-		if err = c.enc(ctx, req, request); err != nil {
-			cancel()
-			return nil, err
+		// If user didn't bother to create a req object we have to set a default value for it ourselves.
+		if req == nil {
+			req, err = http.NewRequest(method, tgt.String(), nil)
+			if err != nil {
+				cancel()
+				return nil, err
+			}
 		}
 
-		for _, f := range c.before {
+		for _, f := range opts.before {
 			ctx = f(ctx, req)
 		}
 
-		resp, err = c.client.Do(req.WithContext(ctx))
+		resp, err = opts.client.Do(req.WithContext(ctx))
 
 		if err != nil {
 			cancel()
@@ -135,24 +76,72 @@ func (c Client) Endpoint() endpoint.Endpoint {
 
 		// If we expect a buffered stream, we don't cancel the context when the endpoint returns.
 		// Instead, we should call the cancel func when closing the response body.
-		if c.bufferedStream {
+		if opts.bufferedStream {
 			resp.Body = bodyWithCancel{ReadCloser: resp.Body, cancel: cancel}
 		} else {
 			defer resp.Body.Close()
 			defer cancel()
 		}
 
-		for _, f := range c.after {
+		for _, f := range opts.after {
 			ctx = f(ctx, resp)
 		}
 
-		response, err := c.dec(ctx, resp)
+		response, err := dec(ctx, resp)
 		if err != nil {
 			return nil, err
 		}
 
 		return response, nil
 	}
+}
+
+// ClientEndpointOption sets an optional parameter for client endpoint.
+type ClientEndpointOption func(*clientEndpointOpts)
+
+type clientEndpointOpts struct {
+	client         HTTPClient
+	before         []RequestFunc
+	after          []ClientResponseFunc
+	finalizer      []ClientFinalizerFunc
+	bufferedStream bool
+}
+
+// ClientEndpointSetClient sets the underlying HTTP client used for requests.
+// By default, http.DefaultClient is used.
+func ClientEndpointSetClient(client HTTPClient) ClientEndpointOption {
+	return func(e *clientEndpointOpts) { e.client = client }
+}
+
+// ClientEndpointBefore sets the RequestFuncs that are applied to the outgoing HTTP
+// request before it's invoked.
+func ClientEndpointBefore(before ...RequestFunc) ClientEndpointOption {
+	return func(e *clientEndpointOpts) { e.before = append(e.before, before...) }
+}
+
+// ClientEndpointAfter sets the ClientResponseFuncs applied to the incoming HTTP
+// request prior to it being decoded. This is useful for obtaining anything off
+// of the response and adding onto the context prior to decoding.
+func ClientEndpointAfter(after ...ClientResponseFunc) ClientEndpointOption {
+	return func(e *clientEndpointOpts) { e.after = append(e.after, after...) }
+}
+
+// ClientEndpointFinalizer is executed at the end of every HTTP request.
+// By default, no finalizer is registered.
+func ClientEndpointFinalizer(f ...ClientFinalizerFunc) ClientEndpointOption {
+	return func(e *clientEndpointOpts) { e.finalizer = append(e.finalizer, f...) }
+}
+
+// ClientEndpointBufferedStream sets whether the Response.Body is left open, allowing it
+// to be read from later. Useful for transporting a file as a buffered stream.
+// That body has to be Closed to propery end the request.
+func ClientEndpointBufferedStream(buffered bool) ClientEndpointOption {
+	return func(e *clientEndpointOpts) { e.bufferedStream = buffered }
+}
+
+// HTTPClient is an interface that models *http.Client.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
 }
 
 // bodyWithCancel is a wrapper for an io.ReadCloser with also a
@@ -177,11 +166,15 @@ func (bwc bodyWithCancel) Close() error {
 // depending on when an error occurs.
 type ClientFinalizerFunc func(ctx context.Context, err error)
 
-// EncodeJSONRequest is an EncodeRequestFunc that serializes the request as a
+// EncodeJSONClientRequest is an EncodeRequestFunc that serializes the request as a
 // JSON object to the Request body. Many JSON-over-HTTP services can use it as
 // a sensible default. If the request implements Headerer, the provided headers
 // will be applied to the request.
-func EncodeJSONRequest(c context.Context, r *http.Request, request interface{}) error {
+func EncodeJSONClientRequest(c context.Context, method, url string, request interface{}) (*http.Request, error) {
+	r, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, err
+	}
 	r.Header.Set("Content-Type", "application/json; charset=utf-8")
 	if headerer, ok := request.(Headerer); ok {
 		for k := range headerer.Headers() {
@@ -190,13 +183,20 @@ func EncodeJSONRequest(c context.Context, r *http.Request, request interface{}) 
 	}
 	var b bytes.Buffer
 	r.Body = ioutil.NopCloser(&b)
-	return json.NewEncoder(&b).Encode(request)
+	if err := json.NewEncoder(&b).Encode(request); err != nil {
+		return nil, err
+	}
+	return r, nil
 }
 
-// EncodeXMLRequest is an EncodeRequestFunc that serializes the request as a
+// EncodeXMLClientRequest is an EncodeRequestFunc that serializes the request as a
 // XML object to the Request body. If the request implements Headerer,
 // the provided headers will be applied to the request.
-func EncodeXMLRequest(c context.Context, r *http.Request, request interface{}) error {
+func EncodeXMLClientRequest(c context.Context, method, url string, request interface{}) (*http.Request, error) {
+	r, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, err
+	}
 	r.Header.Set("Content-Type", "text/xml; charset=utf-8")
 	if headerer, ok := request.(Headerer); ok {
 		for k := range headerer.Headers() {
@@ -205,5 +205,8 @@ func EncodeXMLRequest(c context.Context, r *http.Request, request interface{}) e
 	}
 	var b bytes.Buffer
 	r.Body = ioutil.NopCloser(&b)
-	return xml.NewEncoder(&b).Encode(request)
+	if err := xml.NewEncoder(&b).Encode(request); err != nil {
+		return nil, err
+	}
+	return r, nil
 }

--- a/transport/http/deprecated_client.go
+++ b/transport/http/deprecated_client.go
@@ -1,0 +1,192 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+// Client wraps a URL and provides a method that implements endpoint.Endpoint.
+// Deprecated: Use NewClientEndpoint instead (for details see https://github.com/go-kit/kit/issues/796).
+type Client struct {
+	client         HTTPClient
+	method         string
+	tgt            *url.URL
+	enc            EncodeRequestFunc
+	dec            DecodeResponseFunc
+	before         []RequestFunc
+	after          []ClientResponseFunc
+	finalizer      []ClientFinalizerFunc
+	bufferedStream bool
+}
+
+// NewClient constructs a usable Client for a single remote method.
+// Deprecated: Use NewClientEndpoint instead (for details see https://github.com/go-kit/kit/issues/796).
+func NewClient(
+	method string,
+	tgt *url.URL,
+	enc EncodeRequestFunc,
+	dec DecodeResponseFunc,
+	options ...ClientOption,
+) *Client {
+	c := &Client{
+		client:         http.DefaultClient,
+		method:         method,
+		tgt:            tgt,
+		enc:            enc,
+		dec:            dec,
+		before:         []RequestFunc{},
+		after:          []ClientResponseFunc{},
+		bufferedStream: false,
+	}
+	for _, option := range options {
+		option(c)
+	}
+	return c
+}
+
+// Endpoint returns a usable endpoint that invokes the remote endpoint.
+// Deprecated: Use NewClientEndpoint instead (for details see https://github.com/go-kit/kit/issues/796).
+func (c Client) Endpoint() endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		ctx, cancel := context.WithCancel(ctx)
+
+		var (
+			resp *http.Response
+			err  error
+		)
+		if c.finalizer != nil {
+			defer func() {
+				if resp != nil {
+					ctx = context.WithValue(ctx, ContextKeyResponseHeaders, resp.Header)
+					ctx = context.WithValue(ctx, ContextKeyResponseSize, resp.ContentLength)
+				}
+				for _, f := range c.finalizer {
+					f(ctx, err)
+				}
+			}()
+		}
+
+		req, err := http.NewRequest(c.method, c.tgt.String(), nil)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+
+		if err = c.enc(ctx, req, request); err != nil {
+			cancel()
+			return nil, err
+		}
+
+		for _, f := range c.before {
+			ctx = f(ctx, req)
+		}
+
+		resp, err = c.client.Do(req.WithContext(ctx))
+
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+
+		// If we expect a buffered stream, we don't cancel the context when the endpoint returns.
+		// Instead, we should call the cancel func when closing the response body.
+		if c.bufferedStream {
+			resp.Body = bodyWithCancel{ReadCloser: resp.Body, cancel: cancel}
+		} else {
+			defer resp.Body.Close()
+			defer cancel()
+		}
+
+		for _, f := range c.after {
+			ctx = f(ctx, resp)
+		}
+
+		response, err := c.dec(ctx, resp)
+		if err != nil {
+			return nil, err
+		}
+
+		return response, nil
+	}
+}
+
+// ClientOption sets an optional parameter for clients.
+// Deprecated: Use ClientEndpointOption instead (for details see https://github.com/go-kit/kit/issues/796).
+type ClientOption func(*Client)
+
+// SetClient sets the underlying HTTP client used for requests.
+// By default, http.DefaultClient is used.
+// Deprecated: Use ClientEndpointSetClient instead (for details see https://github.com/go-kit/kit/issues/796).
+func SetClient(client HTTPClient) ClientOption {
+	return func(c *Client) { c.client = client }
+}
+
+// ClientBefore sets the RequestFuncs that are applied to the outgoing HTTP
+// request before it's invoked.
+// Deprecated: Use ClientEndpointBefore instead (for details see https://github.com/go-kit/kit/issues/796).
+func ClientBefore(before ...RequestFunc) ClientOption {
+	return func(c *Client) { c.before = append(c.before, before...) }
+}
+
+// ClientAfter sets the ClientResponseFuncs applied to the incoming HTTP
+// request prior to it being decoded. This is useful for obtaining anything off
+// of the response and adding onto the context prior to decoding.
+// Deprecated: Use ClientEndpointAfter instead (for details see https://github.com/go-kit/kit/issues/796).
+func ClientAfter(after ...ClientResponseFunc) ClientOption {
+	return func(c *Client) { c.after = append(c.after, after...) }
+}
+
+// ClientFinalizer is executed at the end of every HTTP request.
+// By default, no finalizer is registered.
+// Deprecated: Use ClientEndpointFinalizer instead (for details see https://github.com/go-kit/kit/issues/796).
+func ClientFinalizer(f ...ClientFinalizerFunc) ClientOption {
+	return func(s *Client) { s.finalizer = append(s.finalizer, f...) }
+}
+
+// BufferedStream sets whether the Response.Body is left open, allowing it
+// to be read from later. Useful for transporting a file as a buffered stream.
+// That body has to be Closed to propery end the request.
+// Deprecated: Use ClientEndpointBufferedStream instead (for details see https://github.com/go-kit/kit/issues/796).
+func BufferedStream(buffered bool) ClientOption {
+	return func(c *Client) { c.bufferedStream = buffered }
+}
+
+// EncodeJSONRequest is an EncodeRequestFunc that serializes the request as a
+// JSON object to the Request body. Many JSON-over-HTTP services can use it as
+// a sensible default. If the request implements Headerer, the provided headers
+// will be applied to the request.
+// Deprecated: Use EncodeJSONClientRequest instead (for details see https://github.com/go-kit/kit/issues/796).
+func EncodeJSONRequest(c context.Context, r *http.Request, request interface{}) error {
+	r.Header.Set("Content-Type", "application/json; charset=utf-8")
+	if headerer, ok := request.(Headerer); ok {
+		for k := range headerer.Headers() {
+			r.Header.Set(k, headerer.Headers().Get(k))
+		}
+	}
+	var b bytes.Buffer
+	r.Body = ioutil.NopCloser(&b)
+	return json.NewEncoder(&b).Encode(request)
+}
+
+// EncodeXMLRequest is an EncodeRequestFunc that serializes the request as a
+// XML object to the Request body. If the request implements Headerer,
+// the provided headers will be applied to the request.
+// Deprecated: Use EncodeXMLClientRequest instead (for details see https://github.com/go-kit/kit/issues/796).
+func EncodeXMLRequest(c context.Context, r *http.Request, request interface{}) error {
+	r.Header.Set("Content-Type", "text/xml; charset=utf-8")
+	if headerer, ok := request.(Headerer); ok {
+		for k := range headerer.Headers() {
+			r.Header.Set(k, headerer.Headers().Get(k))
+		}
+	}
+	var b bytes.Buffer
+	r.Body = ioutil.NopCloser(&b)
+	return xml.NewEncoder(&b).Encode(request)
+}

--- a/transport/http/encode_decode.go
+++ b/transport/http/encode_decode.go
@@ -11,10 +11,17 @@ import (
 // JSON decodes from the request body to the concrete request type.
 type DecodeRequestFunc func(context.Context, *http.Request) (request interface{}, err error)
 
+// EncodeClientRequestFunc encodes the passed request object and returns it as HTTP request
+// object. It's designed to be used in HTTP clients, for client-side
+// endpoints. One straightforward EncodeClientRequestFunc could be something that JSON
+// encodes the object directly to the request body.
+type EncodeClientRequestFunc func(ctx context.Context, method, url string, request interface{}) (*http.Request, error)
+
 // EncodeRequestFunc encodes the passed request object into the HTTP request
 // object. It's designed to be used in HTTP clients, for client-side
 // endpoints. One straightforward EncodeRequestFunc could be something that JSON
 // encodes the object directly to the request body.
+// Deprecated: Use EncodeClientRequestFunc instead (for details see https://github.com/go-kit/kit/issues/796).
 type EncodeRequestFunc func(context.Context, *http.Request, interface{}) error
 
 // EncodeResponseFunc encodes the passed response object to the HTTP response


### PR DESCRIPTION
TODO:
- check out whether some docs require updating as well (so that they will describe new API usage  instead of the deprecated one)
- increase test coverage (especially check the part about `Content-Length`)