### PR TITLE
cmd/kitgen: deprecate

### DIFF
--- a/cmd/kitgen/README.md
+++ b/cmd/kitgen/README.md
@@ -1,4 +1,9 @@
+**DEPRECATED**
+
+kitgen is no longer maintained.
+
 # kitgen
+
 kitgen is an experimental code generation utility that helps with some of the
 boilerplate code required to implement the "onion" pattern `go-kit` utilizes.
 


### PR DESCRIPTION
Closes #639, #647, #745, #762, #779, #784, #910, #949.