### PR TITLE
fix(sd): support ipv6 for consul and eureka

### DIFF
--- a/sd/consul/instancer.go
+++ b/sd/consul/instancer.go
@@ -3,6 +3,8 @@ package consul
 import (
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	consul "github.com/hashicorp/consul/api"
@@ -181,7 +183,7 @@ func makeInstances(entries []*consul.ServiceEntry) []string {
 		if entry.Service.Address != "" {
 			addr = entry.Service.Address
 		}
-		instances[i] = fmt.Sprintf("%s:%d", addr, entry.Service.Port)
+		instances[i] = net.JoinHostPort(addr, strconv.Itoa(entry.Service.Port))
 	}
 	return instances
 }

--- a/sd/eureka/instancer.go
+++ b/sd/eureka/instancer.go
@@ -1,7 +1,8 @@
 package eureka
 
 import (
-	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/hudl/fargo"
 
@@ -84,7 +85,7 @@ func (s *Instancer) getInstances() ([]string, error) {
 func convertFargoAppToInstances(app *fargo.Application) []string {
 	instances := make([]string, len(app.Instances))
 	for i, inst := range app.Instances {
-		instances[i] = fmt.Sprintf("%s:%d", inst.IPAddr, inst.Port)
+		instances[i] = net.JoinHostPort(inst.IPAddr, strconv.Itoa(inst.Port))
 	}
 	return instances
 }

--- a/sd/eureka/instancer_test.go
+++ b/sd/eureka/instancer_test.go
@@ -90,3 +90,19 @@ func TestBadInstancerScheduleUpdates(t *testing.T) {
 		t.Errorf("want %d, have %d", want, have)
 	}
 }
+
+func TestConvertFargoAppToInstances(t *testing.T) {
+	app := &fargo.Application{
+		Instances: []*fargo.Instance{
+			{IPAddr: "10.0.0.10", Port: 8000},
+			{IPAddr: "2001:db8:1::ab9:C0A8:102", Port: 8000},
+		},
+	}
+	expect := []string{"10.0.0.10:8000", "[2001:db8:1::ab9:C0A8:102]:8000"}
+	for i, inst := range convertFargoAppToInstances(app) {
+		if inst != expect[i] {
+			t.Fatalf("instance %s converting is wrong", expect[i])
+		}
+	}
+
+}

--- a/sd/eureka/registrar.go
+++ b/sd/eureka/registrar.go
@@ -2,7 +2,9 @@ package eureka
 
 import (
 	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -51,7 +53,7 @@ func NewRegistrar(conn fargoConnection, instance *fargo.Instance, logger log.Log
 	return &Registrar{
 		conn:     conn,
 		instance: instance,
-		logger:   log.With(logger, "service", instance.App, "address", fmt.Sprintf("%s:%d", instance.IPAddr, instance.Port)),
+		logger:   log.With(logger, "service", instance.App, "address", net.JoinHostPort(instance.IPAddr, strconv.Itoa(instance.Port))),
 	}
 }
 


### PR DESCRIPTION
Now IPv6 + port in instances will be string like `2001:db8:1::ab9:C0A8:102:8000`(8000 is the port) for consul and eureka. The correct instance should be like `[2001:db8:1::ab9:C0A8:102]:8000`, otherwise the HTTP call will fail.

I also checked other sd. It's correct in dnssrv already: https://github.com/go-kit/kit/blob/23eb35bf0c0178aa8254e4d6886f713b62cc3a48/sd/dnssrv/instancer.go#L99

Other sd seem don't have this problem either like etcd and zk.