### PR TITLE
tracing.opentracing endpoint middleware options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 // indirect
 	github.com/opentracing/basictracer-go v1.0.0 // indirect
-	github.com/opentracing/opentracing-go v1.1.0
+	github.com/opentracing/opentracing-go v1.2.0
 	github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5
 	github.com/openzipkin/zipkin-go v0.2.2
 	github.com/pact-foundation/pact-go v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -106,7 +106,6 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCydnIczKteheJEzHRToSGK3Bnlw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -254,8 +253,9 @@ github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go
 github.com/opentracing/basictracer-go v1.0.0 h1:YyUAhaEfjoWXclZVJ9sGoNct7j4TVk7lZWlQw5UXuoo=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
+github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5 h1:ZCnq+JUrvXcDVhX/xRolRBZifmabN1HcS1wrPSvxhrU=
 github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxSfWAKL3wpBW7V8scJMt8N8gnaMCS9E/cA=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
@@ -380,7 +380,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 h1:fHDIZ2oxGnUZRN6WgWFCbYBjH9uqVPRCUVUDhs0wnbA=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/tracing/opentracing/endpoint.go
+++ b/tracing/opentracing/endpoint.go
@@ -31,7 +31,7 @@ func TraceEndpoint(tracer opentracing.Tracer, operationName string, opts ...Endp
 				}
 			}
 
