### PR TITLE
metrics/generic: fix uint64 alignment

### DIFF
--- a/metrics/generic/generic.go
+++ b/metrics/generic/generic.go
@@ -18,9 +18,9 @@ import (
 
 // Counter is an in-memory implementation of a Counter.
 type Counter struct {
+	bits uint64 // bits has to be the first word in order to be 64-aligned on 32-bit
 	Name string
 	lvs  lv.LabelValues
-	bits uint64
 }
 
 // NewCounter returns a new, usable Counter.
@@ -81,9 +81,9 @@ func (c *Counter) LabelValues() []string {
 
 // Gauge is an in-memory implementation of a Gauge.
 type Gauge struct {
+	bits uint64 // bits has to be the first word in order to be 64-aligned on 32-bit
 	Name string
 	lvs  lv.LabelValues
-	bits uint64
 }
 
 // NewGauge returns a new, usable Gauge.


### PR DESCRIPTION
Fixes uint64 alignment on 32-bit arch.

- https://golang.org/pkg/sync/atomic/#pkg-note-BUG
- https://github.com/golang/go/issues/599

<details>
<summary>panic on Counter</summary>

```
Stack: goroutine 59 [running]: 
runtime/debug.Stack(0x4d20140, 0x2662937, 0x17)
        /usr/local/go/src/runtime/debug/stack.go:24 +0x78
github.com/containous/traefik/v2/pkg/safe.defaultRecoverGoroutine(0x2232840, 0x41a7570)
        /go/src/github.com/containous/traefik/pkg/safe/routine.go:66 +0x90
github.com/containous/traefik/v2/pkg/safe.GoWithRecover.func1.1(0x276cc34)
        /go/src/github.com/containous/traefik/pkg/safe/routine.go:56 +0x44
panic(0x2232840, 0x41a7570)
        /usr/local/go/src/runtime/panic.go:969 +0x118
runtime/internal/atomic.goLoad64(0x4fbab54, 0x51b6920, 0x2350f01)
        /usr/local/go/src/runtime/internal/atomic/atomic_arm.go:131 +0x1c
github.com/go-kit/kit/metrics/generic.(*Counter).Add(0x4fbab40, 0x0, 0x3ff00000)
        /go/pkg/mod/github.com/go-kit/kit@v0.9.0/metrics/generic/generic.go:46 +0x28
github.com/containous/traefik/v2/pkg/metrics.(*pilotCounter).Add(0x4c0ea70, 0x0, 0x3ff00000)
        /go/src/github.com/containous/traefik/pkg/metrics/pilot.go:229 +0xa4
github.com/go-kit/kit/metrics/multi.Counter.Add(0x4d11940, 0x2, 0x2, 0x0, 0x3ff00000)
        /go/pkg/mod/github.com/go-kit/kit@v0.9.0/metrics/multi/multi.go:20 +0x40
main.setupServer.func3(0x4fcd810, 0x51b68f8, 0x51b6900, 0x51a1f00)
        /go/src/github.com/containous/traefik/cmd/traefik/traefik.go:258 +0x4c
github.com/containous/traefik/v2/pkg/server.(*ConfigurationWatcher).loadMessage(0x51265a0, 0x2626245, 0x4, 0x4fcd710)
        /go/src/github.com/containous/traefik/pkg/server/configurationwatcher.go:150 +0x14c
github.com/containous/traefik/v2/pkg/server.(*ConfigurationWatcher).listenConfigurations(0x51265a0, 0x2ae2d18, 0x4fba0c0)
        /go/src/github.com/containous/traefik/pkg/server/configurationwatcher.go:132 +0x2c
github.com/containous/traefik/v2/pkg/safe.(*Pool).GoCtx.func1()
        /go/src/github.com/containous/traefik/pkg/safe/routine.go:36 +0x5c
github.com/containous/traefik/v2/pkg/safe.GoWithRecover.func1(0x276cc34, 0x51c8010)
        /go/src/github.com/containous/traefik/pkg/safe/routine.go:59 +0x48
created by github.com/containous/traefik/v2/pkg/safe.GoWithRecover
        /go/src/github.com/containous/traefik/pkg/safe/routine.go:53 +0x34
```

</details>

<details>
<summary>panic on Gauge</summary>


```
runtime/debug.Stack(0x44ae140, 0x2653087, 0x17)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x78
github.com/containous/traefik/v2/pkg/safe.defaultRecoverGoroutine(0x2222e48, 0x3e24e78)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:66 +0x90
github.com/containous/traefik/v2/pkg/safe.GoWithRecover.func1.1(0x275c22c)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:56 +0x44
panic(0x2222e48, 0x3e24e78)
	/usr/local/go/src/runtime/panic.go:969 +0x118
github.com/go-kit/kit/metrics/generic.(*Gauge).Set(...)
	/go/src/github.com/go-kit/kit/metrics/generic/generic.go:107
github.com/containous/traefik/v2/pkg/metrics.(*pilotGauge).Set(0x440e680, 0x79400000, 0x41d7d0ed)
	/go/src/github.com/containous/traefik/pkg/metrics/pilot.go:261 +0xbc
github.com/go-kit/kit/metrics/multi.Gauge.Set(0x440e780, 0x1, 0x1, 0x79400000, 0x41d7d0ed)
	/go/src/github.com/go-kit/kit/metrics/multi/multi.go:44 +0x40
main.setupServer.func3(0x47de1f0, 0x4713bb8, 0x4713bc0, 0x47dc7a0)
	/go/src/github.com/containous/traefik/cmd/traefik/traefik.go:259 +0xf0
github.com/containous/traefik/v2/pkg/server.(*ConfigurationWatcher).loadMessage(0x488a360, 0x2620f52, 0x8, 0x47de1a0)
	/go/src/github.com/containous/traefik/pkg/server/configurationwatcher.go:150 +0x14c
github.com/containous/traefik/v2/pkg/server.(*ConfigurationWatcher).listenConfigurations(0x488a360, 0x2ad1dc0, 0x46f28a0)
	/go/src/github.com/containous/traefik/pkg/server/configurationwatcher.go:132 +0x2c
github.com/containous/traefik/v2/pkg/safe.(*Pool).GoCtx.func1()
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:36 +0x5c
github.com/containous/traefik/v2/pkg/safe.GoWithRecover.func1(0x275c22c, 0x4605ae0)
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:59 +0x48
created by github.com/containous/traefik/v2/pkg/safe.GoWithRecover
	/go/src/github.com/containous/traefik/pkg/safe/routine.go:53 +0x34 
```

</details>

Related to https://github.com/containous/traefik/issues/7207