### PR TITLE
Replace aws lambda structs with stubs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/VividCortex/gohistogram v1.0.0
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a
-	github.com/aws/aws-lambda-go v1.13.3
 	github.com/aws/aws-sdk-go v1.38.65
 	github.com/aws/aws-sdk-go-v2 v1.6.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a h1:pv34s756C4pEXnjgPfGYgdhg/ZdajGhyOvzx8k+23nw=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
-github.com/aws/aws-lambda-go v1.13.3 h1:SuCy7H3NLyp+1Mrfp+m80jcbi9KYWAs9/BXwppwRDzY=
-github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.38.65 h1:umGu5gjIOKxzhi34T0DIA1TWupUDjV2aAW5vK6154Gg=
 github.com/aws/aws-sdk-go v1.38.65/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v1.6.0 h1:r20hdhm8wZmKkClREfacXrKfX0Y7/s0aOoeraFbf/sY=
@@ -54,7 +52,6 @@ github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmf
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -285,13 +282,11 @@ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3x
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
-github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da h1:p3Vo3i64TCLY7gIfzeQaUJ+kppEO5WQG3cL8iE8tGHU=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
@@ -315,7 +310,6 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/transport/awslambda/handler_test.go
+++ b/transport/awslambda/handler_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/go-kit/kit/endpoint"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/transport"
@@ -20,6 +19,17 @@ const (
 	KeyAfterOne  key = iota
 	KeyEncMode   key = iota
 )
