### PR TITLE
Improve inconsistent Consul SD index handling.

### DIFF
--- a/sd/consul/client_test.go
+++ b/sd/consul/client_test.go
@@ -90,7 +90,7 @@ func (c *testClient) Service(service, tag string, _ bool, opts *stdconsul.QueryO
 		results = append(results, entry)
 	}
 
-	return results, &stdconsul.QueryMeta{}, nil
+	return results, &stdconsul.QueryMeta{LastIndex: opts.WaitIndex}, nil
 }
 
 func (c *testClient) Register(r *stdconsul.AgentServiceRegistration) error {


### PR DESCRIPTION
Consul has guidelines for how the index movement should be handled.

https://www.consul.io/api-docs/features/blocking#implementation-details

Generally the index should always increase but if it does not increase this
patch implements the suggested solutions for recovery.