### PR TITLE
fix invalid endpoint no return error

### DIFF
--- a/sd/etcdv3/client.go
+++ b/sd/etcdv3/client.go
@@ -110,6 +110,7 @@ func NewClient(ctx context.Context, machines []string, options ClientOptions) (C
 		TLS:               tlscfg,
 		Username:          options.Username,
 		Password:          options.Password,
+		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
pass "grpc.WithBlock()" to block until the underlying connection is up.