### PR TITLE
Move the ClientAfter calls to before the decode

### DIFF
--- a/transport/http/jsonrpc/client.go
+++ b/transport/http/jsonrpc/client.go
@@ -196,15 +196,15 @@ func (c Client) Endpoint() endpoint.Endpoint {
 			defer resp.Body.Close()
 		}
 
+		for _, f := range c.after {
+			ctx = f(ctx, resp)
+		}
+
 		// Decode the body into an object
 		var rpcRes Response
 		err = json.NewDecoder(resp.Body).Decode(&rpcRes)
 		if err != nil {
 			return nil, err
-		}
-
-		for _, f := range c.after {
-			ctx = f(ctx, resp)
 		}
 
 		return c.dec(ctx, rpcRes)


### PR DESCRIPTION
ClientAfter is documented as running _prior_ to being decoded. But, this
was only partly true. They were run prior to decode, but after the
jsonrpc unmarshalling,

As the callback uses the bare response object, and at least for me, is
used to debug what's seen on the wire, this seems incorrect.

This oddity does not exist in other transports, as there is not the duplicate decode step. 