-			span := opentracing.SpanFromContext(ctx)
+			var span opentracing.Span
 			if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
 				span = tracer.StartSpan(
 					operationName,

--- a/tracing/opentracing/endpoint.go
+++ b/tracing/opentracing/endpoint.go
@@ -41,13 +41,14 @@ func TraceEndpoint(tracer opentracing.Tracer, operationName string, opts ...Endp
 				span = tracer.StartSpan(operationName)
 			}
 			defer span.Finish()
-			ctx = opentracing.ContextWithSpan(ctx, span)
 
 			applyTags(span, cfg.Tags)
 			if cfg.GetTags != nil {
 				extraTags := cfg.GetTags(ctx)
 				applyTags(span, extraTags)
 			}
+
+			ctx = opentracing.ContextWithSpan(ctx, span)
 
 			response, err := next(ctx, request)
 			if err := identifyError(response, err, cfg.IgnoreBusinessError); err != nil {

--- a/tracing/opentracing/endpoint_options.go
+++ b/tracing/opentracing/endpoint_options.go
@@ -44,23 +44,29 @@ func WithIgnoreBusinessError(ignoreBusinessError bool) EndpointOption {
 	}
 }
 
-// WithOperationName allows to set function that can set the span operation name based on the existing one
+// WithOperationNameFunc allows to set function that can set the span operation name based on the existing one
 // for the endpoint and information in the context.
-func WithOperationName(getOperationName func(ctx context.Context, name string) string) EndpointOption {
+func WithOperationNameFunc(getOperationName func(ctx context.Context, name string) string) EndpointOption {
 	return func(o *EndpointOptions) {
 		o.GetOperationName = getOperationName
 	}
 }
 
-// WithTags sets the default tags for the spans created by the Endpoint tracer.
+// WithTags adds default tags for the spans created by the Endpoint tracer.
 func WithTags(tags opentracing.Tags) EndpointOption {
 	return func(o *EndpointOptions) {
-		o.Tags = tags
+		if o.Tags == nil {
+			o.Tags = make(opentracing.Tags)
+		}
+
+		for key, value := range tags {
+			o.Tags[key] = value
+		}
 	}
 }
 
-// WithExtraTags extracts additional tags from the context.
-func WithExtraTags(getTags func(ctx context.Context) opentracing.Tags) EndpointOption {
+// WithTagsFunc set the func to extracts additional tags from the context.
+func WithTagsFunc(getTags func(ctx context.Context) opentracing.Tags) EndpointOption {
 	return func(o *EndpointOptions) {
 		o.GetTags = getTags
 	}

--- a/tracing/opentracing/endpoint_options.go
+++ b/tracing/opentracing/endpoint_options.go
@@ -2,6 +2,7 @@ package opentracing
 
 import (
 	"context"
+
 	"github.com/opentracing/opentracing-go"
 )
 

--- a/tracing/opentracing/endpoint_options.go
+++ b/tracing/opentracing/endpoint_options.go
@@ -1,0 +1,69 @@
+package opentracing
+
+import (
+	"context"
+	"github.com/opentracing/opentracing-go"
+)
+
+// EndpointOptions holds the options for tracing an endpoint
+type EndpointOptions struct {
+	// IgnoreBusinessError if set to true will not treat a business error
+	// identified through the endpoint.Failer interface as a span error.
+	IgnoreBusinessError bool
+
+	// GetOperationName is an optional function that can set the span operation name based on the existing one
+	// for the endpoint and information in the context.
+	//
+	// If the function is nil, or the returned name is empty, the existing name for the endpoint is used.
+	GetOperationName func(ctx context.Context, name string) string
+
+	// Tags holds the default tags which will be set on span
+	// creation by our Endpoint middleware.
+	Tags opentracing.Tags
+
+	// GetTags is an optional function that can extract trace tags
+	// from the context and add them to the span.
+	GetTags func(ctx context.Context) opentracing.Tags
+}
+
+// EndpointOption allows for functional options to Opentracing endpoint
+// tracing middleware.
+type EndpointOption func(*EndpointOptions)
+
+// WithOptions sets all configuration options at once by use of the
+// EndpointOptions struct.
+func WithOptions(options EndpointOptions) EndpointOption {
+	return func(o *EndpointOptions) {
+		*o = options
+	}
+}
+
+// WithIgnoreBusinessError if set to true will not treat a business error
+// identified through the endpoint.Failer interface as a span error.
+func WithIgnoreBusinessError(ignoreBusinessError bool) EndpointOption {
+	return func(o *EndpointOptions) {
+		o.IgnoreBusinessError = ignoreBusinessError
+	}
+}
+
+// WithOperationName allows to set function that can set the span operation name based on the existing one
+// for the endpoint and information in the context.
+func WithOperationName(getOperationName func(ctx context.Context, name string) string) EndpointOption {
+	return func(o *EndpointOptions) {
+		o.GetOperationName = getOperationName
+	}
+}
+
+// WithTags sets the default tags for the spans created by the Endpoint tracer.
+func WithTags(tags opentracing.Tags) EndpointOption {
+	return func(o *EndpointOptions) {
+		o.Tags = tags
+	}
+}
+
+// WithExtraTags extracts additional attributes from the context.
+func WithExtraTags(getTags func(ctx context.Context) opentracing.Tags) EndpointOption {
+	return func(o *EndpointOptions) {
+		o.GetTags = getTags
+	}
+}

--- a/tracing/opentracing/endpoint_options.go
+++ b/tracing/opentracing/endpoint_options.go
@@ -21,17 +21,15 @@ type EndpointOptions struct {
 	// creation by our Endpoint middleware.
 	Tags opentracing.Tags
 
-	// GetTags is an optional function that can extract trace tags
+	// GetTags is an optional function that can extract tags
 	// from the context and add them to the span.
 	GetTags func(ctx context.Context) opentracing.Tags
 }
 
-// EndpointOption allows for functional options to Opentracing endpoint
-// tracing middleware.
+// EndpointOption allows for functional options to endpoint tracing middleware.
 type EndpointOption func(*EndpointOptions)
 
-// WithOptions sets all configuration options at once by use of the
-// EndpointOptions struct.
+// WithOptions sets all configuration options at once by use of the EndpointOptions struct.
 func WithOptions(options EndpointOptions) EndpointOption {
 	return func(o *EndpointOptions) {
 		*o = options
@@ -61,7 +59,7 @@ func WithTags(tags opentracing.Tags) EndpointOption {
 	}
 }
 
-// WithExtraTags extracts additional attributes from the context.
+// WithExtraTags extracts additional tags from the context.
 func WithExtraTags(getTags func(ctx context.Context) opentracing.Tags) EndpointOption {
 	return func(o *EndpointOptions) {
 		o.GetTags = getTags

--- a/tracing/opentracing/endpoint_test.go
+++ b/tracing/opentracing/endpoint_test.go
@@ -41,231 +41,7 @@ func (r failedResponse) Failed() error {
 	return r.err
 }
 
-func TestTraceServer(t *testing.T) {
-	tracer := mocktracer.New()
-
-	// Initialize the ctx with a nameless Span.
-	contextSpan := tracer.StartSpan("").(*mocktracer.MockSpan)
-	ctx := opentracing.ContextWithSpan(context.Background(), contextSpan)
-
-	tracedEndpoint := kitot.TraceServer(tracer, "testOp")(endpoint.Nop)
-	if _, err := tracedEndpoint(ctx, struct{}{}); err != nil {
-		t.Fatal(err)
-	}
-
-	finishedSpans := tracer.FinishedSpans()
-	if want, have := 1, len(finishedSpans); want != have {
-		t.Fatalf("Want %v span(s), found %v", want, have)
-	}
-
-	// Test that the op name is updated
-	endpointSpan := finishedSpans[0]
-	if want, have := "testOp", endpointSpan.OperationName; want != have {
-		t.Fatalf("Want %q, have %q", want, have)
-	}
-	contextContext := contextSpan.Context().(mocktracer.MockSpanContext)
-	endpointContext := endpointSpan.Context().(mocktracer.MockSpanContext)
-	// ...and that the ID is unmodified.
-	if want, have := contextContext.SpanID, endpointContext.SpanID; want != have {
-		t.Errorf("Want SpanID %q, have %q", want, have)
-	}
-}
-
-func TestTraceServerNoContextSpan(t *testing.T) {
-	tracer := mocktracer.New()
-
-	// Empty/background context.
-	tracedEndpoint := kitot.TraceServer(tracer, "testOp")(endpoint.Nop)
-	if _, err := tracedEndpoint(context.Background(), struct{}{}); err != nil {
-		t.Fatal(err)
-	}
-
-	// tracedEndpoint created a new Span.
-	finishedSpans := tracer.FinishedSpans()
-	if want, have := 1, len(finishedSpans); want != have {
-		t.Fatalf("Want %v span(s), found %v", want, have)
-	}
-
-	endpointSpan := finishedSpans[0]
-	if want, have := "testOp", endpointSpan.OperationName; want != have {
-		t.Fatalf("Want %q, have %q", want, have)
-	}
-}
-
-func TestTraceServerWithOptions(t *testing.T) {
-	tracer := mocktracer.New()
-
-	// span 1 without options
-	mw := kitot.TraceServer(tracer, span1)
-	tracedEndpoint := mw(endpoint.Nop)
-	_, _ = tracedEndpoint(context.Background(), struct{}{})
-
-	// span 2 with options
-	mw = kitot.TraceServer(
-		tracer,
-		span2,
-		kitot.WithOptions(kitot.EndpointOptions{}),
-	)
-	tracedEndpoint = mw(func(context.Context, interface{}) (interface{}, error) {
-		return nil, err1
-	})
-	_, _ = tracedEndpoint(context.Background(), struct{}{})
-
-	// span 3 with disabled IgnoreBusinessError option
-	mw = kitot.TraceServer(
-		tracer,
-		span3,
-		kitot.WithIgnoreBusinessError(false),
-	)
-	tracedEndpoint = mw(func(context.Context, interface{}) (interface{}, error) {
-		return failedResponse{
-			err: err2,
-		}, nil
-	})
-	_, _ = tracedEndpoint(context.Background(), struct{}{})
-
-	// span 4 with enabled IgnoreBusinessError option
-	mw = kitot.TraceServer(tracer, span4, kitot.WithIgnoreBusinessError(true))
-	tracedEndpoint = mw(func(context.Context, interface{}) (interface{}, error) {
-		return failedResponse{
-			err: err3,
-		}, nil
-	})
-	_, _ = tracedEndpoint(context.Background(), struct{}{})
-
-	// span 5 with OperationNameFunc option
-	mw = kitot.TraceServer(
-		tracer,
-		span5,
-		kitot.WithOperationNameFunc(func(ctx context.Context, name string) string {
-			return fmt.Sprintf("%s-%s", "new", name)
-		}),
-	)
-	tracedEndpoint = mw(endpoint.Nop)
-	_, _ = tracedEndpoint(context.Background(), struct{}{})
-
-	// span 6 with Tags options
-	mw = kitot.TraceServer(
-		tracer,
-		span6,
-		kitot.WithTags(map[string]interface{}{
-			"tag1": "tag1",
-			"tag2": "tag2",
-		}),
-		kitot.WithTags(map[string]interface{}{
-			"tag3": "tag3",
-		}),
-	)
-	tracedEndpoint = mw(endpoint.Nop)
-	_, _ = tracedEndpoint(context.Background(), struct{}{})
-
-	// span 7 with TagsFunc options
-	mw = kitot.TraceServer(
-		tracer,
-		span7,
-		kitot.WithTags(map[string]interface{}{
-			"tag1": "tag1",
-			"tag2": "tag2",
-		}),
-		kitot.WithTags(map[string]interface{}{
-			"tag3": "tag3",
-		}),
-		kitot.WithTagsFunc(func(ctx context.Context) opentracing.Tags {
-			return map[string]interface{}{
-				"tag4": "tag4",
-			}
-		}),
-	)
-	tracedEndpoint = mw(endpoint.Nop)
-	_, _ = tracedEndpoint(context.Background(), struct{}{})
-
-	finishedSpans := tracer.FinishedSpans()
-	if want, have := 7, len(finishedSpans); want != have {
-		t.Fatalf("Want %v span(s), found %v", want, have)
-	}
-
-	// test span 1
-	span := finishedSpans[0]
-
-	if want, have := span1, span.OperationName; want != have {
-		t.Fatalf("Want %q, have %q", want, have)
-	}
-
-	// test span 2
-	span = finishedSpans[1]
-
-	if want, have := span2, span.OperationName; want != have {
-		t.Fatalf("Want %q, have %q", want, have)
-	}
-
-	if want, have := true, span.Tag("error"); want != have {
-		t.Fatalf("Want %v, have %v", want, have)
-	}
-
-	// test span 3
-	span = finishedSpans[2]
-
-	if want, have := span3, span.OperationName; want != have {
-		t.Fatalf("Want %q, have %q", want, have)
-	}
-
-	if want, have := true, span.Tag("error"); want != have {
-		t.Fatalf("Want %v, have %v", want, have)
-	}
-
-	// test span 4
-	span = finishedSpans[3]
-
-	if want, have := span4, span.OperationName; want != have {
-		t.Fatalf("Want %q, have %q", want, have)
-	}
-
-	if want, have := (interface{})(nil), span.Tag("error"); want != have {
-		t.Fatalf("Want %q, have %q", want, have)
-	}
-
-	// test span 5
-	span = finishedSpans[4]
-
-	if want, have := fmt.Sprintf("%s-%s", "new", span5), span.OperationName; want != have {
-		t.Fatalf("Want %q, have %q", want, have)
-	}
-
-	// test span 6
-	span = finishedSpans[5]
-
-	if want, have := span6, span.OperationName; want != have {
-		t.Fatalf("Want %q, have %q", want, have)
-	}
-
-	if want, have := map[string]interface{}{
-		"span.kind": ext.SpanKindRPCServerEnum,
-		"tag1":      "tag1",
-		"tag2":      "tag2",
-		"tag3":      "tag3",
-	}, span.Tags(); fmt.Sprint(want) != fmt.Sprint(have) {
-		t.Fatalf("Want %q, have %q", want, have)
-	}
-
-	// test span 7
-	span = finishedSpans[6]
-
-	if want, have := span7, span.OperationName; want != have {
-		t.Fatalf("Want %q, have %q", want, have)
-	}
-
-	if want, have := map[string]interface{}{
-		"span.kind": ext.SpanKindRPCServerEnum,
-		"tag1":      "tag1",
-		"tag2":      "tag2",
-		"tag3":      "tag3",
-		"tag4":      "tag4",
-	}, span.Tags(); fmt.Sprint(want) != fmt.Sprint(have) {
-		t.Fatalf("Want %q, have %q", want, have)
-	}
-}
-
-func TestTraceClient(t *testing.T) {
+func TestTraceEndpoint(t *testing.T) {
 	tracer := mocktracer.New()
 
 	// Initialize the ctx with a parent Span.
@@ -273,7 +49,7 @@ func TestTraceClient(t *testing.T) {
 	defer parentSpan.Finish()
 	ctx := opentracing.ContextWithSpan(context.Background(), parentSpan)
 
-	tracedEndpoint := kitot.TraceClient(tracer, "testOp")(endpoint.Nop)
+	tracedEndpoint := kitot.TraceEndpoint(tracer, "testOp")(endpoint.Nop)
 	if _, err := tracedEndpoint(ctx, struct{}{}); err != nil {
 		t.Fatal(err)
 	}
@@ -298,11 +74,11 @@ func TestTraceClient(t *testing.T) {
 	}
 }
 
-func TestTraceClientNoContextSpan(t *testing.T) {
+func TestTraceEndpointNoContextSpan(t *testing.T) {
 	tracer := mocktracer.New()
 
 	// Empty/background context.
-	tracedEndpoint := kitot.TraceClient(tracer, "testOp")(endpoint.Nop)
+	tracedEndpoint := kitot.TraceEndpoint(tracer, "testOp")(endpoint.Nop)
 	if _, err := tracedEndpoint(context.Background(), struct{}{}); err != nil {
 		t.Fatal(err)
 	}
@@ -314,21 +90,22 @@ func TestTraceClientNoContextSpan(t *testing.T) {
 	}
 
 	endpointSpan := finishedSpans[0]
+
 	if want, have := "testOp", endpointSpan.OperationName; want != have {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
 }
 
-func TestTraceClientWithOptions(t *testing.T) {
+func TestTraceEndpointWithOptions(t *testing.T) {
 	tracer := mocktracer.New()
 
 	// span 1 without options
-	mw := kitot.TraceClient(tracer, span1)
+	mw := kitot.TraceEndpoint(tracer, span1)
 	tracedEndpoint := mw(endpoint.Nop)
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
 	// span 2 with options
-	mw = kitot.TraceClient(
+	mw = kitot.TraceEndpoint(
 		tracer,
 		span2,
 		kitot.WithOptions(kitot.EndpointOptions{}),
@@ -339,7 +116,7 @@ func TestTraceClientWithOptions(t *testing.T) {
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
 	// span 3 with disabled IgnoreBusinessError option
-	mw = kitot.TraceClient(
+	mw = kitot.TraceEndpoint(
 		tracer,
 		span3,
 		kitot.WithIgnoreBusinessError(false),
@@ -352,7 +129,7 @@ func TestTraceClientWithOptions(t *testing.T) {
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
 	// span 4 with enabled IgnoreBusinessError option
-	mw = kitot.TraceClient(tracer, span4, kitot.WithIgnoreBusinessError(true))
+	mw = kitot.TraceEndpoint(tracer, span4, kitot.WithIgnoreBusinessError(true))
 	tracedEndpoint = mw(func(context.Context, interface{}) (interface{}, error) {
 		return failedResponse{
 			err: err3,
@@ -361,7 +138,7 @@ func TestTraceClientWithOptions(t *testing.T) {
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
 	// span 5 with OperationNameFunc option
-	mw = kitot.TraceClient(
+	mw = kitot.TraceEndpoint(
 		tracer,
 		span5,
 		kitot.WithOperationNameFunc(func(ctx context.Context, name string) string {
@@ -372,7 +149,7 @@ func TestTraceClientWithOptions(t *testing.T) {
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
 	// span 6 with Tags options
-	mw = kitot.TraceClient(
+	mw = kitot.TraceEndpoint(
 		tracer,
 		span6,
 		kitot.WithTags(map[string]interface{}{
@@ -387,7 +164,7 @@ func TestTraceClientWithOptions(t *testing.T) {
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
 	// span 7 with TagsFunc options
-	mw = kitot.TraceClient(
+	mw = kitot.TraceEndpoint(
 		tracer,
 		span7,
 		kitot.WithTags(map[string]interface{}{
@@ -466,10 +243,9 @@ func TestTraceClientWithOptions(t *testing.T) {
 	}
 
 	if want, have := map[string]interface{}{
-		"span.kind": ext.SpanKindRPCClientEnum,
-		"tag1":      "tag1",
-		"tag2":      "tag2",
-		"tag3":      "tag3",
+		"tag1": "tag1",
+		"tag2": "tag2",
+		"tag3": "tag3",
 	}, span.Tags(); fmt.Sprint(want) != fmt.Sprint(have) {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
@@ -482,11 +258,66 @@ func TestTraceClientWithOptions(t *testing.T) {
 	}
 
 	if want, have := map[string]interface{}{
-		"span.kind": ext.SpanKindRPCClientEnum,
-		"tag1":      "tag1",
-		"tag2":      "tag2",
-		"tag3":      "tag3",
-		"tag4":      "tag4",
+		"tag1": "tag1",
+		"tag2": "tag2",
+		"tag3": "tag3",
+		"tag4": "tag4",
+	}, span.Tags(); fmt.Sprint(want) != fmt.Sprint(have) {
+		t.Fatalf("Want %q, have %q", want, have)
+	}
+}
+
+func TestTraceServer(t *testing.T) {
+	tracer := mocktracer.New()
+
+	// Empty/background context.
+	tracedEndpoint := kitot.TraceServer(tracer, "testOp")(endpoint.Nop)
+	if _, err := tracedEndpoint(context.Background(), struct{}{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// tracedEndpoint created a new Span.
+	finishedSpans := tracer.FinishedSpans()
+	if want, have := 1, len(finishedSpans); want != have {
+		t.Fatalf("Want %v span(s), found %v", want, have)
+	}
+
+	span := finishedSpans[0]
+
+	if want, have := "testOp", span.OperationName; want != have {
+		t.Fatalf("Want %q, have %q", want, have)
+	}
+
+	if want, have := map[string]interface{}{
+		ext.SpanKindRPCServer.Key: ext.SpanKindRPCServer.Value,
+	}, span.Tags(); fmt.Sprint(want) != fmt.Sprint(have) {
+		t.Fatalf("Want %q, have %q", want, have)
+	}
+}
+
+func TestTraceClient(t *testing.T) {
+	tracer := mocktracer.New()
+
+	// Empty/background context.
+	tracedEndpoint := kitot.TraceClient(tracer, "testOp")(endpoint.Nop)
+	if _, err := tracedEndpoint(context.Background(), struct{}{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// tracedEndpoint created a new Span.
+	finishedSpans := tracer.FinishedSpans()
+	if want, have := 1, len(finishedSpans); want != have {
+		t.Fatalf("Want %v span(s), found %v", want, have)
+	}
+
+	span := finishedSpans[0]
+
+	if want, have := "testOp", span.OperationName; want != have {
+		t.Fatalf("Want %q, have %q", want, have)
+	}
+
+	if want, have := map[string]interface{}{
+		ext.SpanKindRPCClient.Key: ext.SpanKindRPCClient.Value,
 	}, span.Tags(); fmt.Sprint(want) != fmt.Sprint(have) {
 		t.Fatalf("Want %q, have %q", want, have)
 	}

--- a/tracing/opentracing/endpoint_test.go
+++ b/tracing/opentracing/endpoint_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/opentracing/opentracing-go/ext"
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/mocktracer"
 
 	"github.com/go-kit/kit/endpoint"

--- a/tracing/opentracing/endpoint_test.go
+++ b/tracing/opentracing/endpoint_test.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
+	otext "github.com/opentracing/opentracing-go/ext"
+	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/opentracing/opentracing-go/mocktracer"
 
 	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/sd"
+	"github.com/go-kit/kit/sd/lb"
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 )
 
@@ -22,6 +27,7 @@ const (
 	span5 = "SPAN-5"
 	span6 = "SPAN-6"
 	span7 = "SPAN-7"
+	span8 = "SPAN-8"
 )
 
 var (
@@ -115,10 +121,31 @@ func TestTraceEndpointWithOptions(t *testing.T) {
 	})
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
-	// span 3 with disabled IgnoreBusinessError option
+	// span 3 with lb error
 	mw = kitot.TraceEndpoint(
 		tracer,
 		span3,
+		kitot.WithOptions(kitot.EndpointOptions{}),
+	)
+	tracedEndpoint = mw(
+		lb.Retry(
+			5,
+			1*time.Second,
+			lb.NewRoundRobin(
+				sd.FixedEndpointer{
+					func(context.Context, interface{}) (interface{}, error) {
+						return nil, err1
+					},
+				},
+			),
+		),
+	)
+	_, _ = tracedEndpoint(context.Background(), struct{}{})
+
+	// span 4 with disabled IgnoreBusinessError option
+	mw = kitot.TraceEndpoint(
+		tracer,
+		span4,
 		kitot.WithIgnoreBusinessError(false),
 	)
 	tracedEndpoint = mw(func(context.Context, interface{}) (interface{}, error) {
@@ -128,8 +155,8 @@ func TestTraceEndpointWithOptions(t *testing.T) {
 	})
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
-	// span 4 with enabled IgnoreBusinessError option
-	mw = kitot.TraceEndpoint(tracer, span4, kitot.WithIgnoreBusinessError(true))
+	// span 5 with enabled IgnoreBusinessError option
+	mw = kitot.TraceEndpoint(tracer, span5, kitot.WithIgnoreBusinessError(true))
 	tracedEndpoint = mw(func(context.Context, interface{}) (interface{}, error) {
 		return failedResponse{
 			err: err3,
@@ -137,10 +164,10 @@ func TestTraceEndpointWithOptions(t *testing.T) {
 	})
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
-	// span 5 with OperationNameFunc option
+	// span 6 with OperationNameFunc option
 	mw = kitot.TraceEndpoint(
 		tracer,
-		span5,
+		span6,
 		kitot.WithOperationNameFunc(func(ctx context.Context, name string) string {
 			return fmt.Sprintf("%s-%s", "new", name)
 		}),
@@ -148,10 +175,10 @@ func TestTraceEndpointWithOptions(t *testing.T) {
 	tracedEndpoint = mw(endpoint.Nop)
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
-	// span 6 with Tags options
+	// span 7 with Tags options
 	mw = kitot.TraceEndpoint(
 		tracer,
-		span6,
+		span7,
 		kitot.WithTags(map[string]interface{}{
 			"tag1": "tag1",
 			"tag2": "tag2",
@@ -163,10 +190,10 @@ func TestTraceEndpointWithOptions(t *testing.T) {
 	tracedEndpoint = mw(endpoint.Nop)
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
-	// span 7 with TagsFunc options
+	// span 8 with TagsFunc options
 	mw = kitot.TraceEndpoint(
 		tracer,
-		span7,
+		span8,
 		kitot.WithTags(map[string]interface{}{
 			"tag1": "tag1",
 			"tag2": "tag2",
@@ -184,7 +211,7 @@ func TestTraceEndpointWithOptions(t *testing.T) {
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
 	finishedSpans := tracer.FinishedSpans()
-	if want, have := 7, len(finishedSpans); want != have {
+	if want, have := 8, len(finishedSpans); want != have {
 		t.Fatalf("Want %v span(s), found %v", want, have)
 	}
 
@@ -217,6 +244,22 @@ func TestTraceEndpointWithOptions(t *testing.T) {
 		t.Fatalf("Want %v, have %v", want, have)
 	}
 
+	if want, have := 1, len(span.Logs()); want != have {
+		t.Fatalf("incorrect logs count, wanted %d, got %d", want, have)
+	}
+
+	if want, have := []otlog.Field{
+		otlog.String("event", "error"),
+		otlog.String("error.object", "some error (previously: some error; some error; some error; some error)"),
+		otlog.String("gokit.retry.error.1", "some error"),
+		otlog.String("gokit.retry.error.2", "some error"),
+		otlog.String("gokit.retry.error.3", "some error"),
+		otlog.String("gokit.retry.error.4", "some error"),
+		otlog.String("gokit.retry.error.5", "some error"),
+	}, span.Logs()[0].Fields; reflect.DeepEqual(want, have) {
+		t.Fatalf("Want %q, have %q", want, have)
+	}
+
 	// test span 4
 	span = finishedSpans[3]
 
@@ -224,21 +267,59 @@ func TestTraceEndpointWithOptions(t *testing.T) {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
 
-	if want, have := (interface{})(nil), span.Tag("error"); want != have {
+	if want, have := true, span.Tag("error"); want != have {
+		t.Fatalf("Want %v, have %v", want, have)
+	}
+
+	if want, have := 2, len(span.Logs()); want != have {
+		t.Fatalf("incorrect logs count, wanted %d, got %d", want, have)
+	}
+
+	if want, have := []otlog.Field{
+		otlog.String("gokit.business.error", "some business error"),
+	}, span.Logs()[0].Fields; reflect.DeepEqual(want, have) {
+		t.Fatalf("Want %q, have %q", want, have)
+	}
+
+	if want, have := []otlog.Field{
+		otlog.String("event", "error"),
+		otlog.String("error.object", "some business error"),
+	}, span.Logs()[1].Fields; reflect.DeepEqual(want, have) {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
 
 	// test span 5
 	span = finishedSpans[4]
 
-	if want, have := fmt.Sprintf("%s-%s", "new", span5), span.OperationName; want != have {
+	if want, have := span5, span.OperationName; want != have {
+		t.Fatalf("Want %q, have %q", want, have)
+	}
+
+	if want, have := (interface{})(nil), span.Tag("error"); want != have {
+		t.Fatalf("Want %q, have %q", want, have)
+	}
+
+	if want, have := 1, len(span.Logs()); want != have {
+		t.Fatalf("incorrect logs count, wanted %d, got %d", want, have)
+	}
+
+	if want, have := []otlog.Field{
+		otlog.String("gokit.business.error", "some business error"),
+	}, span.Logs()[0].Fields; reflect.DeepEqual(want, have) {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
 
 	// test span 6
 	span = finishedSpans[5]
 
-	if want, have := span6, span.OperationName; want != have {
+	if want, have := fmt.Sprintf("%s-%s", "new", span6), span.OperationName; want != have {
+		t.Fatalf("Want %q, have %q", want, have)
+	}
+
+	// test span 7
+	span = finishedSpans[6]
+
+	if want, have := span7, span.OperationName; want != have {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
 
@@ -250,10 +331,10 @@ func TestTraceEndpointWithOptions(t *testing.T) {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
 
-	// test span 7
-	span = finishedSpans[6]
+	// test span 8
+	span = finishedSpans[7]
 
-	if want, have := span7, span.OperationName; want != have {
+	if want, have := span8, span.OperationName; want != have {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
 
@@ -289,7 +370,7 @@ func TestTraceServer(t *testing.T) {
 	}
 
 	if want, have := map[string]interface{}{
-		ext.SpanKindRPCServer.Key: ext.SpanKindRPCServer.Value,
+		otext.SpanKindRPCServer.Key: otext.SpanKindRPCServer.Value,
 	}, span.Tags(); fmt.Sprint(want) != fmt.Sprint(have) {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
@@ -317,7 +398,7 @@ func TestTraceClient(t *testing.T) {
 	}
 
 	if want, have := map[string]interface{}{
-		ext.SpanKindRPCClient.Key: ext.SpanKindRPCClient.Value,
+		otext.SpanKindRPCClient.Key: otext.SpanKindRPCClient.Value,
 	}, span.Tags(); fmt.Sprint(want) != fmt.Sprint(have) {
 		t.Fatalf("Want %q, have %q", want, have)
 	}

--- a/tracing/opentracing/endpoint_test.go
+++ b/tracing/opentracing/endpoint_test.go
@@ -133,11 +133,11 @@ func TestTraceServerWithOptions(t *testing.T) {
 	})
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
-	// span 5 with OperationName option
+	// span 5 with OperationNameFunc option
 	mw = kitot.TraceServer(
 		tracer,
 		span5,
-		kitot.WithOperationName(func(ctx context.Context, name string) string {
+		kitot.WithOperationNameFunc(func(ctx context.Context, name string) string {
 			return fmt.Sprintf("%s-%s", "new", name)
 		}),
 	)
@@ -150,21 +150,29 @@ func TestTraceServerWithOptions(t *testing.T) {
 		span6,
 		kitot.WithTags(map[string]interface{}{
 			"tag1": "tag1",
+			"tag2": "tag2",
+		}),
+		kitot.WithTags(map[string]interface{}{
+			"tag3": "tag3",
 		}),
 	)
 	tracedEndpoint = mw(endpoint.Nop)
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
-	// span 7 with ExtraTags options
+	// span 7 with TagsFunc options
 	mw = kitot.TraceServer(
 		tracer,
 		span7,
 		kitot.WithTags(map[string]interface{}{
 			"tag1": "tag1",
+			"tag2": "tag2",
 		}),
-		kitot.WithExtraTags(func(ctx context.Context) opentracing.Tags {
+		kitot.WithTags(map[string]interface{}{
+			"tag3": "tag3",
+		}),
+		kitot.WithTagsFunc(func(ctx context.Context) opentracing.Tags {
 			return map[string]interface{}{
-				"tag2": "tag2",
+				"tag4": "tag4",
 			}
 		}),
 	)
@@ -233,6 +241,8 @@ func TestTraceServerWithOptions(t *testing.T) {
 	if want, have := map[string]interface{}{
 		"span.kind": ext.SpanKindRPCServerEnum,
 		"tag1":      "tag1",
+		"tag2":      "tag2",
+		"tag3":      "tag3",
 	}, span.Tags(); fmt.Sprint(want) != fmt.Sprint(have) {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
@@ -248,6 +258,8 @@ func TestTraceServerWithOptions(t *testing.T) {
 		"span.kind": ext.SpanKindRPCServerEnum,
 		"tag1":      "tag1",
 		"tag2":      "tag2",
+		"tag3":      "tag3",
+		"tag4":      "tag4",
 	}, span.Tags(); fmt.Sprint(want) != fmt.Sprint(have) {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
@@ -348,11 +360,11 @@ func TestTraceClientWithOptions(t *testing.T) {
 	})
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
-	// span 5 with OperationName option
+	// span 5 with OperationNameFunc option
 	mw = kitot.TraceClient(
 		tracer,
 		span5,
-		kitot.WithOperationName(func(ctx context.Context, name string) string {
+		kitot.WithOperationNameFunc(func(ctx context.Context, name string) string {
 			return fmt.Sprintf("%s-%s", "new", name)
 		}),
 	)
@@ -365,21 +377,29 @@ func TestTraceClientWithOptions(t *testing.T) {
 		span6,
 		kitot.WithTags(map[string]interface{}{
 			"tag1": "tag1",
+			"tag2": "tag2",
+		}),
+		kitot.WithTags(map[string]interface{}{
+			"tag3": "tag3",
 		}),
 	)
 	tracedEndpoint = mw(endpoint.Nop)
 	_, _ = tracedEndpoint(context.Background(), struct{}{})
 
-	// span 7 with ExtraTags options
+	// span 7 with TagsFunc options
 	mw = kitot.TraceClient(
 		tracer,
 		span7,
 		kitot.WithTags(map[string]interface{}{
 			"tag1": "tag1",
+			"tag2": "tag2",
 		}),
-		kitot.WithExtraTags(func(ctx context.Context) opentracing.Tags {
+		kitot.WithTags(map[string]interface{}{
+			"tag3": "tag3",
+		}),
+		kitot.WithTagsFunc(func(ctx context.Context) opentracing.Tags {
 			return map[string]interface{}{
-				"tag2": "tag2",
+				"tag4": "tag4",
 			}
 		}),
 	)
@@ -448,6 +468,8 @@ func TestTraceClientWithOptions(t *testing.T) {
 	if want, have := map[string]interface{}{
 		"span.kind": ext.SpanKindRPCClientEnum,
 		"tag1":      "tag1",
+		"tag2":      "tag2",
+		"tag3":      "tag3",
 	}, span.Tags(); fmt.Sprint(want) != fmt.Sprint(have) {
 		t.Fatalf("Want %q, have %q", want, have)
 	}
@@ -463,6 +485,8 @@ func TestTraceClientWithOptions(t *testing.T) {
 		"span.kind": ext.SpanKindRPCClientEnum,
 		"tag1":      "tag1",
 		"tag2":      "tag2",
+		"tag3":      "tag3",
+		"tag4":      "tag4",
 	}, span.Tags(); fmt.Sprint(want) != fmt.Sprint(have) {
 		t.Fatalf("Want %q, have %q", want, have)
 	}


### PR DESCRIPTION
# what

- Add `TraceEndpoint` function to not rely on client/server kinds.
- TraceServer and TraceClient should differ only in span kind tag value
- Extend `tracing.opentracing` endpoint middleware API with some options (like it was done for Opencensus):
  - optionally trace business errors
  - add option to set static/dynamic tags
  - add option to set dynamic name based on context and previous name
  - bump opentracing lib (to have `ext.LogError` function)

# why

closes #804 