### PR TITLE
fix failing opencensus tests

### DIFF
--- a/tracing/opencensus/grpc_test.go
+++ b/tracing/opencensus/grpc_test.go
@@ -51,7 +51,10 @@ func TestGRPCClientTrace(t *testing.T) {
 	}
 
 	for _, tr := range traces {
-		clientTracer := ockit.GRPCClientTrace(ockit.WithName(tr.name))
+		clientTracer := ockit.GRPCClientTrace(
+			ockit.WithName(tr.name),
+			ockit.WithSampler(trace.AlwaysSample()),
+		)
 
 		ep := grpctransport.NewClient(
 			cc,
@@ -136,7 +139,10 @@ func TestGRPCServerTrace(t *testing.T) {
 			func(context.Context, interface{}) (interface{}, error) {
 				return nil, tr.err
 			},
-			ockit.GRPCServerTrace(ockit.WithName(tr.name)),
+			ockit.GRPCServerTrace(
+				ockit.WithName(tr.name),
+				ockit.WithSampler(trace.AlwaysSample()),
+			),
 		)
 
 		if tr.useParent {

--- a/tracing/opencensus/http_test.go
+++ b/tracing/opencensus/http_test.go
@@ -38,7 +38,10 @@ func TestHTTPClientTrace(t *testing.T) {
 	}
 
 	for _, tr := range traces {
-		clientTracer := ockit.HTTPClientTrace(ockit.WithName(tr.name))
+		clientTracer := ockit.HTTPClientTrace(
+			ockit.WithName(tr.name),
+			ockit.WithSampler(trace.AlwaysSample()),
+		)
 		ep := kithttp.NewClient(
 			"GET",
 			rURL,
@@ -117,6 +120,7 @@ func TestHTTPServerTrace(t *testing.T) {
 			func(context.Context, http.ResponseWriter, interface{}) error { return errors.New("dummy") },
 			ockit.HTTPServerTrace(
 				ockit.WithName(tr.name),
+				ockit.WithSampler(trace.AlwaysSample()),
 				ockit.WithHTTPPropagation(tr.propagation),
 			),
 		)
@@ -134,6 +138,9 @@ func TestHTTPServerTrace(t *testing.T) {
 		if tr.useParent {
 			client = http.Client{
 				Transport: &ochttp.Transport{
+					StartOptions: trace.StartOptions{
+						Sampler: trace.AlwaysSample(),
+					},
 					Propagation: tr.propagation,
 				},
 			}


### PR DESCRIPTION
Tests for http and grpc opencensus tracing were failing due to their use of the default sampler. Adding an AlwaysSample sampler allows them to pass again.