### PR TITLE
feat: move from `streadway/amqp` to `rabbitmq-amqp091-go`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,9 @@ require (
 	github.com/openzipkin/zipkin-go v0.2.5
 	github.com/performancecopilot/speed/v4 v4.0.0
 	github.com/prometheus/client_golang v1.11.0
+	github.com/rabbitmq/amqp091-go v1.2.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/sony/gobreaker v0.4.1
-	github.com/streadway/amqp v1.0.0
 	github.com/streadway/handy v0.0.0-20200128134331-0f66f006fb2e
 	go.etcd.io/etcd/client/pkg/v3 v3.5.0
 	go.etcd.io/etcd/client/v2 v2.305.0

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/rabbitmq/amqp091-go v1.2.0 h1:1pHBxAsQh54R9eX/xo679fUEAfv3loMqi0pvRFOj2nk=
+github.com/rabbitmq/amqp091-go v1.2.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -427,8 +429,6 @@ github.com/sony/gobreaker v0.4.1 h1:oMnRNZXX5j85zso6xCPRNPtmAycat+WcoKbklScLDgQ=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
-github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
-github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20200128134331-0f66f006fb2e h1:mOtuXaRAbVZsxAHVdPR3IjfmN8T1h2iczJLynhLybf8=
 github.com/streadway/handy v0.0.0-20200128134331-0f66f006fb2e/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/transport/amqp/encode_decode.go
+++ b/transport/amqp/encode_decode.go
@@ -3,7 +3,7 @@ package amqp
 import (
 	"context"
 
-	"github.com/streadway/amqp"
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 // DecodeRequestFunc extracts a user-domain request object from

--- a/transport/amqp/publisher.go
+++ b/transport/amqp/publisher.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/endpoint"
-	"github.com/streadway/amqp"
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 // The golang AMQP implementation requires the []byte representation of

--- a/transport/amqp/publisher_test.go
+++ b/transport/amqp/publisher_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	amqptransport "github.com/go-kit/kit/transport/amqp"
-	"github.com/streadway/amqp"
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 var (

--- a/transport/amqp/request_response_func.go
+++ b/transport/amqp/request_response_func.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/streadway/amqp"
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 // RequestFunc may take information from a publisher request and put it into a

--- a/transport/amqp/subscriber.go
+++ b/transport/amqp/subscriber.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/go-kit/kit/transport"
 	"github.com/go-kit/log"
-	"github.com/streadway/amqp"
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 // Subscriber wraps an endpoint and provides a handler for AMQP Delivery messages.

--- a/transport/amqp/subscriber_test.go
+++ b/transport/amqp/subscriber_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	amqptransport "github.com/go-kit/kit/transport/amqp"
-	"github.com/streadway/amqp"
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 var (


### PR DESCRIPTION
This PR replaces the unmaintained `github.com/streadway/amqp` dependency with the new `github.com/rabbitmq/amqp091-go`.

Close #1178.