### PR TITLE
Close the response body after reading from it

### DIFF
--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -23,6 +23,7 @@ func TestCounter(t *testing.T) {
 
 	scrape := func() string {
 		resp, _ := http.Get(s.URL)
+		defer resp.Body.Close()
 		buf, _ := ioutil.ReadAll(resp.Body)
 		return string(buf)
 	}
@@ -54,6 +55,7 @@ func TestGauge(t *testing.T) {
 
 	scrape := func() string {
 		resp, _ := http.Get(s.URL)
+		defer resp.Body.Close()
 		buf, _ := ioutil.ReadAll(resp.Body)
 		return string(buf)
 	}
@@ -85,6 +87,7 @@ func TestSummary(t *testing.T) {
 
 	scrape := func() string {
 		resp, _ := http.Get(s.URL)
+		defer resp.Body.Close()
 		buf, _ := ioutil.ReadAll(resp.Body)
 		return string(buf)
 	}
@@ -130,6 +133,7 @@ func TestHistogram(t *testing.T) {
 
 	scrape := func() string {
 		resp, _ := http.Get(s.URL)
+		defer resp.Body.Close()
 		buf, _ := ioutil.ReadAll(resp.Body)
 		return string(buf)
 	}


### PR DESCRIPTION
According to https://golang.org/pkg/net/http/, the response body should
be closed after reading from it:

```
resp, err := http.Get("http://example.com/")
if err != nil {
        // handle error
}
defer resp.Body.Close()
body, err := ioutil.ReadAll(resp.Body)
// ...
```

Note: I saw a few other places in the repo this could probably be added as well, but starting with here as I'm a `go` n00b and there's a chance I'm misunderstanding and this isn't actually required...