### PR TITLE
Switch to a fork of jwt-go with a fix to CVE-2020-26160

### DIFF
--- a/auth/jwt/README.md
+++ b/auth/jwt/README.md
@@ -12,7 +12,7 @@ will be added to the context via the `jwt.JWTClaimsContextKey`.
 
 ```go
 import (
-	stdjwt "github.com/dgrijalva/jwt-go"
+	stdjwt "github.com/form3tech-oss/jwt-go"
 
 	"github.com/go-kit/kit/auth/jwt"
 	"github.com/go-kit/kit/endpoint"
@@ -34,7 +34,7 @@ the token string and add it to the context via the `jwt.JWTTokenContextKey`.
 
 ```go
 import (
-	stdjwt "github.com/dgrijalva/jwt-go"
+	stdjwt "github.com/form3tech-oss/jwt-go"
 
 	"github.com/go-kit/kit/auth/jwt"
 	"github.com/go-kit/kit/endpoint"
@@ -65,7 +65,7 @@ Example of use in a client:
 
 ```go
 import (
-	stdjwt "github.com/dgrijalva/jwt-go"
+	stdjwt "github.com/form3tech-oss/jwt-go"
 
 	grpctransport "github.com/go-kit/kit/transport/grpc"
 	"github.com/go-kit/kit/auth/jwt"

--- a/auth/jwt/middleware.go
+++ b/auth/jwt/middleware.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/form3tech-oss/jwt-go"
 
 	"github.com/go-kit/kit/endpoint"
 )

--- a/auth/jwt/middleware_test.go
+++ b/auth/jwt/middleware_test.go
@@ -8,7 +8,7 @@ import (
 
 	"crypto/subtle"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/form3tech-oss/jwt-go"
 	"github.com/go-kit/kit/endpoint"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/davecgh/go-spew v1.1.1
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible
 	github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db // indirect
 	github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8 // indirect
 	github.com/go-logfmt/logfmt v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4s
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
+github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db h1:gb2Z18BhTPJPpLQWj4T+rfKHYCHxRHCtRxhKKjRidVw=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8 h1:a9ENSRDFBUPkJ5lCgVZh26+ZbGyoVJG7yb5SSzF5H54=


### PR DESCRIPTION
More details available in this issue: https://github.com/dgrijalva/jwt-go/issues/428