### PR TITLE
Upgrade to the latest version of the setup-go github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2-beta
+        uses: actions/setup-go@v2.1.3
         with:
           stable: 'false'
           go-version: ${{ matrix.go }}


### PR DESCRIPTION
The github action pipeline is currently broken, giving us the following error:

```
Run actions/setup-go@v2-beta
Setup go  version spec 1.14
Error: Unable to process command '::set-env name=GOROOT::/opt/hostedtoolcache/go/1.14.12/x64' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

The beta version utilizes the deprecated `set-env` and `add-path` commands. In the `2.1.3` release, they've introduced a fix (https://github.com/actions/setup-go/pull/76) by upgrading the core library. More details can be found at  https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Sample faling build: https://github.com/go-kit/kit/pull/1013/checks?check_run_id=1453805584