### PR TITLE
Add Version to JSON-RPC client request

### DIFF
--- a/transport/http/jsonrpc/client.go
+++ b/transport/http/jsonrpc/client.go
@@ -164,7 +164,7 @@ func (c Client) Endpoint() endpoint.Endpoint {
 			return nil, err
 		}
 		rpcReq := clientRequest{
-			JSONRPC: "",
+			JSONRPC: Version,
 			Method:  c.method,
 			Params:  params,
 			ID:      c.requestID.Generate(),

--- a/transport/http/jsonrpc/client_test.go
+++ b/transport/http/jsonrpc/client_test.go
@@ -133,6 +133,9 @@ func TestClientHappyPath(t *testing.T) {
 	if id, _ := requestAtServer.ID.Int(); id != wantID {
 		t.Fatalf("Request ID at server: want=%d, got=%d", wantID, id)
 	}
+	if requestAtServer.JSONRPC != jsonrpc.Version {
+		t.Fatalf("JSON-RPC version at server: want=%s, got=%s", jsonrpc.Version, requestAtServer.JSONRPC)
+	}
 
 	var paramsAtServer addRequest
 	err = json.Unmarshal(requestAtServer.Params, &paramsAtServer)


### PR DESCRIPTION
This tiny PR addresses the issue with JSON-RPC client: https://github.com/go-kit/kit/issues/986

For some reason current implementation leaves `jsonrpc` field empty and there is no easy way to change it (there is a workaround with `ClientBefore` which is not a good option). Some server implementations require this field to be `2.0`.

According to the documentation go-kit implementation only supports v2.0, that is why I don't think this parameter should be configurable.