### PR TITLE
Remove dead link to code generator from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ different starting assumptions.
 
 - [RecoLabs/microgen](https://github.com/RecoLabs/microgen)
 - [GrantZheng/kit](https://github.com/GrantZheng/kit)
-- [chaseSpace/kit](https://github.com/chaseSpace/kit)
 - [kujtimiihoxha/kit](https://github.com/kujtimiihoxha/kit) (unmaintained)
 - [nytimes/marvin](https://github.com/nytimes/marvin)
 - [sagikazarmark/mga](https://github.com/sagikazarmark/mga)


### PR DESCRIPTION
When browsing the code genorators listed in the README, it looks like one is a dead link. I had a search around Leigg's repos and it looks like he's just deleted it.

I suggest removing the dead link to https://github.com/chaseSpace/kit.