### PR TITLE
readme: add third-party extensions block

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ different starting assumptions.
 - [sagikazarmark/protoc-gen-kit](https://github.com/sagikazarmark/protoc-gen-kit)
 - [tuneinc/truss](https://github.com/tuneinc/truss)
 
+## Third-party extensions
+
+Third-party tools and libraries that extends Go kit functionality.
+
+- [alebabai/go-kit-kafka](https://github.com/alebabai/go-kit-kafka), module with Apache Kafka transport abstractions
+
 ## Related projects
 
 Projects with a ★ have had particular influence on Go kit's design (or vice-versa).


### PR DESCRIPTION
## what

Add third-part extensions block to the readme with link to `go-kit-kafka` repository.

## why

related to the #1209 