### PR TITLE
log/term: fix build on GOOS=js GOARCH=wasm

### DIFF
--- a/log/term/terminal_stub.go
+++ b/log/term/terminal_stub.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build appengine
+// +build appengine js
 
 package term
 


### PR DESCRIPTION
Before this fix, the build would fail, as IsTerminal isn't defined on
that platform:

	$ GOOS=js GOARCH=wasm go build
	# github.com/go-kit/kit/log/term
	./term.go:14:6: undefined: IsTerminal

The reason is pretty simple; js/wasm doesn't have syscalls, and thus it
doesn't have an "is a terminal" syscall.

Grouping it with appengine to always assume that the output is not a
terminal is good enough for now, as it at least makes the package build.

No change is needed in any other file, because none of the other
IsTerminal +build lines include js/wasm in any way.