### PR TITLE
Fixing generic.Counter.With() - closes issue #525

### DIFF
--- a/metrics/generic/generic.go
+++ b/metrics/generic/generic.go
@@ -32,11 +32,8 @@ func NewCounter(name string) *Counter {
 
 // With implements Counter.
 func (c *Counter) With(labelValues ...string) metrics.Counter {
-	return &Counter{
-		Name: c.Name,
-		bits: atomic.LoadUint64(&c.bits),
-		lvs:  c.lvs.With(labelValues...),
-	}
+	c.lvs = c.lvs.With(labelValues...)
+	return c
 }
 
 // Add implements Counter.

--- a/metrics/generic/generic_test.go
+++ b/metrics/generic/generic_test.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"math"
 	"math/rand"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -29,6 +30,17 @@ func TestCounter(t *testing.T) {
 	value := counter.Value
 	if err := teststat.TestCounter(counter, value); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestIssue525(t *testing.T) {
+	counter := generic.NewCounter("issue525_counter")
+	sameCounter := counter.With("label", "counter").(*generic.Counter)
+	if want, have := counter, sameCounter; want != have {
+		t.Errorf("Instance: want %p, have %p", want, have)
+	}
+	if want, have := []string{"label", "counter"}, sameCounter.LabelValues(); !reflect.DeepEqual(want, have) {
+		t.Errorf("Label values mismatch: want %+v, have %+v", want, have)
 	}
 }
 

--- a/metrics/generic/generic_test.go
+++ b/metrics/generic/generic_test.go
@@ -34,13 +34,20 @@ func TestCounter(t *testing.T) {
 }
 
 func TestIssue525(t *testing.T) {
-	counter := generic.NewCounter("issue525_counter")
-	sameCounter := counter.With("label", "counter").(*generic.Counter)
-	if want, have := counter, sameCounter; want != have {
-		t.Errorf("Instance: want %p, have %p", want, have)
-	}
-	if want, have := []string{"label", "counter"}, sameCounter.LabelValues(); !reflect.DeepEqual(want, have) {
+	counterWithoutLabels := generic.NewCounter("issue525_counter")
+	counterWithLabels := counterWithoutLabels.With("label", "counter").(*generic.Counter)
+	if want, have := []string{"label", "counter"}, counterWithLabels.LabelValues(); !reflect.DeepEqual(want, have) {
 		t.Errorf("Label values mismatch: want %+v, have %+v", want, have)
+	}
+
+	counterWithoutLabels.Add(1)
+	counterWithLabels.Add(1)
+	counterWithLabels.Add(1)
+	if want, have := float64(1), counterWithoutLabels.Value(); want != have {
+		t.Errorf("Wrong counter value: want %f, have %f", want, have)
+	}
+	if want, have := float64(2), counterWithLabels.Value(); want != have {
+		t.Errorf("Wrong counter value: want %f, have %f", want, have)
 	}
 }
 


### PR DESCRIPTION
Every `With()` call was returning a new instance which wouldn't work unless they were reassigned back to original variable.

Specifically, calls to `Value()` and `ValueReset()` would be returning original instance's (the one created with `NewCounter()`) values.

Reworked it to return the same instance but with updated `lvs` field.