### PR TITLE
Fixed instancer loop logic that was causing Consul to get spammed

### DIFF
--- a/sd/consul/instancer.go
+++ b/sd/consul/instancer.go
@@ -65,9 +65,9 @@ func (s *Instancer) loop(lastIndex uint64) {
 		instances []string
 		err       error
 		d         time.Duration = 10 * time.Millisecond
+		index     uint64
 	)
 	for {
-		index := lastIndex
 		instances, index, err = s.getInstances(lastIndex, s.quitc)
 		switch {
 		case errors.Is(err, errStopped):
@@ -82,11 +82,12 @@ func (s *Instancer) loop(lastIndex uint64) {
 			time.Sleep(d)
 			d = conn.Exponential(d)
 		case index < lastIndex:
-			s.logger.Log("err", "index is less than previous; reseting to default")
+			s.logger.Log("err", "index is less than previous; resetting to default")
 			lastIndex = defaultIndex
 			time.Sleep(d)
 			d = conn.Exponential(d)
 		default:
+			lastIndex = index
 			s.cache.Update(sd.Event{Instances: instances})
 			d = 10 * time.Millisecond
 		}


### PR DESCRIPTION
Address issue #1214 - Instancer spamming Consul with requests

The instancer loop was never updating the lastIndex but passing it to getInstances which caused Instancer to spam Consul repeatedly and nearly killed our Consul agent pods and time instances were added or removed from Consul for that service.