### PR TITLE
Capture newlines in log stdlib

### DIFF
--- a/log/stdlib.go
+++ b/log/stdlib.go
@@ -131,7 +131,7 @@ const (
 	logRegexpDate = `(?P<date>[0-9]{4}/[0-9]{2}/[0-9]{2})?[ ]?`
 	logRegexpTime = `(?P<time>[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?)?[ ]?`
 	logRegexpFile = `(?P<file>.+?:[0-9]+)?`
-	logRegexpMsg  = `(: )?(?P<msg>.*)`
+	logRegexpMsg  = `(: )?(?P<msg>(?s:.*))`
 )
 
 var (
@@ -145,7 +145,7 @@ func subexps(line []byte) map[string]string {
 	}
 	result := map[string]string{}
 	for i, name := range logRegexp.SubexpNames() {
-		result[name] = string(m[i])
+		result[name] = strings.TrimRight(string(m[i]), "\n")
 	}
 	return result
 }

--- a/log/stdlib_test.go
+++ b/log/stdlib_test.go
@@ -130,6 +130,12 @@ func TestStdlibAdapterSubexps(t *testing.T) {
 			"file": "",
 			"msg":  "hello world",
 		},
+		"hello\nworld": {
+			"date": "",
+			"time": "",
+			"file": "",
+			"msg":  "hello\nworld",
+		},
 		"2009/01/23: hello world": {
 			"date": "2009/01/23",
 			"time": "",


### PR DESCRIPTION
Capture newlines in the stdlib adapter messages. Avoids cutting off
multi-line log messages.

See: https://github.com/prometheus/node_exporter/issues/1886

Signed-off-by: Ben Kochie <superq@gmail.com>