### PR TITLE
jsonrpc.DefaultErrorEncoder: add RequestID in error body

### DIFF
--- a/transport/http/jsonrpc/server.go
+++ b/transport/http/jsonrpc/server.go
@@ -11,7 +11,9 @@ import (
 	httptransport "github.com/go-kit/kit/transport/http"
 )
 
-const requestIDKey = "request-id"
+type requestIDKeyType struct{}
+
+var requestIDKey requestIDKeyType
 
 // Server wraps an endpoint and implements http.Handler.
 type Server struct {
@@ -183,8 +185,8 @@ func DefaultErrorEncoder(ctx context.Context, err error, w http.ResponseWriter) 
 	w.WriteHeader(http.StatusOK)
 
 	var requestID *RequestID
-	if ctx.Value(requestIDKey) != nil {
-		requestID = ctx.Value(requestIDKey).(*RequestID)
+	if v := ctx.Value(requestIDKey); v != nil {
+		requestID = v.(*RequestID)
 	}
 	_ = json.NewEncoder(w).Encode(Response{
 		ID:      requestID,

--- a/transport/http/jsonrpc/server.go
+++ b/transport/http/jsonrpc/server.go
@@ -11,6 +11,8 @@ import (
 	httptransport "github.com/go-kit/kit/transport/http"
 )
 
+const requestIDKey = "request-id"
+
 // Server wraps an endpoint and implements http.Handler.
 type Server struct {
 	ecm          EndpointCodecMap
@@ -105,6 +107,8 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ctx = context.WithValue(ctx, requestIDKey, req.ID)
+
 	// Get the endpoint and codecs from the map using the method
 	// defined in the JSON  object
 	ecm, ok := s.ecm[req.Method]
@@ -160,7 +164,7 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // If the error implements ErrorCoder, the provided code will be set on the
 // response error.
 // If the error implements Headerer, the given headers will be set.
-func DefaultErrorEncoder(_ context.Context, err error, w http.ResponseWriter) {
+func DefaultErrorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", ContentType)
 	if headerer, ok := err.(httptransport.Headerer); ok {
 		for k := range headerer.Headers() {
@@ -177,7 +181,13 @@ func DefaultErrorEncoder(_ context.Context, err error, w http.ResponseWriter) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+
+	var requestID *RequestID
+	if ctx.Value(requestIDKey) != nil {
+		requestID = ctx.Value(requestIDKey).(*RequestID)
+	}
 	_ = json.NewEncoder(w).Encode(Response{
+		ID:      requestID,
 		JSONRPC: Version,
 		Error:   &e,
 	})


### PR DESCRIPTION
This PR adds requestID field in `jsonrpc.DefaultErrorEncoder` as requested in issue #959.