### PR TITLE
Use external nats instance for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
         env:
           eureka.server.responseCacheUpdateIntervalMs: 1000
 
+      nats:
+        image: nats:2.2.6
+        ports:
+          - 4222
+
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2.1.3
@@ -59,6 +64,7 @@ jobs:
           CONSUL_ADDR: localhost:${{ job.services.consul.ports[8500] }}
           ZK_ADDR: localhost:${{ job.services.zk.ports[2181] }}
           EUREKA_ADDR: http://localhost:${{ job.services.eureka.ports[8761] }}/eureka
+          NATS_URL: nats://localhost:${{ job.services.nats.ports[4222] }}
         run: go test -v -race -coverprofile=coverage.coverprofile -covermode=atomic -tags integration ./...
 
       - name: Upload coverage

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -24,3 +24,8 @@ services:
       eureka.server.responseCacheUpdateIntervalMs: 1000
     ports:
       - "8761:8761"
+
+  nats:
+    image: nats:2.2.6
+    ports:
+      - "4222:4222"

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/hudl/fargo v1.3.0
 	github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d
 	github.com/lightstep/lightstep-tracer-go v0.22.0
-	github.com/nats-io/nats-server/v2 v2.2.6
+	github.com/nats-io/nats-server/v2 v2.2.6 // indirect
 	github.com/nats-io/nats.go v1.11.0
 	github.com/oklog/oklog v0.3.2
 	github.com/oklog/run v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
-github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.14.1 h1:Yh8v0hpCj63p5edXOLaqTJW0IJ1p+eMW6+YSOqw1d6s=
 github.com/apache/thrift v0.14.1/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/transport/nats/publisher_test.go
+++ b/transport/nats/publisher_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package nats_test
 
 import (
@@ -19,8 +21,7 @@ func TestPublisher(t *testing.T) {
 		}
 	)
 
-	s, c := newNATSConn(t)
-	defer func() { s.Shutdown(); s.WaitForShutdown() }()
+	c := newNATSConn(t)
 	defer c.Close()
 
 	sub, err := c.QueueSubscribe("natstransport.test", "natstransport", func(msg *nats.Msg) {
@@ -64,8 +65,7 @@ func TestPublisherBefore(t *testing.T) {
 		}
 	)
 
-	s, c := newNATSConn(t)
-	defer func() { s.Shutdown(); s.WaitForShutdown() }()
+	c := newNATSConn(t)
 	defer c.Close()
 
 	sub, err := c.QueueSubscribe("natstransport.test", "natstransport", func(msg *nats.Msg) {
@@ -113,8 +113,7 @@ func TestPublisherAfter(t *testing.T) {
 		}
 	)
 
-	s, c := newNATSConn(t)
-	defer func() { s.Shutdown(); s.WaitForShutdown() }()
+	c := newNATSConn(t)
 	defer c.Close()
 
 	sub, err := c.QueueSubscribe("natstransport.test", "natstransport", func(msg *nats.Msg) {
@@ -161,8 +160,7 @@ func TestPublisherTimeout(t *testing.T) {
 		}
 	)
 
-	s, c := newNATSConn(t)
-	defer func() { s.Shutdown(); s.WaitForShutdown() }()
+	c := newNATSConn(t)
 	defer c.Close()
 
 	ch := make(chan struct{})
@@ -199,8 +197,7 @@ func TestPublisherCancellation(t *testing.T) {
 		}
 	)
 
-	s, c := newNATSConn(t)
-	defer func() { s.Shutdown(); s.WaitForShutdown() }()
+	c := newNATSConn(t)
 	defer c.Close()
 
 	sub, err := c.QueueSubscribe("natstransport.test", "natstransport", func(msg *nats.Msg) {
@@ -232,8 +229,7 @@ func TestPublisherCancellation(t *testing.T) {
 func TestEncodeJSONRequest(t *testing.T) {
 	var data string
 
-	s, c := newNATSConn(t)
-	defer func() { s.Shutdown(); s.WaitForShutdown() }()
+	c := newNATSConn(t)
 	defer c.Close()
 
 	sub, err := c.QueueSubscribe("natstransport.test", "natstransport", func(msg *nats.Msg) {


### PR DESCRIPTION
This isn't a huge win in terms of dependencies (nats server is still going to be a transitive dependency), but it unifies how integration tests are executed.