### PR TITLE
Add a span name getter to opencensus endpoint options

### DIFF
--- a/tracing/opencensus/endpoint.go
+++ b/tracing/opencensus/endpoint.go
@@ -31,6 +31,10 @@ func TraceEndpoint(name string, options ...EndpointOption) endpoint.Middleware {
 
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+			if name == TraceEndpointDefaultName && cfg.GetSpanName != nil {
+				name = cfg.GetSpanName(ctx)
+			}
+
 			ctx, span := trace.StartSpan(ctx, name)
 			if len(cfg.Attributes) > 0 {
 				span.AddAttributes(cfg.Attributes...)

--- a/tracing/opencensus/endpoint.go
+++ b/tracing/opencensus/endpoint.go
@@ -32,9 +32,7 @@ func TraceEndpoint(name string, options ...EndpointOption) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			if cfg.GetName != nil {
-				newName := cfg.GetName(ctx, name)
-
-				if newName != "" {
+				if newName := cfg.GetName(ctx, name); newName != "" {
 					name = newName
 				}
 			}

--- a/tracing/opencensus/endpoint.go
+++ b/tracing/opencensus/endpoint.go
@@ -44,9 +44,8 @@ func TraceEndpoint(name string, options ...EndpointOption) endpoint.Middleware {
 			defer span.End()
 
 			if cfg.GetAttributes != nil {
-				attributes := cfg.GetAttributes(ctx)
-				if len(attributes) > 0 {
-					span.AddAttributes(attributes...)
+				if attrs := cfg.GetAttributes(ctx); len(attrs) > 0 {
+					span.AddAttributes(attrs...)
 				}
 			}
 

--- a/tracing/opencensus/endpoint_options.go
+++ b/tracing/opencensus/endpoint_options.go
@@ -22,8 +22,7 @@ type EndpointOptions struct {
 	// If the function is nil, or the returned name is empty, the existing name for the endpoint is used.
 	GetName func(ctx context.Context, name string) string
 
-	// GetAttributes is an optional function that attaches additional attributes to the span
-	// based on the information found in the context.
+	// GetAttributes is an optional function that can extract trace attributes from the context and add them to the span.
 	GetAttributes func(ctx context.Context) []trace.Attribute
 }
 

--- a/tracing/opencensus/endpoint_options.go
+++ b/tracing/opencensus/endpoint_options.go
@@ -16,10 +16,12 @@ type EndpointOptions struct {
 	// creation by our Endpoint middleware.
 	Attributes []trace.Attribute
 
-	// GetSpanName holds the function to use for generating the span name
-	// from the information found in the incoming Request.
-	// Defaults to the name that the middleware was initialized with.
-	GetSpanName func(ctx context.Context) string
+	// GetSpanDetails holds the function to use for generating the span name
+	// based on the current name and from the information found in the incoming Request.
+	// It can also return additional attributes for the span.
+	//
+	// A returned empty name defaults to the name that the middleware was initialized with.
+	GetSpanDetails func(ctx context.Context, name string) (string, []trace.Attribute)
 }
 
 // EndpointOption allows for functional options to our OpenCensus endpoint
@@ -47,5 +49,12 @@ func WithEndpointAttributes(attrs ...trace.Attribute) EndpointOption {
 func WithIgnoreBusinessError(val bool) EndpointOption {
 	return func(o *EndpointOptions) {
 		o.IgnoreBusinessError = val
+	}
+}
+
+// WithSpanDetails extracts details from the request context (like span name and additional attributes).
+func WithSpanDetails(fn func(ctx context.Context, name string) (string, []trace.Attribute)) EndpointOption {
+	return func(o *EndpointOptions) {
+		o.GetSpanDetails = fn
 	}
 }

--- a/tracing/opencensus/endpoint_options.go
+++ b/tracing/opencensus/endpoint_options.go
@@ -22,7 +22,8 @@ type EndpointOptions struct {
 	// If the function is nil, or the returned name is empty, the existing name for the endpoint is used.
 	GetName func(ctx context.Context, name string) string
 
-	// GetAttributes is an optional function that can extract trace attributes from the context and add them to the span.
+	// GetAttributes is an optional function that can extract trace attributes 
+	// from the context and add them to the span.
 	GetAttributes func(ctx context.Context) []trace.Attribute
 }
 

--- a/tracing/opencensus/endpoint_options.go
+++ b/tracing/opencensus/endpoint_options.go
@@ -1,6 +1,10 @@
 package opencensus
 
-import "go.opencensus.io/trace"
+import (
+	"context"
+
+	"go.opencensus.io/trace"
+)
 
 // EndpointOptions holds the options for tracing an endpoint
 type EndpointOptions struct {
@@ -11,6 +15,11 @@ type EndpointOptions struct {
 	// Attributes holds the default attributes which will be set on span
 	// creation by our Endpoint middleware.
 	Attributes []trace.Attribute
+
+	// GetSpanName holds the function to use for generating the span name
+	// from the information found in the incoming Request.
+	// Defaults to the name that the middleware was initialized with.
+	GetSpanName func(ctx context.Context) string
 }
 
 // EndpointOption allows for functional options to our OpenCensus endpoint

--- a/tracing/opencensus/endpoint_options.go
+++ b/tracing/opencensus/endpoint_options.go
@@ -16,14 +16,14 @@ type EndpointOptions struct {
 	// creation by our Endpoint middleware.
 	Attributes []trace.Attribute
 
-	// GetName holds the function used for generating the span name
-	// based on the current name and from the information found in the incoming Request.
+	// GetName is an optional function that can set the span name based on the existing name
+	// for the endpoint and information in the context.
 	//
-	// If the returned name is empty, the existing name for the endpoint is kept.
+	// If the function is nil, or the returned name is empty, the existing name for the endpoint is used.
 	GetName func(ctx context.Context, name string) string
 
-	// GetAttributes holds the function used for extracting additional attributes
-	// from the information found in the incoming Request.
+	// GetAttributes is an optional function that attaches additional attributes to the span
+	// based on the information found in the context.
 	GetAttributes func(ctx context.Context) []trace.Attribute
 }
 

--- a/tracing/opencensus/endpoint_options.go
+++ b/tracing/opencensus/endpoint_options.go
@@ -16,12 +16,15 @@ type EndpointOptions struct {
 	// creation by our Endpoint middleware.
 	Attributes []trace.Attribute
 
-	// GetSpanDetails holds the function to use for generating the span name
+	// GetName holds the function used for generating the span name
 	// based on the current name and from the information found in the incoming Request.
-	// It can also return additional attributes for the span.
 	//
-	// A returned empty name defaults to the name that the middleware was initialized with.
-	GetSpanDetails func(ctx context.Context, name string) (string, []trace.Attribute)
+	// If the returned name is empty, the existing name for the endpoint is kept.
+	GetName func(ctx context.Context, name string) string
+
+	// GetAttributes holds the function used for extracting additional attributes
+	// from the information found in the incoming Request.
+	GetAttributes func(ctx context.Context) []trace.Attribute
 }
 
 // EndpointOption allows for functional options to our OpenCensus endpoint
@@ -52,9 +55,16 @@ func WithIgnoreBusinessError(val bool) EndpointOption {
 	}
 }
 
-// WithSpanDetails extracts details from the request context (like span name and additional attributes).
-func WithSpanDetails(fn func(ctx context.Context, name string) (string, []trace.Attribute)) EndpointOption {
+// WithSpanName extracts additional attributes from the request context.
+func WithSpanName(fn func(ctx context.Context, name string) string) EndpointOption {
 	return func(o *EndpointOptions) {
-		o.GetSpanDetails = fn
+		o.GetName = fn
+	}
+}
+
+// WithSpanAttributes extracts additional attributes from the request context.
+func WithSpanAttributes(fn func(ctx context.Context) []trace.Attribute) EndpointOption {
+	return func(o *EndpointOptions) {
+		o.GetAttributes = fn
 	}
 }

--- a/tracing/opencensus/endpoint_test.go
+++ b/tracing/opencensus/endpoint_test.go
@@ -88,8 +88,11 @@ func TestTraceEndpoint(t *testing.T) {
 	}
 	mw = opencensus.TraceEndpoint(
 		"",
-		opencensus.WithSpanDetails(func(ctx context.Context, name string) (string, []trace.Attribute) {
-			return span6, span6Attrs
+		opencensus.WithSpanName(func(ctx context.Context, name string) string {
+			return span6
+		}),
+		opencensus.WithSpanAttributes(func(ctx context.Context) []trace.Attribute {
+			return span6Attrs
 		}),
 	)
 	mw(endpoint.Nop)(ctx, nil)

--- a/tracing/opencensus/endpoint_test.go
+++ b/tracing/opencensus/endpoint_test.go
@@ -20,6 +20,7 @@ const (
 	span3 = "SPAN-3"
 	span4 = "SPAN-4"
 	span5 = "SPAN-5"
+	span6 = "SPAN-6"
 )
 
 var (
@@ -76,13 +77,20 @@ func TestTraceEndpoint(t *testing.T) {
 	mw = opencensus.TraceEndpoint(span4)
 	mw(passEndpoint)(ctx, failedResponse{err: err3})
 
-	// span4
+	// span5
 	mw = opencensus.TraceEndpoint(span5, opencensus.WithIgnoreBusinessError(true))
 	mw(passEndpoint)(ctx, failedResponse{err: err4})
 
+	// span6
+	opts = opencensus.EndpointOptions{GetSpanName: func(ctx context.Context) string {
+		return span6
+	}}
+	mw = opencensus.TraceEndpoint("", opencensus.WithEndpointConfig(opts))
+	mw(endpoint.Nop)(ctx, nil)
+
 	// check span count
 	spans := e.Flush()
-	if want, have := 5, len(spans); want != have {
+	if want, have := 6, len(spans); want != have {
 		t.Fatalf("incorrected number of spans, wanted %d, got %d", want, have)
 	}
 
@@ -156,4 +164,9 @@ func TestTraceEndpoint(t *testing.T) {
 		t.Fatalf("incorrect attribute count, wanted %d, got %d", want, have)
 	}
 
+	// test span 6
+	span = spans[5]
+	if want, have := span6, span.Name; want != have {
+		t.Errorf("incorrect span name, wanted %q, got %q", want, have)
+	}
 }


### PR DESCRIPTION
This is an experimental PR suggested by @basvanbeek in https://github.com/go-kit/kit/pull/946#issuecomment-573043128

It adds a span name getter function to the opencensus endpoint tracer config.

Other options might worth adding:

- StartOptions
- GetStartOptions

See the opencensus ochttp plugin for more.