+
+// Created based on github.com/aws/aws-lambda-go@v1.13.3/events.APIGatewayProxyRequest for the purposes of the tests below.
+type apiGatewayProxyRequest struct {
+	Body string `json:"body"`
+}
+
+// Created based on github.com/aws/aws-lambda-go@v1.13.3/events.APIGatewayProxyResponse for the purposes of the tests below.
+type apiGatewayProxyResponse struct {
+	StatusCode int    `json:"statusCode"`
+	Body       string `json:"body"`
+}
 
 func TestDefaultErrorEncoder(t *testing.T) {
 	ctx := context.Background()
@@ -76,7 +86,7 @@ func TestInvokeHappyPath(t *testing.T) {
 			resp []byte,
 			_ error,
 		) {
-			apigwResp := events.APIGatewayProxyResponse{}
+			apigwResp := apiGatewayProxyResponse{}
 			err := json.Unmarshal(resp, &apigwResp)
 			if err != nil {
 				t.Fatalf("Should have no error, but got: %+v", err)
@@ -97,7 +107,7 @@ func TestInvokeHappyPath(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	req, _ := json.Marshal(events.APIGatewayProxyRequest{
+	req, _ := json.Marshal(apiGatewayProxyRequest{
 		Body: `{"name":"john doe"}`,
 	})
 	resp, err := helloHandler.Invoke(ctx, req)
@@ -106,7 +116,7 @@ func TestInvokeHappyPath(t *testing.T) {
 		t.Fatalf("Should have no error, but got: %+v", err)
 	}
 
-	apigwResp := events.APIGatewayProxyResponse{}
+	apigwResp := apiGatewayProxyResponse{}
 	err = json.Unmarshal(resp, &apigwResp)
 	if err != nil {
 		t.Fatalf("Should have no error, but got: %+v", err)
@@ -136,7 +146,7 @@ func TestInvokeFailDecode(t *testing.T) {
 			ctx context.Context,
 			err error,
 		) ([]byte, error) {
-			apigwResp := events.APIGatewayProxyResponse{}
+			apigwResp := apiGatewayProxyResponse{}
 			apigwResp.Body = `{"error":"yes"}`
 			apigwResp.StatusCode = 500
 			resp, err := json.Marshal(apigwResp)
@@ -145,7 +155,7 @@ func TestInvokeFailDecode(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	req, _ := json.Marshal(events.APIGatewayProxyRequest{
+	req, _ := json.Marshal(apiGatewayProxyRequest{
 		Body: `{"name":"john doe"}`,
 	})
 	resp, err := helloHandler.Invoke(ctx, req)
@@ -154,7 +164,7 @@ func TestInvokeFailDecode(t *testing.T) {
 		t.Fatalf("Should have no error, but got: %+v", err)
 	}
 
-	apigwResp := events.APIGatewayProxyResponse{}
+	apigwResp := apiGatewayProxyResponse{}
 	json.Unmarshal(resp, &apigwResp)
 	if apigwResp.StatusCode != 500 {
 		t.Fatalf("Expect status code of 500, instead of %d", apigwResp.StatusCode)
@@ -186,7 +196,7 @@ func TestInvokeFailEndpoint(t *testing.T) {
 			ctx context.Context,
 			err error,
 		) ([]byte, error) {
-			apigwResp := events.APIGatewayProxyResponse{}
+			apigwResp := apiGatewayProxyResponse{}
 			apigwResp.Body = `{"error":"yes"}`
 			apigwResp.StatusCode = 500
 			resp, err := json.Marshal(apigwResp)
@@ -195,7 +205,7 @@ func TestInvokeFailEndpoint(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	req, _ := json.Marshal(events.APIGatewayProxyRequest{
+	req, _ := json.Marshal(apiGatewayProxyRequest{
 		Body: `{"name":"john doe"}`,
 	})
 	resp, err := helloHandler.Invoke(ctx, req)
@@ -204,7 +214,7 @@ func TestInvokeFailEndpoint(t *testing.T) {
 		t.Fatalf("Should have no error, but got: %+v", err)
 	}
 
-	apigwResp := events.APIGatewayProxyResponse{}
+	apigwResp := apiGatewayProxyResponse{}
 	json.Unmarshal(resp, &apigwResp)
 	if apigwResp.StatusCode != 500 {
 		t.Fatalf("Expect status code of 500, instead of %d", apigwResp.StatusCode)
@@ -244,7 +254,7 @@ func TestInvokeFailEncode(t *testing.T) {
 			err error,
 		) ([]byte, error) {
 			// convert error into proper APIGateway response.
-			apigwResp := events.APIGatewayProxyResponse{}
+			apigwResp := apiGatewayProxyResponse{}
 			apigwResp.Body = `{"error":"yes"}`
 			apigwResp.StatusCode = 500
 			resp, err := json.Marshal(apigwResp)
@@ -253,7 +263,7 @@ func TestInvokeFailEncode(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	req, _ := json.Marshal(events.APIGatewayProxyRequest{
+	req, _ := json.Marshal(apiGatewayProxyRequest{
 		Body: `{"name":"john doe"}`,
 	})
 	resp, err := helloHandler.Invoke(ctx, req)
@@ -262,7 +272,7 @@ func TestInvokeFailEncode(t *testing.T) {
 		t.Fatalf("Should have no error, but got: %+v", err)
 	}
 
-	apigwResp := events.APIGatewayProxyResponse{}
+	apigwResp := apiGatewayProxyResponse{}
 	json.Unmarshal(resp, &apigwResp)
 	if apigwResp.StatusCode != 500 {
 		t.Fatalf("Expect status code of 500, instead of %d", apigwResp.StatusCode)
@@ -272,7 +282,7 @@ func TestInvokeFailEncode(t *testing.T) {
 func decodeHelloRequestWithTwoBefores(
 	ctx context.Context, req []byte,
 ) (interface{}, error) {
-	apigwReq := events.APIGatewayProxyRequest{}
+	apigwReq := apiGatewayProxyRequest{}
 	err := json.Unmarshal([]byte(req), &apigwReq)
 	if err != nil {
 		return apigwReq, err
@@ -303,7 +313,7 @@ func decodeHelloRequestWithTwoBefores(
 func encodeResponse(
 	ctx context.Context, response interface{},
 ) ([]byte, error) {
-	apigwResp := events.APIGatewayProxyResponse{}
+	apigwResp := apiGatewayProxyResponse{}
 
 	mode, ok := ctx.Value(KeyEncMode).(string)
 	if ok && mode == "fail_encode" {


### PR DESCRIPTION
This PR removes the aws-lambda module dependency by replacing some structs with internal stubs.

Since the actual data only travels as JSON, it doesn't make much sense to use the original structs IMO. One less dependency...

Related #1109