### PR TITLE
use batch values API for CloudWatch PutMetric data call

### DIFF
--- a/metrics/cloudwatch/cloudwatch.go
+++ b/metrics/cloudwatch/cloudwatch.go
@@ -181,25 +181,23 @@ func (cw *CloudWatch) Send() error {
 			Timestamp:  aws.Time(now),
 		}
 
-		if l := len(values); l > 1 {
-			// CloudWatch Put Metrics API (https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html)
-			// expects batch of unique values including the array of corresponding counts
-			valuesCounter := make(map[float64]int)
-			for _, v := range values {
-				valuesCounter[v]++
-			}
-
-			for value, count := range valuesCounter {
-				if len(datum.Values) == maxValuesInABatch {
-					break
-				}
-				datum.Values = append(datum.Values, aws.Float64(value))
-				datum.Counts = append(datum.Counts, aws.Float64(float64(count)))
-			}
-		} else if l == 1 {
-			datum.Value = aws.Float64(values[0])
-		} else {
+		if len(values) == 0 {
 			return true
+		}
+
+		// CloudWatch Put Metrics API (https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html)
+		// expects batch of unique values including the array of corresponding counts
+		valuesCounter := make(map[float64]int)
+		for _, v := range values {
+			valuesCounter[v]++
+		}
+
+		for value, count := range valuesCounter {
+			if len(datum.Values) == maxValuesInABatch {
+				break
+			}
+			datum.Values = append(datum.Values, aws.Float64(value))
+			datum.Counts = append(datum.Counts, aws.Float64(float64(count)))
 		}
 
 		datums = append(datums, datum)

--- a/metrics/expvar/expvar_test.go
+++ b/metrics/expvar/expvar_test.go
@@ -17,7 +17,7 @@ func TestCounter(t *testing.T) {
 
 func TestGauge(t *testing.T) {
 	gauge := NewGauge("expvar_gauge").With("label values", "not supported").(*Gauge)
-	value := func() float64 { f, _ := strconv.ParseFloat(gauge.f.String(), 64); return f }
+	value := func() []float64 { f, _ := strconv.ParseFloat(gauge.f.String(), 64); return []float64{f} }
 	if err := teststat.TestGauge(gauge, value); err != nil {
 		t.Fatal(err)
 	}

--- a/metrics/generic/generic_test.go
+++ b/metrics/generic/generic_test.go
@@ -45,7 +45,7 @@ func TestGauge(t *testing.T) {
 	if want, have := name, gauge.Name; want != have {
 		t.Errorf("Name: want %q, have %q", want, have)
 	}
-	value := gauge.Value
+	value := func() []float64 { return []float64{gauge.Value()} }
 	if err := teststat.TestGauge(gauge, value); err != nil {
 		t.Fatal(err)
 	}

--- a/metrics/influx/influx_test.go
+++ b/metrics/influx/influx_test.go
@@ -34,12 +34,12 @@ func TestGauge(t *testing.T) {
 	in := New(map[string]string{"foo": "alpha"}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
 	re := regexp.MustCompile(`influx_gauge,foo=alpha value=([0-9\.]+) [0-9]+`)
 	gauge := in.NewGauge("influx_gauge")
-	value := func() float64 {
+	value := func() []float64 {
 		client := &bufWriter{}
 		in.WriteTo(client)
 		match := re.FindStringSubmatch(client.buf.String())
 		f, _ := strconv.ParseFloat(match[1], 64)
-		return f
+		return []float64{f}
 	}
 	if err := teststat.TestGauge(gauge, value); err != nil {
 		t.Fatal(err)

--- a/metrics/pcp/pcp_test.go
+++ b/metrics/pcp/pcp_test.go
@@ -40,7 +40,7 @@ func TestGauge(t *testing.T) {
 
 	gauge = gauge.With("label values", "not supported").(*Gauge)
 
-	value := func() float64 { f := gauge.g.Val(); return f }
+	value := func() []float64 { f := gauge.g.Val(); return []float64{f} }
 	if err := teststat.TestGauge(gauge, value); err != nil {
 		t.Fatal(err)
 	}

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -68,10 +68,10 @@ func TestGauge(t *testing.T) {
 		Help:      "This is a different help string.",
 	}, []string{"foo"}).With("foo", "bar")
 
-	value := func() float64 {
+	value := func() []float64 {
 		matches := re.FindStringSubmatch(scrape())
 		f, _ := strconv.ParseFloat(matches[1], 64)
-		return f
+		return []float64{f}
 	}
 
 	if err := teststat.TestGauge(gauge, value); err != nil {

--- a/metrics/teststat/buffers.go
+++ b/metrics/teststat/buffers.go
@@ -23,10 +23,10 @@ func SumLines(w io.WriterTo, regex string) func() float64 {
 // LastLine expects a regex whose first capture group can be parsed as a
 // float64. It will dump the WriterTo and parse each line, expecting to find a
 // match. It returns the final captured float.
-func LastLine(w io.WriterTo, regex string) func() float64 {
-	return func() float64 {
+func LastLine(w io.WriterTo, regex string) func() []float64 {
+	return func() []float64 {
 		_, final := stats(w, regex, nil)
-		return final
+		return []float64{final}
 	}
 }
 

--- a/metrics/teststat/teststat.go
+++ b/metrics/teststat/teststat.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"reflect"
 	"strings"
 
 	"github.com/go-kit/kit/metrics"
@@ -38,24 +39,24 @@ func FillCounter(counter metrics.Counter) float64 {
 
 // TestGauge puts some values through the gauge, and then calls the value func
 // to check that the gauge has the correct final value.
-func TestGauge(gauge metrics.Gauge, value func() float64) error {
+func TestGauge(gauge metrics.Gauge, value func() []float64) error {
 	a := rand.Perm(100)
 	n := rand.Intn(len(a))
 
-	var want float64
+	var want []float64
 	for i := 0; i < n; i++ {
 		f := float64(a[i])
 		gauge.Set(f)
-		want = f
+		want = append(want, f)
 	}
 
 	for i := 0; i < n; i++ {
 		f := float64(a[i])
 		gauge.Add(f)
-		want += f
+		want[len(want)-1] += f
 	}
 
-	if have := value(); want != have {
+	if have := value(); reflect.DeepEqual(want, have) {
 		return fmt.Errorf("want %f, have %f", want, have)
 	}
 


### PR DESCRIPTION
Some time ago, [AWS introduced the way to publish a batch of metric values](https://github.com/aws/aws-sdk-go/blob/master/CHANGELOG.md#release-v11536-2018-09-17) in one call.

So there is no point in sending `last(values)` if we could send the whole batch.
This PR implements the sending of values batch,