### PR TITLE
Fix nats test panics

### DIFF
--- a/transport/nats/subscriber_test.go
+++ b/transport/nats/subscriber_test.go
@@ -46,10 +46,6 @@ func newNATSConn(t *testing.T) (*server.Server, *nats.Conn) {
 		t.Fatal("not ready for connections")
 	}
 
-	//if n := s.NumSubscriptions(); n > 0 {
-	//	t.Fatalf("found %d active subscriptions on the server", n)
-	//}
-
 	c, err := nats.Connect("nats://"+s.Addr().String(), nats.Name(t.Name()))
 	if err != nil {
 		t.Fatalf("failed to connect to NATS server: %s", err)

--- a/transport/nats/subscriber_test.go
+++ b/transport/nats/subscriber_test.go
@@ -42,8 +42,6 @@ func newNATSConn(t *testing.T) (*server.Server, *nats.Conn) {
 		t.Fatal("not yet running")
 	}
 
-	t.Log(s.Addr().String())
-
 	if ok := s.ReadyForConnections(5 * time.Second); !ok {
 		t.Fatal("not ready for connections")
 	}


### PR DESCRIPTION
The removed log line accessed the listener potentially before it was set which lead to panics. I decided to remove the log line instead of moving it after `ReadyForConnections` because knowing the address doesn't make much sense and it gets logged if something goes wrong.