### PR TITLE
Fixes Beego framework link

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Projects with a ★ have had particular influence on Go kit's design (or vice-ve
 - [Negroni](https://github.com/codegangsta/negroni)
 - [Goji](https://github.com/zenazn/goji)
 - [Martini](https://github.com/go-martini/martini)
-- [Beego](http://beego.me/)
+- [Beego](https://beego.vip/)
 - [Revel](https://revel.github.io/) (considered [harmful](https://github.com/go-kit/kit/issues/350))
 - [GoBuffalo](https://gobuffalo.io/)
 


### PR DESCRIPTION
Beego link to https://beego.me/ points to a dead site.
According to https://github.com/beego/beego/issues/4818 the site has been updated to https://beego.vip/