### PR TITLE
Log CloudWatch response error

### DIFF
--- a/metrics/cloudwatch/cloudwatch.go
+++ b/metrics/cloudwatch/cloudwatch.go
@@ -255,7 +255,7 @@ func (cw *CloudWatch) Send() error {
 	}
 	var firstErr error
 	for i := 0; i < cap(errors); i++ {
-		if err := <-errors; err != nil && firstErr != nil {
+		if err := <-errors; err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}


### PR DESCRIPTION
Condition to log CloudWatch Response Error is broken, as a result, the error is never logged.
This PR fixes the condition