### PR TITLE
Fix: if register failed, return error for handling

### DIFF
--- a/sd/etcd/registrar.go
+++ b/sd/etcd/registrar.go
@@ -69,15 +69,18 @@ func NewRegistrar(client Client, service Service, logger log.Logger) *Registrar 
 
 // Register implements the sd.Registrar interface. Call it when you want your
 // service to be registered in etcd, typically at startup.
-func (r *Registrar) Register() {
+func (r *Registrar) Register() error {
 	if err := r.client.Register(r.service); err != nil {
 		r.logger.Log("err", err)
+		return err
 	} else {
 		r.logger.Log("action", "register")
 	}
 	if r.service.TTL != nil {
 		go r.loop()
 	}
+
+	return nil
 }
 
 func (r *Registrar) loop() {
@@ -104,9 +107,10 @@ func (r *Registrar) loop() {
 
 // Deregister implements the sd.Registrar interface. Call it when you want your
 // service to be deregistered from etcd, typically just prior to shutdown.
-func (r *Registrar) Deregister() {
+func (r *Registrar) Deregister() error {
 	if err := r.client.Deregister(r.service); err != nil {
 		r.logger.Log("err", err)
+		return err
 	} else {
 		r.logger.Log("action", "deregister")
 	}
@@ -117,4 +121,6 @@ func (r *Registrar) Deregister() {
 		close(r.quit)
 		r.quit = nil
 	}
+
+	return nil
 }

--- a/sd/etcdv3/registrar.go
+++ b/sd/etcdv3/registrar.go
@@ -66,23 +66,26 @@ func NewRegistrar(client Client, service Service, logger log.Logger) *Registrar 
 
 // Register implements the sd.Registrar interface. Call it when you want your
 // service to be registered in etcd, typically at startup.
-func (r *Registrar) Register() {
+func (r *Registrar) Register() error {
 	if err := r.client.Register(r.service); err != nil {
 		r.logger.Log("err", err)
-		return
+		return err
 	}
 	if r.service.TTL != nil {
 		r.logger.Log("action", "register", "lease", r.client.LeaseID())
 	} else {
 		r.logger.Log("action", "register")
 	}
+
+	return nil
 }
 
 // Deregister implements the sd.Registrar interface. Call it when you want your
 // service to be deregistered from etcd, typically just prior to shutdown.
-func (r *Registrar) Deregister() {
+func (r *Registrar) Deregister() error{
 	if err := r.client.Deregister(r.service); err != nil {
 		r.logger.Log("err", err)
+		return err
 	} else {
 		r.logger.Log("action", "deregister")
 	}
@@ -93,4 +96,6 @@ func (r *Registrar) Deregister() {
 		close(r.quit)
 		r.quit = nil
 	}
+
+	return nil
 }

--- a/sd/registrar.go
+++ b/sd/registrar.go
@@ -8,6 +8,6 @@ package sd
 // that identifying instance information (e.g. host:port) must be given via the
 // concrete constructor; this interface merely signals lifecycle changes.
 type Registrar interface {
-	Register()
-	Deregister()
+	Register() error
+	Deregister() error
 }


### PR DESCRIPTION
When I use go-kit's etcd, I find that I don't know if the `func Register()` was successful, so I need it  return an error as info.