### PR TITLE
go.mod: Upgrade go min version to 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: # Support latest and one minor back
-        go: ["1.17", "1.18", "1.19"]
+        go: ["1.18", "1.19"]
     env:
       GOFLAGS: -mod=readonly
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kit/kit
 
-go 1.17
+go 1.18
 
 require (
 	github.com/VividCortex/gohistogram v1.0.0


### PR DESCRIPTION
This will permit to use generics in future merge requests