### PR TITLE
feat(jsonrpc): add method to retrieve request ID from context

### DIFF
--- a/transport/http/jsonrpc/server.go
+++ b/transport/http/jsonrpc/server.go
@@ -15,6 +15,25 @@ type requestIDKeyType struct{}
 
 var requestIDKey requestIDKeyType
 
+// RequestIDFromContext returns the request id from context.
+func RequestIDFromContext(ctx context.Context) *RequestID {
+	if ctx == nil {
+		return nil
+	}
+
+	v := ctx.Value(requestIDKey)
+	if v == nil {
+		return nil
+	}
+
+	vv, ok := v.(*RequestID)
+	if !ok {
+		return nil
+	}
+
+	return vv
+}
+
 // Server wraps an endpoint and implements http.Handler.
 type Server struct {
 	ecm          EndpointCodecMap
@@ -198,12 +217,8 @@ func DefaultErrorEncoder(ctx context.Context, err error, w http.ResponseWriter) 
 
 	w.WriteHeader(http.StatusOK)
 
-	var requestID *RequestID
-	if v := ctx.Value(requestIDKey); v != nil {
-		requestID = v.(*RequestID)
-	}
 	_ = json.NewEncoder(w).Encode(Response{
-		ID:      requestID,
+		ID:      RequestIDFromContext(ctx),
 		JSONRPC: Version,
 		Error:   &e,
 	})


### PR DESCRIPTION
This  enhancement introduces a method to retrieve the request ID from the context. This is particularly useful for customizing the `ErrorEncoder` for the jsonrpc transport.