### PR TITLE
README: update codegen link to truss

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ different starting assumptions.
 - [nytimes/marvin](https://github.com/nytimes/marvin)
 - [sagikazarmark/mga](https://github.com/sagikazarmark/mga)
 - [sagikazarmark/protoc-gen-go-kit](https://github.com/sagikazarmark/protoc-gen-go-kit)
-- [tuneinc/truss](https://github.com/tuneinc/truss)
+- [metaverse/truss](https://github.com/metaverse/truss)
 
 ## Related projects
 


### PR DESCRIPTION
The maintainers renamed their GitHub organisation to metaverse.